### PR TITLE
Script for auto fixing gendered translation being placed outside gendered tags

### DIFF
--- a/TranslationProgressReporter/FixMaleFemaleTranslation.py
+++ b/TranslationProgressReporter/FixMaleFemaleTranslation.py
@@ -1,0 +1,159 @@
+from copy import deepcopy
+import html
+import io
+import os
+import glob
+import csv
+import argparse
+from xml.etree.ElementTree import Element
+import lxml.etree as ET
+from lxml import html as ETHtml
+from JEScripts_Preprocessor import (
+    JEScript_CleanupInlineTags,
+    JEScript_PreprocessInlineTags,
+    Preprocess_JEScript_XML_Content,
+)
+from pathlib import Path
+
+# -----
+# setup argparse
+parser = argparse.ArgumentParser(
+    description="Find places in .xml scripts (JE Scripts) where <ascii></ascii> translation for gendered (male/female) text is placed not inside them. Then correct them automatically."
+)
+parser.add_argument(
+    "-dir",
+    type=str,
+    required=True,
+    help="Path to folder(s) containing XML files to check and fix (It will be recursively scanned).",
+)
+
+parser.add_argument("-v", action="store_true", help="use if you need more debug info")
+parser.add_argument("-exclude", nargs="+", type=str, default=[])
+
+args = parser.parse_args()
+
+
+def Check_skip_dirs(fPath: str = ""):
+    if len(fPath) == 0:
+        # print("Empty path")
+        return True
+    # print(f"amount of skipdirs: {len(args.exclude)}")
+    if len(args.exclude) > 0:
+        for badDir in args.exclude:
+            if fPath.find(badDir) > -1:
+                print(f"skipping: {fPath}")
+                return True
+
+    return False
+
+
+def Get_file_list(aDir, aFiletype=".xml"):
+    outList = []
+    if args.v:
+        print(f"Main dir: {aDir}")
+
+    for fPath, subDirs, files in os.walk(aDir):
+        for f in files:
+            if f.endswith(aFiletype):
+                fullpath = os.path.join(fPath, f)
+                if Check_skip_dirs(fullpath):
+                    continue
+
+                if args.v:
+                    print("found [.xml] script file: " + fullpath)
+                outList.append(fullpath)
+
+    return outList
+
+
+def AddMissingChildAscii(tagList):
+    changes_count: int = 0
+    if len(tagList) > 0:
+        for gender_tag in tagList:
+            ascii_tag = gender_tag.find("ascii")
+            sibling_ascii_tag = gender_tag.find("../ascii")
+            if ascii_tag is None and sibling_ascii_tag is not None:
+                gender_tag.append(deepcopy(sibling_ascii_tag))
+                changes_count += 1
+
+    return changes_count
+
+
+def CorrectMaleFemaleTanslations(xmlFile):
+    xml_contents: str = ""
+    xml_bytes: bytes = 0
+    changes_count: int = 0
+    with open(xmlFile, "r", encoding="utf-8") as fobj:
+        file_contents = fobj.read()
+        if len(file_contents) == 0:
+            print(f"Error correcting file: {xmlFile}. File is empty. skipping...")
+            return
+
+        xml_contents = JEScript_PreprocessInlineTags(file_contents)
+        xml_bytes = xml_contents.encode("utf-8")
+
+        try:
+            root = ETHtml.fromstring(xml_contents)
+            maleTags = root.xpath(".//male")
+            femaleTags = root.xpath(".//female")
+
+            changes_count += AddMissingChildAscii(maleTags)
+            changes_count += AddMissingChildAscii(femaleTags)
+            # now we need to cleanup the badly placed <male>/<female> sibling <ascii> tags
+            for tag in maleTags:
+                sibling_ascii_tag = tag.find("../ascii")
+                if sibling_ascii_tag is not None:
+                    outer_tag = tag.getparent()
+                    outer_tag.remove(sibling_ascii_tag)
+        except ET.XMLSyntaxError as e:
+            if args.v:
+                print(
+                    f"XmlSyntaxError while parsing file:[{xmlFile}] :: Reason:{e.msg}"
+                )
+
+        changes_count += 1
+        fobj.close()
+
+    # saving modified xml
+    if changes_count > 0:
+        print(f"there were some changes. Now we need to resave file: {xmlFile}")
+        with open(xmlFile, "w", encoding="UTF-8") as fobj:
+            # we need to make sure that it will use the same indent as the file uses
+            ET.indent(root, space="  ")
+            xml_contents = ETHtml.tostring(root, pretty_print=True).decode("UTF-8")
+            xml_contents = JEScript_CleanupInlineTags(xml_contents)
+            xml_bytes = html.unescape(xml_contents)
+            fobj.write(xml_bytes)
+            fobj.close()
+
+
+def main():
+    # parse path that needs to be scanned
+    dir = args.dir
+    scanPath = Path(dir)  # by default let's assume it's absolute
+    if not scanPath.is_absolute():  # now we check if maybe it's a relative path
+        # convert relative Path to absolute path for sanity
+        scanPath = Path(os.getcwd(), dir).resolve()
+
+    else:
+        print("using absolute path")
+
+    # search for xml files:
+    print("Scanning dir: [" + args.dir + "] for .xml files")
+    # use this for testing and debugging
+    # XmlList = []
+    # XmlList.append("./Tests/test2.xml")
+    # use this for real list from directory
+    XmlList = Get_file_list(args.dir, ".xml")
+    # search through file list
+
+    print(f"searching for missing EN translations in {len(XmlList)} files.")
+    print("Please wait...")
+    for xml in XmlList:
+        CorrectMaleFemaleTanslations(xml)
+
+
+# End main()
+
+if __name__ == "__main__":
+    main()

--- a/TranslationProgressReporter/JEScripts_Preprocessor.py
+++ b/TranslationProgressReporter/JEScripts_Preprocessor.py
@@ -1,15 +1,14 @@
 import re
 
 faulty_tags = [
- #simple <tag_name> format tags
+    # simple <tag_name> format tags
     "end_line",
     "three_dots",
     "player_name",
     "player_nickname",
     "hearth",
-    "paw"
-    "weapon_type",
-    "break", #<- this one seems to not be present in any .xml(JE scripts). But it was defined in ScriptValidator tool, so we should keep it for safety/compatibility sake (even if it's not needed)
+    "paw" "weapon_type",
+    "break",  # <- this one seems to not be present in any .xml(JE scripts). But it was defined in ScriptValidator tool, so we should keep it for safety/compatibility sake (even if it's not needed)
     "quote",
     "music_note",
     "option_1",
@@ -18,26 +17,63 @@ faulty_tags = [
     "greater_than",
     "black_dot",
     "left_arrow",
- #tags with attributes format: <tag_name attr="val"...>
+    # tags with attributes format: <tag_name attr="val"...>
     "player",
     "info",
     "portrait_l",
     "portrait_r",
- #this one can be both: with attributes and simple <tag_name> only formats
+    # this one can be both: with attributes and simple <tag_name> only formats
     "partner",
 ]
 
+WorkTagStart = "|InlineTag|"
+WorkTagEnd = "|/InlineTag|"
+WorkTagStart_regex = "\|InlineTag\|"
+WorkTagEnd_regex = "\|/InlineTag\|"
 
-def Preprocess_JEScript_XML_Content(xml_text: str=""):
+
+def Preprocess_JEScript_XML_Content(xml_text: str = ""):
     if len(xml_text) > 0:
         for tag_name in faulty_tags:
-            xml_text = re.sub(rf'<{tag_name}\b([^>]*)>', rf'<{tag_name}\1/>', xml_text)
+            xml_text = re.sub(rf"<{tag_name}\b([^>]*)>", rf"<{tag_name}\1/>", xml_text)
     else:
-        print("[Preprocess_JEScript_XML_Content()] xml contents where empty. No parsing done")
+        print(
+            "[Preprocess_JEScript_XML_Content()] xml contents were empty. No parsing done"
+        )
     return xml_text
 
-#when doing debug test run
-if __name__ == '__main__':
+
+def JEScript_PreprocessInlineTags(xml_text: str = ""):
+    if len(xml_text) > 0:
+        for tag_name in faulty_tags:
+            xml_text = re.sub(
+                rf"<{tag_name}\b([^>]*)>",
+                rf"{WorkTagStart}{tag_name}\1{WorkTagEnd}",
+                xml_text,
+            )
+    else:
+        print("[JEScript_ReplaceInlineTags()] xml contents were empty. No parsing done")
+    return xml_text
+
+
+def JEScript_CleanupInlineTags(xml_text: str = ""):
+    if len(xml_text) > 0:
+        for tag_name in faulty_tags:
+            # stage 1: try to also fix unnecessary new lines
+            xml_text = re.sub(
+                rf"{WorkTagStart_regex}{tag_name}\b([^\|]*){WorkTagEnd_regex}",
+                rf"<{tag_name}\1/>",
+                xml_text,
+            )
+    else:
+        print(
+            "[Postprocess_JEScript_XML_Content()] xml contents were empty. No parsing done"
+        )
+    return xml_text
+
+
+# when doing debug test run
+if __name__ == "__main__":
     # Load the XML file
     xml_text = ""
     with open("./Tests/test.xml", encoding="utf-8") as fobj:

--- a/TranslationProgressReporter/ProgressReporter.py
+++ b/TranslationProgressReporter/ProgressReporter.py
@@ -1,109 +1,200 @@
+import os
+import glob
+import csv
 import argparse
 import lxml.etree as ET
 from lxml import html as ETHtml
 from JEScripts_Preprocessor import Preprocess_JEScript_XML_Content
-import os
 from pathlib import Path
-import csv
-#-----
-#setup argparse
-parser = argparse.ArgumentParser(description='Find places in .xml scripts (JE Scripts) that are missing English translations')
-parser.add_argument('-dir', type=str, required=True, help='Path to folder(s) containing XML files to validate (It will be recursively scanned).')
-parser.add_argument('-out', nargs='?', default='TranslationReport.csv', help='a .csv file where the report should be written to.')
-parser.add_argument('-v', action='store_true' , help='use if you need more debug info')
-parser.add_argument('-skip_gendered', action='store_true' , help='use if you want to skip reporting missing translations inside of <male>/<female> tags')
-parser.add_argument('-skip_locations', action='store_true' , help='use if you want to skip reporting missing translations inside <location> tags')
-parser.add_argument('-skip_others', action='store_true' , help='use if you want to skip all other tags with untranslated text')
+
+# -----
+# setup argparse
+parser = argparse.ArgumentParser(
+    description="Find places in .xml scripts (JE Scripts) that are missing English translations"
+)
+parser.add_argument(
+    "-dir",
+    type=str,
+    required=True,
+    help="Path to folder(s) containing XML files to validate (It will be recursively scanned).",
+)
+parser.add_argument(
+    "-out",
+    nargs="?",
+    default="TranslationReport.csv",
+    help="a .csv file where the report should be written to.",
+)
+parser.add_argument("-v", action="store_true", help="use if you need more debug info")
+parser.add_argument("-exclude", nargs="+", type=str, default=[])
+parser.add_argument(
+    "-skip_gendered",
+    action="store_true",
+    help="use if you want to skip reporting missing translations inside of <male>/<female> tags",
+)
+parser.add_argument(
+    "-skip_locations",
+    action="store_true",
+    help="use if you want to skip reporting missing translations inside <location> tags",
+)
+parser.add_argument(
+    "-skip_others",
+    action="store_true",
+    help="use if you want to skip all other tags with untranslated text",
+)
 
 
 args = parser.parse_args()
-#TODO: group error msg in a dictionary, for better filtering and sorting posibilities
-#EntriesByCategory = {}
-#-----
+# TODO: group error msg in a dictionary, for better filtering and sorting posibilities
+# EntriesByCategory = {}
+# -----
+
+
+def Check_skip_dirs(fPath: str = ""):
+    if len(fPath) == 0:
+        # print("Empty path")
+        return True
+    # print(f"amount of skipdirs: {len(args.exclude)}")
+    if len(args.exclude) > 0:
+        for badDir in args.exclude:
+            if fPath.find(badDir) > -1:
+                print(f"skipping: {fPath}")
+                return True
+
+    return False
+
+
+# end Check_skip_dirs()
+
 
 def Get_file_list(aDir, aFiletype=".xml"):
     outList = []
+    if args.v:
+        print(f"Main dir: {aDir}")
+
     for fPath, subDirs, files in os.walk(aDir):
         for f in files:
             if f.endswith(aFiletype):
-                fullpath = os.path.join(fPath,f)
-                if(args.v):
-                    print("found [.xml] script file: "+fullpath)
+                fullpath = os.path.join(fPath, f)
+                if Check_skip_dirs(fullpath):
+                    continue
+
+                if args.v:
+                    print("found [.xml] script file: " + fullpath)
                 outList.append(fullpath)
 
     return outList
-#end Get_file_list()
+
+
+# end Get_file_list()
+
 
 def check_gendered_missing_EN_loc(fName, outer):
     endline_num = outer.sourceline + (len(ETHtml.tostring(outer).strip().split()) - 1)
     nextOuterSibling = outer.getnext()
     outer_tag_name = outer.tag.lower()
-    msg=""
-    #if the outer's next sibling is not another gendered tag or a translation, that means the whole JP text was not translated
-    if nextOuterSibling is None or (nextOuterSibling.tag != "male" and nextOuterSibling.tag != "female" and nextOuterSibling.tag != "ascii"):
-        msg = resultMsg = f"file: [{fName}] :: start Line: {outer.sourceline} -> End line: {endline_num} | [MALE/FEMALE] Missing EN translation (<ascii></ascii> tags)."
+    msg = ""
+    # if the outer's next sibling is not another gendered tag or a translation, that means the whole JP text was not translated
+    if nextOuterSibling is not None and nextOuterSibling.tag == "ascii":
+        msg = resultMsg = (
+            f"file: [{fName}] :: start Line: {outer.sourceline} -> End line: {endline_num} | [MALE/FEMALE] there is only a single EN translation for both gender's text (<ascii></ascii> tags)."
+        )
+    # if the outer's next sibling is not another gendered tag or a translation, that means the whole JP text was not translated
+    elif nextOuterSibling is None or (
+        nextOuterSibling.tag != "male"
+        and nextOuterSibling.tag != "female"
+        and nextOuterSibling.tag != "ascii"
+    ):
+        msg = resultMsg = (
+            f"file: [{fName}] :: start Line: {outer.sourceline} -> End line: {endline_num} | [MALE/FEMALE] Missing EN translation (<ascii></ascii> tags)."
+        )
     return msg
-#end check_gendered_missing_EN_loc(inSjisTag)
+
+
+# end check_gendered_missing_EN_loc(inSjisTag)
+
 
 def find_missing_EN_loc(xmlFile):
     missingEnList = []
     with open(xmlFile, encoding="utf-8") as fobj:
-        xml_contents = Preprocess_JEScript_XML_Content(fobj.read()) #here we fixup all unclosed custom tags, to make sure our xml has a valid structure
-        xml_bytes = xml_contents.encode("utf-8")
-        try:
-            root = ETHtml.fromstring(xml_bytes)
-            
-            for sjis_tag in root.xpath(".//sjis"):
-                next_sibling = sjis_tag.getnext()
-                if next_sibling is None or next_sibling.tag != "ascii": #here we know that there is no translation right after JP text in <sjis></sjis>
-                    resultMsg = ""
-                    endline_num = sjis_tag.sourceline + (len(ETHtml.tostring(sjis_tag).strip().split()) - 1)
-                    #now let's check if it's not a <sjis></sjis> wrapped with <male>/<female>tags
-                    outer_tag = sjis_tag.getparent()
-                    outer_tag_name = outer_tag.tag.lower()
-                    if outer_tag_name == "male" or outer_tag_name == "female":
-                        if args.skip_gendered: #check if we should skip gendered
-                            continue
-                        #gendered text may have a single translation <ascii></ascii> tag, right after </male> or </female> closing tags. This means both <sjis> JP text have the same EN <ascii> translation
-                        resultMsg = check_gendered_missing_EN_loc(xmlFile, outer_tag)
-                    elif outer_tag_name == "location":
-                        if args.skip_locations: #check if we should skip locations
-                            continue
-                        type = f"[{outer_tag_name.upper()}]"
-                        resultMsg = f"file: [{xmlFile}] :: start Line: {sjis_tag.sourceline} -> End line: {endline_num} | {type} Missing EN translation (<ascii></ascii> tags)."
-                    else:
-                        if args.skip_others: #check if we should skip dialogues
-                            continue
-                        type = f"[{outer_tag_name.upper()}]"
-                        resultMsg = f"file: [{xmlFile}] :: start Line: {sjis_tag.sourceline} -> End line: {endline_num} | {type} Missing EN translation (<ascii></ascii> tags)."
-                    #save result message
-                    if resultMsg != "":
-                        missingEnList.append(resultMsg)
-                        if(args.v):
-                            print(resultMsg)
-        except ET.XMLSyntaxError as e:
-            errorMsg = f"XmlSyntaxError while parsing file:[{xmlFile}] :: Reason:{e.msg}"
-            missingEnList.append(errorMsg)
-            if(args.v):
-                print(errorMsg)
+        file_contents = fobj.read()
+        if len(file_contents) > 0:
+            xml_contents = Preprocess_JEScript_XML_Content(
+                file_contents
+            )  # here we fixup all unclosed custom tags, to make sure our xml has a valid structure
+            xml_bytes = xml_contents.encode("utf-8")
+            try:
+                root = ETHtml.fromstring(xml_bytes)
+
+                for sjis_tag in root.xpath(".//sjis"):
+                    next_sibling = sjis_tag.getnext()
+                    if (
+                        next_sibling is None or next_sibling.tag != "ascii"
+                    ):  # here we know that there is no translation right after JP text in <sjis></sjis>
+                        resultMsg = ""
+                        endline_num = sjis_tag.sourceline + (
+                            len(ETHtml.tostring(sjis_tag).strip().split()) - 1
+                        )
+                        # now let's check if it's not a <sjis></sjis> wrapped with <male>/<female>tags
+                        outer_tag = sjis_tag.getparent()
+                        outer_tag_name = outer_tag.tag.lower()
+                        if outer_tag_name == "male" or outer_tag_name == "female":
+                            if args.skip_gendered:  # check if we should skip gendered
+                                continue
+                            # gendered text may have a single translation <ascii></ascii> tag, right after </male> or </female> closing tags. This means both <sjis> JP text have the same EN <ascii> translation
+                            resultMsg = check_gendered_missing_EN_loc(
+                                xmlFile, outer_tag
+                            )
+                        elif outer_tag_name == "location":
+                            if args.skip_locations:  # check if we should skip locations
+                                continue
+                            type = f"[{outer_tag_name.upper()}]"
+                            resultMsg = f"file: [{xmlFile}] :: start Line: {sjis_tag.sourceline} -> End line: {endline_num} | {type} Missing EN translation (<ascii></ascii> tags)."
+                        else:
+                            if args.skip_others:  # check if we should skip dialogues
+                                continue
+                            type = f"[{outer_tag_name.upper()}]"
+                            resultMsg = f"file: [{xmlFile}] :: start Line: {sjis_tag.sourceline} -> End line: {endline_num} | {type} Missing EN translation (<ascii></ascii> tags)."
+                        # save result message
+                        if resultMsg != "":
+                            missingEnList.append(resultMsg)
+                            if args.v:
+                                print(resultMsg)
+            except ET.XMLSyntaxError as e:
+                errorMsg = (
+                    f"XmlSyntaxError while parsing file:[{xmlFile}] :: Reason:{e.msg}"
+                )
+                missingEnList.append(errorMsg)
+                if args.v:
+                    print(errorMsg)
     return missingEnList
-#END find_missing_EN_loc(xmlFile)
+
+
+# END find_missing_EN_loc(xmlFile)
+
 
 def export_to_csv(msgList):
-    #TODO: write an export function
+    # TODO: write an export function
     pass
-#end export_to_csv(msgList)
-                    
-def main():
-    #parse path that needs to be scanned
-    scanPath = Path(args.dir) #by default let's assume it's absolute
-    if not scanPath.is_absolute(): #now we check if maybe it's a relative path
-        scanPath = Path(os.getcwd(), args.dir).resolve() #convert relative Path to absolute path for sanity
 
-    #search for xml files:
-    print("Scanning dir: ["+args.dir+"] for .xml files")
-    XmlList = Get_file_list(scanPath, ".xml")
-    #search through file list
+
+# end export_to_csv(msgList)
+
+
+def main():
+    # parse path that needs to be scanned
+    dir = args.dir
+    scanPath = Path(dir)  # by default let's assume it's absolute
+    if not scanPath.is_absolute():  # now we check if maybe it's a relative path
+        scanPath = Path(
+            os.getcwd(), dir
+        ).resolve()  # convert relative Path to absolute path for sanity
+    else:
+        print("using absolute path")
+
+    # search for xml files:
+    print("Scanning dir: [" + args.dir + "] for .xml files")
+    XmlList = Get_file_list(args.dir, ".xml")
+    # search through file list
     resultList = []
 
     print(f"searching for missing EN translations in {len(XmlList)} files.")
@@ -111,17 +202,21 @@ def main():
     for xml in XmlList:
         resultList += find_missing_EN_loc(xml)
     finalList = []
-    msg =f"Found {len(resultList)} missing EN translations."
-    finalList.append(msg+" Below are the results:")
-    print(msg+f" Results are written to: {args.out}")
+    msg = f"Found {len(resultList)} missing EN translations."
+    if len(resultList) > 0:
+        finalList.append(msg + " Below are the results:")
+    else:
+        finalList.append(msg)
+    print(msg + f" Results are written to: {args.out}")
     finalList += resultList
-    #TODO: save xmlList to a .log or to a .csv file
-    with open(args.out, 'w', newline='') as csvfile:
+    # TODO: save xmlList to a .log or to a .csv file
+    with open(args.out, "w", newline="") as csvfile:
         writer = csv.writer(csvfile)
         for item in finalList:
             writer.writerow([item])
 
-#End main()
 
-if __name__ == '__main__':
+# End main()
+
+if __name__ == "__main__":
     main()

--- a/TranslationProgressReporter/Tests/test2.xml
+++ b/TranslationProgressReporter/Tests/test2.xml
@@ -1,0 +1,265 @@
+<bigtext>
+  <info box="nobox" effect="big">
+  <sjis>
+    鍛冶師とは!<end_line>
+  </sjis>
+  <ascii>
+    Craftknights!<end_line>
+  </ascii>
+</bigtext>
+<dialogue>
+  <info box="nobox">
+  <sjis>
+    武器作りの名手であると同時に<end_line>
+    剣の達人でもある『匠』<end_line>
+  </sjis>
+  <ascii>
+    They are expert weaponsmiths,<end_line>
+    and at the same time,<end_line>
+    masters of the sword.<end_line>
+  </ascii>
+</dialogue>
+<dialogue>
+  <info box="nobox">
+  <sjis>
+    鍛え抜かれ研ぎすまされた   <end_line>
+    心と体の持ち主にのみ与えられる <end_line>
+    特別な称号       <end_line>
+  </sjis>
+  <ascii>
+    It is a special title only given to<end_line>
+    those who have fully immersed their<end_line>
+    body in the fires of the forge.<end_line>
+  </ascii>
+</dialogue>
+<dialogue>
+  <info box="simple">
+  <sjis>
+    わかっているだろうね<end_line>
+    <player_name><three_dots><end_line>
+  </sjis>
+  <ascii>
+    You know what comes next, right?<end_line>
+    <player_name><three_dots><end_line>
+  </ascii>
+</dialogue>
+<dialogue>
+  <info box="left">
+  <portrait_l entry="player" eye="serious" mouth="serious">
+  <male>
+    <sjis>
+      <three_dots><end_line>
+      ヴィー、ねえちゃん<three_dots><end_line>
+    </sjis>	
+  </male>
+  <female>
+    <sjis>
+      <three_dots><end_line>
+      ヴィー姉<three_dots><end_line>
+    </sjis>	
+  </female>
+  <ascii>
+      <three_dots><end_line>
+      Sister Vee<three_dots><end_line>
+    </ascii>
+</dialogue>
+<dialogue>
+  <info box="right">
+  <portrait_l entry="player" eye="serious" mouth="serious">
+  <portrait_r entry="vee" eye="decided" mouth="neutral">
+  <sjis>
+    これまでのつらい修行に<end_line>
+    よく耐え抜いたな<end_line>
+    本当に立派だったぞ<end_line>
+  </sjis>
+  <ascii>
+    You've done well to endure<end_line>
+    my training for so long.<end_line>
+    I'm impressed.<end_line>
+  </ascii>	
+</dialogue>
+<dialogue>
+  <info box="left">
+  <portrait_l entry="player" eye="decided" mouth="neutral">
+  <portrait_r entry="vee" eye="decided" mouth="neutral">
+  <sjis>
+    ありがとうございます！<end_line>
+  </sjis>
+  <ascii>
+    Thank you very much!<end_line>
+  </ascii>	
+</dialogue>
+<dialogue>
+  <info box="right">
+  <portrait_l entry="player" eye="serious" mouth="neutral">
+  <portrait_r entry="vee" eye="decided" mouth="serious">
+  <sjis>
+    では、これから<end_line>
+    最後の試験を行う<three_dots><end_line>
+  </sjis>
+  <ascii>
+    Well then,<end_line>
+    it's time for the final test<three_dots><end_line>
+  </ascii>	
+</dialogue>
+<dialogue>
+  <info box="left">
+  <portrait_l entry="player" eye="decided" mouth="tense">
+  <portrait_r entry="vee" eye="decided" mouth="serious">
+  <sjis>
+    <three_dots>はい<end_line>
+  </sjis>
+  <ascii>
+    <three_dots>Yes.<end_line>
+  </ascii>	
+</dialogue>
+<dialogue>
+  <info box="right">
+  <portrait_l entry="player" eye="decided" mouth="tense">
+  <portrait_r entry="vee" eye="decided" mouth="tense">
+  <sjis>
+    <player_nickname><end_line>
+    ハンマー持ってるね<end_line>
+  </sjis>
+  <ascii>
+    <player_nickname><end_line>
+    You have your hammer, right?<end_line>
+  </ascii>	
+</dialogue>
+<dialogue>
+  <info box="left">
+  <portrait_l entry="player" eye="decided" mouth="neutral">
+  <portrait_r entry="vee" eye="decided" mouth="tense">
+  <sjis>
+    もちろん！<end_line>
+  </sjis>
+  <ascii>
+    Of course!<end_line>
+  </ascii>	
+</dialogue>
+<dialogue>
+  <info box="right">
+  <portrait_r entry="vee" eye="serious" mouth="talk">
+  <sjis>
+    ふふ<three_dots><end_line>
+    良いハンマーだよ<end_line>
+    アンタの魂がこもってる<three_dots><end_line>
+  </sjis>
+  <ascii>
+    Haha<three_dots><end_line>
+    It's a good hammer.<end_line>
+    It's filled with your soul<three_dots><end_line>
+  </ascii>	
+</dialogue>
+<dialogue>
+  <info box="left">
+  <portrait_l entry="player" eye="decided" mouth="talk">
+  <portrait_r entry="vee" eye="serious" mouth="talk">
+  <male>
+    <sjis>
+      そりゃそうさ！<end_line>
+    </sjis>
+    <ascii>
+      That's a given!<end_line>
+    </ascii>			
+  </male>
+  <female>
+    <sjis>
+      そりゃそうだよ！<end_line>
+    </sjis>
+    <ascii>
+      Well, that's a given!<end_line>
+    </ascii>	
+  </female>
+</dialogue>
+<dialogue>
+  <info box="right">
+  <portrait_l entry="player" eye="decided" mouth="talk">
+  <portrait_r entry="vee" eye="decided" mouth="yell">
+  <sjis>
+    鍛冶師なら！<end_line>
+  </sjis>
+  <ascii>
+    To a Craftknight!<end_line>
+  </ascii>
+</dialogue>
+<bigtext>
+  <info box="both" effect="big">
+  <portrait_l entry="player" eye="decided" mouth="yell">
+  <portrait_r entry="vee" eye="decided" mouth="yell">
+  <sjis>
+    ハンマーは、友！<end_line>
+  </sjis>
+  <ascii>
+    The hammer is, a friend!<end_line>
+  </ascii>	
+</bigtext>
+<bigtext>
+  <info box="both" effect="big">
+  <portrait_l entry="player" eye="decided" mouth="yell">
+  <portrait_r entry="vee" eye="decided" mouth="yell">
+  <sjis>
+    ハンマーは、力！<end_line>
+  </sjis>
+  <ascii>
+    The hammer is, power!<end_line>
+  </ascii>	
+</bigtext>
+<bigtext>
+  <info box="both" effect="big">
+  <portrait_l entry="player" eye="decided" mouth="yell">
+  <portrait_r entry="vee" eye="decided" mouth="yell">
+  <sjis>
+    ハンマーは、命！<end_line>
+  </sjis>
+  <ascii>
+    The hammer is, life!<end_line>
+  </ascii>	
+</bigtext>
+<dialogue>
+  <info box="both">
+  <portrait_l entry="player" eye="happy" mouth="neutral">
+  <portrait_r entry="vee" eye="serious" mouth="talk">
+  <sjis>
+    <three_dots><end_line>
+  </sjis>
+  <ascii>
+    <three_dots><end_line>
+  </ascii>	
+</dialogue>
+<dialogue>
+  <info box="right">
+  <portrait_l entry="player" eye="decided" mouth="tense">
+  <portrait_r entry="vee" eye="decided" mouth="serious">
+  <sjis>
+    じゃあ、そのハンマーで<end_line>
+    このアタシに勝ってみせな！<end_line>
+  </sjis>
+  <ascii>
+    Now then, show me the<end_line>
+    fruits of your labor!<end_line>
+    Take up your hammer, and fight me!<end_line>
+  </ascii>
+</dialogue>
+<dialogue>
+  <info box="right">
+  <portrait_l entry="player" eye="decided" mouth="serious">
+  <portrait_r entry="vee" eye="decided" mouth="tense">
+  <sjis>
+    それがアンタが鍛冶師になるための<three_dots><end_line>
+  </sjis>
+  <ascii>
+    This is<three_dots><end_line>
+  </ascii>	
+</dialogue>
+<bigtext>
+  <info box="right" effect="big">
+  <portrait_l entry="player" eye="decided" mouth="serious">
+  <portrait_r entry="vee" eye="decided" mouth="yell">
+  <sjis>
+    最終試験だ！<end_line>
+  </sjis>
+  <ascii>
+    The final test!<end_line>
+  </ascii>	
+</bigtext>


### PR DESCRIPTION
There are many cases, where <ascii></ascii> translation for gendered tags (<male>/<female> tags) is placed not as direct children nodes of these tags, but there is a single sibling <ascii> tag in the same <dialogue></dialogue>. This can be fixed automatically with the new FixMaleFemaleTranslation.py script.