### PR TITLE
JEScripts corrected with auto fixed gendered <ascii> translation

### DIFF
--- a/Day 00/001_24891724_17bd14c.xml
+++ b/Day 00/001_24891724_17bd14c.xml
@@ -9,7 +9,7 @@
     <ascii>
       Yes!<end_line>
       Victory!<end_line>
-    </ascii>	
+    </ascii>
   </male>
   <female>
     <sjis>
@@ -19,7 +19,7 @@
     <ascii>
       Yay!<end_line>
       I won!<end_line>
-    </ascii>	
+    </ascii>
   </female>
 </dialogue>
 <dialogue>
@@ -34,7 +34,7 @@
     You've grown strong<three_dots><end_line>
     I could feel your determination<end_line>
     with every blow.<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -44,7 +44,7 @@
   </sjis>
   <ascii>
     You were really cool, you know.<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -58,7 +58,7 @@
     <ascii>
       Ah<three_dots>! <end_line>
       Thank you, Sis V.E!<end_line>
-    </ascii>	
+    </ascii>
   </male>
   <female>
     <sjis>
@@ -79,7 +79,7 @@
   </sjis>
   <ascii>
     Well done, <player_name>!<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -167,7 +167,7 @@
     <ascii>
       Vee<three_dots><end_line>
       Are you crying?<end_line>
-    </ascii>		
+    </ascii>
   </male>
   <female>
     <sjis>
@@ -177,7 +177,7 @@
     <ascii>
       Vee is<three_dots><end_line>
       Crying?<end_line>
-    </ascii>		
+    </ascii>
   </female>
 </dialogue>
 <dialogue>
@@ -192,7 +192,7 @@
     When I found him,<end_line>
     it was already too late<three_dots><end_line>
     He asked me to give this to you<three_dots><end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -203,7 +203,7 @@
   <ascii>
     That's<three_dots><end_line>
     Master Rob's<three_dots>!<end_line>
-  </ascii>			
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -213,7 +213,7 @@
   </sjis>
   <ascii>
     No way<three_dots><end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -225,7 +225,7 @@
   <ascii>
     Rob was<three_dots><end_line>
     A Stray Summon Beast<three_dots><end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <bigtext>
   <info box="nobox">
@@ -234,7 +234,7 @@
   </sjis>
   <ascii>
     Killed him!<end_line>
-  </ascii>	
+  </ascii>
 </bigtext>
 <bigtext>
   <info box="nobox" effect="big">
@@ -243,7 +243,7 @@
   </sjis>
   <ascii>
     Masteer!!<end_line>
-  </ascii>	
+  </ascii>
 </bigtext>
 <dialogue>
   <info box="right">
@@ -253,7 +253,7 @@
   </sjis>
   <ascii>
     What's wrong, <player_nickname>?<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -265,7 +265,7 @@
   <ascii>
     Uh<three_dots><end_line>
     Huh<three_dots>?<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -280,7 +280,7 @@
     You were taking forever<three_dots><end_line>
     To think you were lazing<end_line>
     about at your favorite spot <three_dots><end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -291,7 +291,7 @@
   </sjis>
   <ascii>
     Aren't you easygoing<three_dots><end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -302,17 +302,21 @@
       やっぱ、ひるねをするには<end_line>
       ここに限るね<three_dots><end_line>
     </sjis>
+    <ascii>
+    Yeah, this is a great<end_line>
+    place to relax and<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       やっぱ、おひるねするには<end_line>
       ここに限るわ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, this is a great<end_line>
     place to relax and<three_dots><end_line>
-  </ascii>	
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -340,7 +344,7 @@
     Anyway, you were probably<end_line>
     having some idiotic dream,<end_line>
     weren't you?<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -351,7 +355,7 @@
   </sjis>
   <ascii>
     Like beating me in a fight?<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -366,7 +370,7 @@
     <ascii>
       Uwah!? Wow! <end_line>
       How'd you know, Sis Vee? <end_line>
-    </ascii>	
+    </ascii>
   </male>
   <female>
     <sjis>
@@ -377,7 +381,7 @@
     <ascii>
       Uwah!? Amazing! <end_line>
       How did you know, Sis Vee? <end_line>
-    </ascii>	
+    </ascii>
   </female>
 </dialogue>
 <dialogue>
@@ -392,8 +396,8 @@
     <ascii>
       <three_dots>Ouch!<end_line>
       What was that for!?<end_line>
-    </ascii>	
-  </male> 
+    </ascii>
+  </male>
   <female>
     <sjis>
       <three_dots>ったぁい！<end_line>
@@ -404,7 +408,7 @@
       <three_dots>Oww!<end_line>
       That's mean!<end_line>
       Why'd you do that!?<end_line>
-    </ascii>	
+    </ascii>
   </female>
 </dialogue>
 <dialogue>
@@ -421,7 +425,7 @@
       Sis Vee!?<end_line>
       I've told you to call me Master!<end_line>
       Master Vee!<end_line>
-    </ascii>	
+    </ascii>
   </male>
   <female>
     <sjis>
@@ -433,7 +437,7 @@
       Who's your sis!?<end_line>
       I've told you to call me Master!<end_line>
       Master Vee!<end_line>
-    </ascii>	
+    </ascii>
   </female>
 </dialogue>
 <dialogue>
@@ -448,7 +452,7 @@
     <ascii>
       Sorry, Master!<end_line>
       I just made a little mistake!<end_line>
-    </ascii>	
+    </ascii>
   </male>
   <female>
     <sjis>
@@ -459,7 +463,7 @@
     <ascii>
       I'm sorry, Master!<end_line>
       But it was just a little mistake!<end_line>
-    </ascii>	
+    </ascii>
   </female>
 </dialogue>
 <dialogue>
@@ -502,7 +506,7 @@
     </sjis>
     <ascii>
       I-I didn't mean it like that<three_dots>!<end_line>
-    </ascii>	
+    </ascii>
   </male>
   <female>
     <sjis>
@@ -537,7 +541,7 @@
   </sjis>
   <ascii>
     Th-That's right!<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -567,7 +571,7 @@
     I was summoned to this world as a<end_line>
     Craftknight's partner, even though<end_line>
     I'd never touched a forge before!<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -702,7 +706,7 @@
       Master's imagination is running<end_line>
       wild once again<three_dots><end_line>
       I better leave while I can.<end_line>
-    </ascii>	
+    </ascii>
   </female>
 </dialogue>
 <bigtext>
@@ -750,6 +754,11 @@
       お金だって、ほら！<end_line>
       買い物だってちゃんと！<end_line>
     </sjis>
+    <ascii>
+    Yeah, I already returned the sword!<end_line>
+    I got the money here, look!<end_line>
+    And I even did the shopping too!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -757,12 +766,12 @@
       お金だって、ほら！<end_line>
       お買い物だってちゃんと！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, I already returned the sword!<end_line>
     I got the money here, look!<end_line>
     And I even did the shopping too!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -789,6 +798,11 @@
       いやー、ひと仕事おわったんで<end_line>
       ちょっとひと休みしようと<three_dots><end_line>
     </sjis>
+    <ascii>
+    Hehehe<three_dots><end_line>
+    Well, after all that hard work,<end_line>
+    I deserve a break, right<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -796,12 +810,12 @@
       いやー、ひと仕事おわったんで<end_line>
       ちょっとひと休みしよっかなって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hehehe<three_dots><end_line>
     Well, after all that hard work,<end_line>
     I deserve a break, right<three_dots>?<end_line>
-  </ascii>    
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -828,7 +842,7 @@
   </sjis>
   <ascii>
     Don't call me an amateur!<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <player gender="male">
@@ -1237,7 +1251,7 @@
     <player_nickname> looks motivated.<end_line>
     A great example of the 'carrot and<end_line>
     the stick', if I may say so myself.<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -1259,15 +1273,19 @@
       よっし！<end_line>
       オレも出発だ！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Time to get moving!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       わたしも行こう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Time to get moving!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 00/003_24286220_172940c.xml
+++ b/Day 00/003_24286220_172940c.xml
@@ -17,15 +17,18 @@
     <sjis>
       外に行く用はないな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Nothing to do out there<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       外に行く用事はないよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Nothing to do out there<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Day 00/007_24288044_1729b2c.xml
+++ b/Day 00/007_24288044_1729b2c.xml
@@ -29,6 +29,11 @@
       武器を準備してからだな<end_line>
       材料もそろったし、工房に行こう<end_line>
     </sjis>
+    <ascii>
+    I need a weapon if I'm going<end_line>
+    to leave the village. I have the<end_line>
+    materials, I just need to craft it.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -36,12 +41,12 @@
       武器を準備してからだね<end_line>
       材料もそろったし、工房に行こう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I need a weapon if I'm going<end_line>
     to leave the village. I have the<end_line>
     materials, I just need to craft it.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 00/008_24898220_17beaac.xml
+++ b/Day 00/008_24898220_17beaac.xml
@@ -441,16 +441,19 @@
       なんだよ<end_line>
       その言い方<three_dots><end_line>
     </sjis>
+    <ascii>
+    What's your problem<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ<end_line>
       その言い方<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's your problem<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -470,17 +473,21 @@
       うわ！？<end_line>
       なんだよ！？<end_line>
     </sjis>
+    <ascii>
+    Uwah!?<end_line>
+    What is it!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うわ！？<end_line>
       なによ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uwah!?<end_line>
     What is it!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 00/013_24902220_17bfa4c.xml
+++ b/Day 00/013_24902220_17bfa4c.xml
@@ -22,17 +22,21 @@
       初心忘れるべからず！<end_line>
       だろ？<end_line>
     </sjis>
+    <ascii>
+    Never forget the basics!<end_line>
+    Right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       初心忘れるべからず！<end_line>
       でしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Never forget the basics!<end_line>
     Right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -110,7 +114,7 @@
     Shapestone determines weapon type,<end_line>
     while the additional materials<end_line>
     determines strength and appearance.<end_line>
-  </ascii> 
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 00/014_24903532_17bff6c.xml
+++ b/Day 00/014_24903532_17bff6c.xml
@@ -140,18 +140,23 @@
       じゃ、また材料さがしてくる<end_line>
       マニグ採掘場にでも行ってくるよ<end_line>
     </sjis>
+    <ascii>
+    Well, I'm gonna gather<end_line>
+    more materials again.<end_line>
+    Guess I'll go to Manig Mine.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       じゃ、また材料さがしてくる<end_line>
       マニグ採掘場にでも行ってくるね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, I'm gonna gather<end_line>
     more materials again.<end_line>
     Guess I'll go to Manig Mine.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 00/015_24905292_17c064c.xml
+++ b/Day 00/015_24905292_17c064c.xml
@@ -36,17 +36,21 @@
       なんだよ！？<end_line>
       どうしたんだ！？<end_line>
     </sjis>
+    <ascii>
+    Master!<end_line>
+    What's wrong!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！？<end_line>
       どうしたの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Master!<end_line>
     What's wrong!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -58,6 +62,11 @@
       ドリルあたま！？<end_line>
       召喚獣！<end_line>
     </sjis>
+    <ascii>
+    What is that!?<end_line>
+    A drill for a head!?<end_line>
+    A Summon Beast!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -65,12 +74,12 @@
       ドリルあたま！？<end_line>
       召喚獣！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is that!?<end_line>
     A drill for a head!?<end_line>
     A Summon Beast!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -82,6 +91,11 @@
       エリマキけもの！？<end_line>
       召喚獣！<end_line>
     </sjis>
+    <ascii>
+    What is that!?<end_line>
+    An animal with a scarf!?<end_line>
+    A Summon Beast!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -89,12 +103,12 @@
       エリマキけもの！？<end_line>
       召喚獣！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is that!?<end_line>
     An animal with a scarf!?<end_line>
     A Summon Beast!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -106,6 +120,11 @@
       ハネはえてる！？<end_line>
       召喚獣！<end_line>
     </sjis>
+    <ascii>
+    What is that!?<end_line>
+    It's got wings!?<end_line>
+    A Summon Beast!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -113,12 +132,12 @@
       ハネはえてる！？<end_line>
       召喚獣！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is that!?<end_line>
     It's got wings!?<end_line>
     A Summon Beast!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -130,6 +149,11 @@
       ばくはつあたま！？<end_line>
       召喚獣！<end_line>
     </sjis>
+    <ascii>
+    What is that!?<end_line>
+    A blown-up hairstyle!?<end_line>
+    A Summon Beast!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -137,12 +161,12 @@
       ばくはつあたま！？<end_line>
       召喚獣！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is that!?<end_line>
     A blown-up hairstyle!?<end_line>
     A Summon Beast!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 00/016_24906604_17c0b6c.xml
+++ b/Day 00/016_24906604_17c0b6c.xml
@@ -17,17 +17,21 @@
       親方、ケガ！？<end_line>
       さっきのヤツが！？<end_line>
     </sjis>
+    <ascii>
+    Master, are you hurt!?<end_line>
+    Was it that Summon Beast!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       親方、ケガしてるの！？<end_line>
       さっきのアイツのせい！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Master, are you hurt!?<end_line>
     Was it that Summon Beast!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -89,6 +93,11 @@
       親方がやられたんだぜ<end_line>
       だまってられるかよ！<end_line>
     </sjis>
+    <ascii>
+    Why!?<end_line>
+    You got beat up, Master!<end_line>
+    I can't stand here and do nothing!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -96,12 +105,12 @@
       親方がやられたんだよ<end_line>
       だまってられないよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Why!?<end_line>
     You got beat up, Master!<end_line>
     I can't stand here and do nothing!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -231,15 +240,18 @@
     <sjis>
       どうしてそんなこと、わかるのさ？<end_line>
     </sjis>
+    <ascii>
+    How do you know that?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしてそんなこと、わかるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How do you know that?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -324,6 +336,11 @@
       ムカつくよな！<end_line>
       どうしよっかな？<end_line>
     </sjis>
+    <ascii>
+    As if I could sit still<three_dots>!<end_line>
+    I'm so mad<three_dots>!<end_line>
+    What do I do?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -331,10 +348,10 @@
       ムカつくよ<three_dots>！<end_line>
       どうしよっかな？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     As if I could sit still<three_dots>!<end_line>
     I'm so mad<three_dots>!<end_line>
     What do I do?<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 00/018_24909036_17c14ec.xml
+++ b/Day 00/018_24909036_17c14ec.xml
@@ -6,17 +6,21 @@
       あれ？<end_line>
       あいつ、どこ行った？<end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    Where'd they go?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あれ？<end_line>
       あいつ、どこ行ったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     Where'd they go?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 00/019_24909852_17c181c.xml
+++ b/Day 00/019_24909852_17c181c.xml
@@ -179,15 +179,18 @@
     <sjis>
       なんだよ！？<end_line>
     </sjis>
+    <ascii>
+    Huh!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -422,6 +425,11 @@
       お前、そこにいたんだろ？<end_line>
       なにも見てないのか！？<end_line>
     </sjis>
+    <ascii>
+    I'm sure they went that way!<end_line>
+    You were there, right?<end_line>
+    You didn't see anything!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -429,12 +437,12 @@
       あなた、そこにいたんでしょ？<end_line>
       なにも見てないの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm sure they went that way!<end_line>
     You were there, right?<end_line>
     You didn't see anything!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -457,6 +465,11 @@
       じゃあ、さっき光ったのは！？<end_line>
       本当は何してたんだ！？<end_line>
     </sjis>
+    <ascii>
+    What's with you!?<end_line>
+    Then, what was glowing earlier!?<end_line>
+    What are you really up to!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -464,12 +477,12 @@
       じゃあ、さっき光ったのは！？<end_line>
       本当は何してたの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's with you!?<end_line>
     Then, what was glowing earlier!?<end_line>
     What are you really up to!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -531,15 +544,18 @@
     <sjis>
       なんだと！？<end_line>
     </sjis>
+    <ascii>
+    What's your problem!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's your problem!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -563,6 +579,11 @@
       ちゃんと話せよ！<end_line>
       親方がケガしてるんだ！<end_line>
     </sjis>
+    <ascii>
+    What are you trying to say?<end_line>
+    Speak up!<end_line>
+    That Beast hurt my Master, you know!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -570,12 +591,12 @@
       ちゃんと話して！<end_line>
       親方がケガしてるんだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What are you trying to say?<end_line>
     Speak up!<end_line>
     That Beast hurt my Master, you know!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <player gender="male">
@@ -1286,15 +1307,18 @@
     <sjis>
       ちがうみたいだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Well that didn't work<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちがったみたい<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well that didn't work<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -1359,6 +1383,11 @@
       ついでに召喚獣の話も<end_line>
       聞き出してやろう！<end_line>
     </sjis>
+    <ascii>
+    I guess I'll give it back.<end_line>
+    While I'm at it, I'll make her<end_line>
+    tell me about the Summon Beast!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1366,12 +1395,12 @@
       ついでに召喚獣の話も<end_line>
       聞き出してやるんだから！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I guess I'll give it back.<end_line>
     While I'm at it, I'll make her<end_line>
     tell me about the Summon Beast!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <player gender="male">

--- a/Day 00/022_24917052_17c343c.xml
+++ b/Day 00/022_24917052_17c343c.xml
@@ -55,15 +55,18 @@
     <sjis>
       その子を放せ！<end_line>
     </sjis>
+    <ascii>
+    Let go of the girl!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       その子を放して！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Let go of the girl!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -84,15 +87,18 @@
     <sjis>
       聞こえなかったのか？<end_line>
     </sjis>
+    <ascii>
+    Didn't hear me?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       聞こえなかった？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Didn't hear me?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -102,15 +108,18 @@
     <sjis>
       この子を放せって言ったんだ<end_line>
     </sjis>
+    <ascii>
+    I told you to let her go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       この子を放せって言ったの<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I told you to let her go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -120,15 +129,18 @@
     <sjis>
       用なんてあるわけないだろ？<end_line>
     </sjis>
+    <ascii>
+    Not really.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       用なんてあるわけないじゃない<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Not really.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -159,15 +171,18 @@
     <sjis>
       お前たちにはな<end_line>
     </sjis>
+    <ascii>
+    Not with you guys, anyway.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんたたちにはね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Not with you guys, anyway.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -190,6 +205,11 @@
       大事な用がね<end_line>
       だから放してくれよ？<end_line>
     </sjis>
+    <ascii>
+    Sorry, but I do need to talk to<end_line>
+    the girl. And it's important.<end_line>
+    So could you let her go?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -197,12 +217,12 @@
       大事な用がね<end_line>
       だから放してくれない？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sorry, but I do need to talk to<end_line>
     the girl. And it's important.<end_line>
     So could you let her go?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -229,6 +249,11 @@
       男がよってたかって<end_line>
       女の子にからんで、カッコワリィ！<end_line>
     </sjis>
+    <ascii>
+    You're one to talk!<end_line>
+    Guys ganging up and picking<end_line>
+    on a girl, so lame!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -236,12 +261,12 @@
       男がよってたかって<end_line>
       女の子にからんで、カッコワルイ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're one to talk!<end_line>
     Guys ganging up and picking<end_line>
     on a girl, so lame!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -405,15 +430,18 @@
     <sjis>
       悪いけど、ダメだ<end_line>
     </sjis>
+    <ascii>
+    Sorry, but I can't do that.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       悪いけど、ダメだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sorry, but I can't do that.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -446,17 +474,21 @@
       今あんたを放っておくのは<end_line>
       カッコワルイからだ！<end_line>
     </sjis>
+    <ascii>
+    Because if I didn't step in now,<end_line>
+    that'd be really lame!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今あなたを放っておくのは<end_line>
       カッコワルイもん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Because if I didn't step in now,<end_line>
     that'd be really lame!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -490,15 +522,18 @@
     <sjis>
       あんたはこのオレが守る！<end_line>
     </sjis>
+    <ascii>
+    I'll be the one to protect you!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あなたはこのわたしが守る！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'll be the one to protect you!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 00/023_24918956_17c3bac.xml
+++ b/Day 00/023_24918956_17c3bac.xml
@@ -68,15 +68,18 @@
     <sjis>
       これって大事なものなのか？<end_line>
     </sjis>
+    <ascii>
+    Is this important to you?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       これって大事なものなの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Is this important to you?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -100,17 +103,21 @@
       ああ、悪い悪い<end_line>
       すぐに返すよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah, sorry, sorry.<end_line>
+    I'll give it back right away<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ああ、ごめんごめん<end_line>
       すぐに返すから<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, sorry, sorry.<end_line>
     I'll give it back right away<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -514,17 +521,21 @@
       なに言ってンだ！<end_line>
       そんなこと<three_dots><end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+    You can't<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに言ってるの！<end_line>
       そんなこと<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
     You can't<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -665,6 +676,11 @@
       声が<three_dots><end_line>
       さっきの石から<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    What the<three_dots>?<end_line>
+    A voice<three_dots><end_line>
+    Coming from the stone<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -672,12 +688,12 @@
       声が<three_dots><end_line>
       さっきの石から<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What the<three_dots>?<end_line>
     A voice<three_dots><end_line>
     Coming from the stone<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 00/024_24921996_17c478c.xml
+++ b/Day 00/024_24921996_17c478c.xml
@@ -86,17 +86,21 @@
       名前<three_dots>？<end_line>
       名前か<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Name<three_dots>?<end_line>
+    Your name, huh<three_dots>！<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       名前<three_dots>？<end_line>
       名前ね<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Name<three_dots>?<end_line>
     Your name, huh<three_dots>！<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <partner name="run-dor">
@@ -239,15 +243,18 @@
     <sjis>
       うぉおおおお！！<end_line>
     </sjis>
+    <ascii>
+    Uwaaaah!!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うぁああああ！！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uwaaaah!!<end_line>
   </ascii>
+  </female>
 </bigtext>
 <dialogue>
   <info box="left">
@@ -269,17 +276,21 @@
       こいつは<three_dots><end_line>
       さっきの召喚獣<three_dots>！！！<end_line>
     </sjis>
+    <ascii>
+    That's<three_dots><end_line>
+    The Summon Beast from earlier<three_dots>!!!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       まさか<three_dots><end_line>
       さっきの召喚獣<three_dots>！！！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's<three_dots><end_line>
     The Summon Beast from earlier<three_dots>!!!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -304,17 +315,21 @@
       か<three_dots>、かわった！？<end_line>
       なんでだ？<end_line>
     </sjis>
+    <ascii>
+    It<three_dots>, it changed!?<end_line>
+    Why?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       か<three_dots>、かわった！？<end_line>
       なんで？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It<three_dots>, it changed!?<end_line>
     Why?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -1292,17 +1307,21 @@
       子供になった！？<end_line>
       なんでだよ？<end_line>
     </sjis>
+    <ascii>
+    H-He became a kid!?<end_line>
+    Why?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       こ、子供になっちゃった！？<end_line>
       どうして？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     H-He became a kid!?<end_line>
     Why?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1670,17 +1689,21 @@
       どうしたんだ？<end_line>
       弱そうになったぞ<end_line>
     </sjis>
+    <ascii>
+    What happened?<end_line>
+    You're looking weaker now.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしたの？<end_line>
       弱そうになっちゃった<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What happened?<end_line>
     You're looking weaker now.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 00/025_24929932_17c668c.xml
+++ b/Day 00/025_24929932_17c668c.xml
@@ -146,17 +146,21 @@
       え？<end_line>
       そうなのか？<end_line>
     </sjis>
+    <ascii>
+    Eh?<end_line>
+    Really?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え？<end_line>
       そうなの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh?<end_line>
     Really?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -181,6 +185,11 @@
       けど、よかったな<end_line>
       あんなのにつきあわなくてすんで<end_line>
     </sjis>
+    <ascii>
+    I can't tell<three_dots><end_line>
+    But anyway, it's great that it ended<end_line>
+    without you having to go along!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -188,12 +197,12 @@
       けど、よかったね<end_line>
       あんなのにつきあわなくてすんで<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I can't tell<three_dots><end_line>
     But anyway, it's great that it ended<end_line>
     without you having to go along!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -431,6 +440,11 @@
       まあ、よかったじゃないか<end_line>
       あいつらを追っ払えて<end_line>
     </sjis>
+    <ascii>
+    I don't really get it, but<three_dots><end_line>
+    Well, isn't it fine!<end_line>
+    We managed to chase them off!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -438,12 +452,12 @@
       まあ、よかったじゃない！<end_line>
       あいつらは追っ払えたし<end_line>
     </sjis>
-  </female>	
-  <ascii>
+    <ascii>
     I don't really get it, but<three_dots><end_line>
     Well, isn't it fine!<end_line>
     We managed to chase them off!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -532,17 +546,21 @@
       お前、小さいのに強いんだな！<end_line>
       かっこよかったぜ！<end_line>
     </sjis>
+    <ascii>
+    Hey, you're stronger than you look!<end_line>
+    That was pretty cool!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ボク、小さいのに強いんだね！<end_line>
       かっこよかったよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, you're stronger than you look!<end_line>
     That was pretty cool!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -605,15 +623,18 @@
     <sjis>
       なんだと！<end_line>
     </sjis>
+    <ascii>
+    What!? Why?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!? Why?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -652,6 +673,11 @@
       あいつらは追っ払えたことだし<end_line>
       よかったな<end_line>
     </sjis>
+    <ascii>
+    Well, anyway<three_dots><end_line>
+    We drove them off,<end_line>
+    so it's all good.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -659,12 +685,12 @@
       あいつらは追っ払えたことだし<end_line>
       よかったね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, anyway<three_dots><end_line>
     We drove them off,<end_line>
     so it's all good.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -798,6 +824,11 @@
       最初出たときの方が<end_line>
       強そうだったな<end_line>
     </sjis>
+    <ascii>
+    Yeah,<end_line>
+    you looked much stronger<end_line>
+    when you first showed up.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -805,12 +836,12 @@
       最初出たときの方が<end_line>
       強そうだったよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah,<end_line>
     you looked much stronger<end_line>
     when you first showed up.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -881,6 +912,11 @@
       あいつらを追っ払えたし<end_line>
       まあ、よかったじゃないか<end_line>
     </sjis>
+    <ascii>
+    Besides,<end_line>
+    we drove them off.<end_line>
+    Well, I'd say it's all good!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -888,12 +924,12 @@
       あいつらを追っ払えたし<end_line>
       まあ、よかったじゃない！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Besides,<end_line>
     we drove them off.<end_line>
     Well, I'd say it's all good!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1015,17 +1051,21 @@
       武器作りの名人で<end_line>
       剣の達人さ！<end_line>
     </sjis>
+    <ascii>
+    An expert in crafting weapons<end_line>
+    and a master of the sword!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       武器作りの名人で<end_line>
       剣の達人だよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     An expert in crafting weapons<end_line>
     and a master of the sword!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1121,6 +1161,10 @@
       おそったんだ<three_dots><end_line>
       親方にケガさせたんだ<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    This one attacked my Master<three_dots><end_line>
+    She was injured<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1128,11 +1172,11 @@
       おそったんだよ<three_dots><end_line>
       親方にケガさせたんだ<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This one attacked my Master<three_dots><end_line>
     She was injured<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1225,6 +1269,11 @@
       見つけたぜ<end_line>
       親方にケガさせた召喚獣<end_line>
     </sjis>
+    <ascii>
+    Master!<end_line>
+    I found the Summon Beast<end_line>
+    that hurt you.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1232,12 +1281,12 @@
       見つけたよ<end_line>
       親方にケガさせた召喚獣<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Master!<end_line>
     I found the Summon Beast<end_line>
     that hurt you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1260,15 +1309,18 @@
     <sjis>
       こいつだよ<end_line>
     </sjis>
+    <ascii>
+    Right here.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       この子だよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Right here.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 00/026_24933404_17c741c.xml
+++ b/Day 00/026_24933404_17c741c.xml
@@ -49,15 +49,18 @@
     <sjis>
       さすがオレだろ<end_line>
     </sjis>
+    <ascii>
+    Heh, no problem!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       さすがわたしね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Heh, no problem!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -531,17 +534,21 @@
       オレの？<end_line>
       いっしょに鍛冶をするってこと？<end_line>
     </sjis>
+    <ascii>
+    Assistant?<end_line>
+    So we'll be smithing together?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしの？<end_line>
       いっしょに鍛冶をするってこと？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Assistant?<end_line>
     So we'll be smithing together?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -726,6 +733,10 @@
       ミューノだったら<end_line>
       オレがついてるからさ！<end_line>
     </sjis>
+    <ascii>
+    Hey, don't worry about Murno.<end_line>
+    I'll be with her!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -733,11 +744,11 @@
       ミューノだったら<end_line>
       わたしがついてるから！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, don't worry about Murno.<end_line>
     I'll be with her!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -760,15 +771,18 @@
     <sjis>
       なんだよ！？<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -1342,6 +1356,10 @@
       ミューノだったら<end_line>
       オレがついてるからさ！<end_line>
     </sjis>
+    <ascii>
+    Hey, don't worry about Murno.<end_line>
+    I'll be with her!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1349,11 +1367,11 @@
       ミューノだったら<end_line>
       わたしがついてるから！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, don't worry about Murno.<end_line>
     I'll be with her!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -2054,15 +2072,18 @@
     <sjis>
       やれるもんならやってみろよ！<end_line>
     </sjis>
+    <ascii>
+    Hah! Feel free to try!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       やれるもんならやってみなさい！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hah! Feel free to try!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -2100,6 +2121,11 @@
       たのむから<end_line>
       勝負させてくれ<end_line>
     </sjis>
+    <ascii>
+    I'm sorry, Murno.<end_line>
+    I'm asking you,<end_line>
+    let us fight!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -2107,12 +2133,12 @@
       たのむから<end_line>
       勝負させて<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm sorry, Murno.<end_line>
     I'm asking you,<end_line>
     let us fight!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -2196,17 +2222,21 @@
       オレが勝ったら、か<three_dots><end_line>
       おろかなことを<three_dots><end_line>
     </sjis>
+    <ascii>
+    You think you stand a chance<three_dots>?<end_line>
+    How foolish<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしが勝ったら、か<three_dots><end_line>
       おろかなことを<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You think you stand a chance<three_dots>?<end_line>
     How foolish<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -2233,15 +2263,18 @@
     <sjis>
       約束したからな！<end_line>
     </sjis>
+    <ascii>
+    It's a promise, then!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       約束したからね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's a promise, then!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -2292,6 +2325,10 @@
       ミューノだったら<end_line>
       オレがついてるからさ！<end_line>
     </sjis>
+    <ascii>
+    Hey, don't worry about Murno.<end_line>
+    I'll be with her!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -2299,11 +2336,11 @@
       ミューノだったら<end_line>
       わたしがついてるから！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, don't worry about Murno.<end_line>
     I'll be with her!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -2365,17 +2402,21 @@
       なんだと！？<end_line>
       オレが弱いって言いたいのか！<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+    So you're saying I'm weak!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！？<end_line>
       わたしが弱いって言いたいの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
     So you're saying I'm weak!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 00/027_24298364_172c37c.xml
+++ b/Day 00/027_24298364_172c37c.xml
@@ -32,15 +32,18 @@
     <sjis>
       生きるのが男じゃない？<end_line>
     </sjis>
+    <ascii>
+    is what makes us human, isn't it?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       生きるのが女じゃない？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     is what makes us human, isn't it?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Day 00/029_24941068_17c920c.xml
+++ b/Day 00/029_24941068_17c920c.xml
@@ -8,6 +8,11 @@
       オレの実力<end_line>
       わかったか！<end_line>
     </sjis>
+    <ascii>
+    How's that!?<end_line>
+    Now do you understand<end_line>
+    my true power?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -15,12 +20,12 @@
       わたしの実力<end_line>
       わかった？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How's that!?<end_line>
     Now do you understand<end_line>
     my true power?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -528,6 +533,11 @@
       鍛冶の手伝いをしてもらうぞ<end_line>
       いいな<end_line>
     </sjis>
+    <ascii>
+    Then, as promised,<end_line>
+    I'll have you help me with smithing.<end_line>
+    Got it?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -535,12 +545,12 @@
       鍛冶の手伝いをしてもらうよ<end_line>
       いいね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Then, as promised,<end_line>
     I'll have you help me with smithing.<end_line>
     Got it?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -751,6 +761,11 @@
       そんなに気にするなって<end_line>
       お前もけっこう強かったよ<end_line>
     </sjis>
+    <ascii>
+    Hey, don't take it too hard.<end_line>
+    I thought you were<end_line>
+    pretty strong too!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -758,12 +773,12 @@
       そんなに気にしないで<end_line>
       あなたもけっこう強かったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, don't take it too hard.<end_line>
     I thought you were<end_line>
     pretty strong too!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -787,6 +802,11 @@
       強さとしては<end_line>
       オレの次ぐらいじゃないの？<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+    I'd say your strength is<end_line>
+    about just below mine!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -794,12 +814,12 @@
       強さとしては<end_line>
       わたしの次ぐらいだと思うよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
     I'd say your strength is<end_line>
     about just below mine!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -934,6 +954,11 @@
       今日からお前は<end_line>
       オレの弟子だ！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    From today on,<end_line>
+    you're my apprentice!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -941,12 +966,12 @@
       今日からあなたは<end_line>
       わたしの弟子だよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     From today on,<end_line>
     you're my apprentice!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -995,15 +1020,18 @@
     <sjis>
       半人前って言うなよ！<end_line>
     </sjis>
+    <ascii>
+    Don't call me an amateur!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       半人前って言わないでよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't call me an amateur!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -1164,15 +1192,18 @@
     <sjis>
       よろしくたのむぜ<end_line>
     </sjis>
+    <ascii>
+    I'm counting on you,<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よろしくたのむね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm counting on you,<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1246,17 +1277,21 @@
       　　　　こうして、オレと<partner>の　　　　<end_line>
       　　　鍛冶師修行が始まったんだ<three_dots>！　<end_line>
     </sjis>
+    <ascii>
+    And so, <partner> and I began<end_line>
+    training together, as Craftknights<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       　　　　こうして、わたしと<partner>の　　  <end_line>
       　　　鍛冶師修行が始まったんだ<three_dots>！　<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And so, <partner> and I began<end_line>
     training together, as Craftknights<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -1265,17 +1300,21 @@
       　　　　こうして、オレと<partner>の　　　<end_line>
       　　　鍛冶師修行が始まったんだ<three_dots>！　<end_line>
     </sjis>
+    <ascii>
+    And so, <partner> and I began<end_line>
+    training together, as Craftknights<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       　　　こうして、わたしと<partner>の　　　<end_line>
       　　　鍛冶師修行が始まったんだ<three_dots>！　<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And so, <partner> and I began<end_line>
     training together, as Craftknights<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -1284,17 +1323,21 @@
       　　　こうして、オレと<partner>の　　　<end_line>
       　　　鍛冶師修行が始まったんだ<three_dots>！　<end_line>
     </sjis>
+    <ascii>
+    And so, <partner> and I began<end_line>
+    training together, as Craftknights<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       　　こうして、わたしと<partner>の　　　<end_line>
       　　鍛冶師修行が始まったんだ<three_dots>！　　<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And so, <partner> and I began<end_line>
     training together, as Craftknights<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -1303,17 +1346,21 @@
       　　こうして、オレと<partner>の　　　<end_line>
       　　鍛冶師修行が始まったんだ<three_dots>！　　<end_line>
     </sjis>
+    <ascii>
+    And so, <partner> and I began<end_line>
+    training together, as Craftknights<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       　　こうして、わたしと<partner>の　　<end_line>
       　　鍛冶師修行が始まったんだ<three_dots>！　　<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And so, <partner> and I began<end_line>
     training together, as Craftknights<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -1322,17 +1369,21 @@
       　　こうして、オレと<partner>の　　<end_line>
       　　鍛冶師修行が始まったんだ<three_dots>！　　<end_line>
     </sjis>
+    <ascii>
+    And so, <partner> and I began<end_line>
+    training together, as Craftknights<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       　こうして、わたしと<partner>の　　<end_line>
       　　鍛冶師修行が始まったんだ<three_dots>！　　<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And so, <partner> and I began<end_line>
     training together, as Craftknights<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -1341,17 +1392,21 @@
       　こうして、オレと<partner>の　　<end_line>
       　　鍛冶師修行が始まったんだ<three_dots>！　　<end_line>
     </sjis>
+    <ascii>
+    And so, <partner> and I began<end_line>
+    training together, as Craftknights<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       　こうして、わたしと<partner>の　<end_line>
       　　鍛冶師修行が始まったんだ<three_dots>！　　<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And so, <partner> and I began<end_line>
     training together, as Craftknights<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 
 

--- a/Day 00/030_24944844_17ca0cc.xml
+++ b/Day 00/030_24944844_17ca0cc.xml
@@ -411,15 +411,18 @@
     <sjis>
       そんな気にすんなよ<end_line>
     </sjis>
+    <ascii>
+    Don't worry about it too much.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんな気にしないで<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't worry about it too much.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -520,17 +523,21 @@
       仕方ない<end_line>
       行こうぜ、<partner><end_line>
     </sjis>
+    <ascii>
+    It can't be helped.<end_line>
+    Let's go, <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       仕方ない<end_line>
       行こう、<partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It can't be helped.<end_line>
     Let's go, <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 00/032_24253308_172137c.xml
+++ b/Day 00/032_24253308_172137c.xml
@@ -83,17 +83,21 @@
       　　　これからどこへ行くつもり　　　<end_line>
       　　　　だったんだろうか<three_dots>　　　　　<end_line>
     </sjis>
+    <ascii>
+      Where did they intend	<end_line>
+      to go from here<three_dots>?  　　　　<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       　　　これからどこへ行くつもり　　　<end_line>
       　　　　　だったんだろう<three_dots>　　　　　<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
       Where did they intend	<end_line>
       to go from here<three_dots>?  　　　　<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -102,17 +106,21 @@
       　　薬のせいかどうかはしらないが　　<end_line>
       　　あれからミューノの熱も下がった　<end_line>
     </sjis>
+    <ascii>
+    After that, Murnos' fever went down.<end_line>
+    The medicine probably worked.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       　薬のせいかどうかはしらないけど　　<end_line>
       　あれからミューノの熱も下がった　　<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     After that, Murnos' fever went down.<end_line>
     The medicine probably worked.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -207,6 +215,11 @@
       　　ティエのことをどうするか？　　　<end_line>
       　<three_dots>っていうのが、カッコワルイなぁ<three_dots><end_line>
     </sjis>
+    <ascii>
+    But, for now, the question is,<end_line>
+    what to do about Tier?<end_line>
+    <three_dots>Man, I'm so lame<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -214,12 +227,12 @@
       　　ティエのことをどうしよう？　　　<end_line>
       　<three_dots>っていうのが、カッコワルイなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     But, for now, the question is,<end_line>
     what to do about Tier?<end_line>
     <three_dots>Man, I'm so lame<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">

--- a/Day 00/033_24947628_17cabac.xml
+++ b/Day 00/033_24947628_17cabac.xml
@@ -7,6 +7,11 @@
       わかるわけないよな<three_dots><end_line>
       もう帰ろっかな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Well, even if I think about it,<end_line>
+    it's not like I'll understand it<three_dots><end_line>
+    Guess I'll head back<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -14,12 +19,12 @@
       わかるわけないよね<three_dots><end_line>
       もう帰ろっかな<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, even if I think about it,<end_line>
     it's not like I'll understand it<three_dots><end_line>
     Guess I'll head back<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -30,6 +35,11 @@
       誰かいるのか？<end_line>
       まさか<three_dots><end_line>
     </sjis>
+    <ascii>
+    Hm?<end_line>
+    Is someone there?<end_line>
+    Could it be<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -37,12 +47,12 @@
       誰かいるの？<end_line>
       まさか<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hm?<end_line>
     Is someone there?<end_line>
     Could it be<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <menu>
   <option>

--- a/Day 00/034_24950044_17cb51c.xml
+++ b/Day 00/034_24950044_17cb51c.xml
@@ -143,6 +143,11 @@
       今日はいろいろあったんで<end_line>
       アタマを冷やしてたんだよ！<end_line>
     </sjis>
+    <ascii>
+    It wouldn't! Definitely not!<end_line>
+    A lot happened today, so<end_line>
+    I was just cooling my head!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -150,12 +155,12 @@
       今日はいろいろあったから<end_line>
       アタマを冷やしてたのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It wouldn't! Definitely not!<end_line>
     A lot happened today, so<end_line>
     I was just cooling my head!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -235,6 +240,11 @@
       これからよろしくな<end_line>
       <partner>！<end_line>
     </sjis>
+    <ascii>
+    I'll say it anew.<end_line>
+    Let's get along from now on,<end_line>
+    <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -242,12 +252,12 @@
       これからよろしくね<end_line>
       <partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'll say it anew.<end_line>
     Let's get along from now on,<end_line>
     <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -323,15 +333,18 @@
     <sjis>
       <three_dots>ってどうしたんだよ？<end_line>
     </sjis>
+    <ascii>
+    <three_dots>Hey, what's the matter?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>ってどうしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots>Hey, what's the matter?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -382,17 +395,21 @@
       そう、ハラのソコからわきあがる<end_line>
       こう<three_dots><end_line>
     </sjis>
+    <ascii>
+    Yeah, it boils up from the bottom<end_line>
+    of your stomach, like<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そう、お腹のソコからわきあがる<end_line>
       こう<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, it boils up from the bottom<end_line>
     of your stomach, like<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -466,6 +483,10 @@
       あいつにも気合いを<end_line>
       つたえてやるぞ！<end_line>
     </sjis>
+    <ascii>
+    One day, I'll make<end_line>
+    <partner> understand!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -473,11 +494,11 @@
       あの子にも気合いを<end_line>
       つたえてみせる！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     One day, I'll make<end_line>
     <partner> understand!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -582,6 +603,11 @@
       今日はいろいろあったんで<end_line>
       アタマを冷やしてたんだよ！<end_line>
     </sjis>
+    <ascii>
+    I'm sure! Absolutely!<end_line>
+    A lot happened today, so<end_line>
+    I was just cooling my head!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -589,12 +615,12 @@
       今日はいろいろあったんで<end_line>
       アタマを冷やしてたの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm sure! Absolutely!<end_line>
     A lot happened today, so<end_line>
     I was just cooling my head!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -704,6 +730,11 @@
       せっかくパートナーになったんだから<end_line>
       もっと仲良くしようぜ<end_line>
     </sjis>
+    <ascii>
+    Hey, what's that about?<end_line>
+    We finally became partners, so<end_line>
+    let's get along better!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -711,12 +742,12 @@
       せっかくパートナーになったんだから<end_line>
       もっと仲良くしようよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, what's that about?<end_line>
     We finally became partners, so<end_line>
     let's get along better!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -838,15 +869,18 @@
     <sjis>
       <three_dots>ってどうしたんだよ？<end_line>
     </sjis>
+    <ascii>
+      <three_dots>Hey, what's the matter?<end_line>
+    </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>ってどうしたの？<end_line>
     </sjis>
-  </female>
     <ascii>
       <three_dots>Hey, what's the matter?<end_line>
     </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -955,6 +989,10 @@
       もしかしてオレの跡<end_line>
       つけてきたのか？<end_line>
     </sjis>
+    <ascii>
+    What's with the attitude<three_dots><end_line>
+    Did you follow me here?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -962,11 +1000,11 @@
       もしかしてわたしの跡<end_line>
       つけてきたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's with the attitude<three_dots><end_line>
     Did you follow me here?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -991,17 +1029,21 @@
       それは<three_dots><end_line>
       オレのパートナーだから？<end_line>
     </sjis>
+    <ascii>
+    That's<three_dots><end_line>
+    Because you're my partner?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       それは<three_dots><end_line>
       わたしのパートナーだから？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's<three_dots><end_line>
     Because you're my partner?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1030,6 +1072,11 @@
       オレは今日はいろいろあったんで<end_line>
       アタマを冷やしてただけだ！<end_line>
     </sjis>
+    <ascii>
+    What's that!?<end_line>
+    A lot happened today, so<end_line>
+    I was just cooling my head!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1037,12 +1084,12 @@
       わたしは今日はいろいろあったから<end_line>
       アタマを冷やしてただけよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's that!?<end_line>
     A lot happened today, so<end_line>
     I was just cooling my head!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1149,6 +1196,11 @@
       仲良くないと息が合わないから<end_line>
       良い武器が作れないんだぞ<three_dots><end_line>
     </sjis>
+    <ascii>
+    What are you saying?<end_line>
+    We need to work together<end_line>
+    to make good weapons!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1156,12 +1208,12 @@
       仲良くないと息が合わないから<end_line>
       良い武器が作れないのよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What are you saying?<end_line>
     We need to work together<end_line>
     to make good weapons!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1186,6 +1238,11 @@
       あらためてよろしくな<end_line>
       <partner>！<end_line>
     </sjis>
+    <ascii>
+    So! I'll say it once again.<end_line>
+    Let's work together!<end_line>
+    <partner>！<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1193,12 +1250,12 @@
       あらためてよろしく<end_line>
       <partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So! I'll say it once again.<end_line>
     Let's work together!<end_line>
     <partner>！<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1277,15 +1334,18 @@
     <sjis>
       <three_dots>ってどうしたんだよ？<end_line>
     </sjis>
+    <ascii>
+      <three_dots>Hey, what's the matter?<end_line>
+    </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>ってどうしたの？<end_line>
     </sjis>
-  </female>
     <ascii>
       <three_dots>Hey, what's the matter?<end_line>
     </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1313,6 +1373,11 @@
       なんだよ<end_line>
       むずかしい年頃なのか？<end_line>
     </sjis>
+    <ascii>
+    Hmph<three_dots><end_line>
+    What's with him?<end_line>
+    Maybe he's at a rebellious age?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1320,12 +1385,12 @@
       なによ<end_line>
       むずかしい年頃なのかな？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hmph<three_dots><end_line>
     What's with him?<end_line>
     Maybe he's at a rebellious age?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1365,6 +1430,11 @@
       まさか、オレの跡をつけてたのか？<end_line>
       どうして？<end_line>
     </sjis>
+    <ascii>
+    Eh<three_dots>?<end_line>
+    You were following me?<end_line>
+    Why?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1372,12 +1442,12 @@
       まさか、わたしの跡をつけてたの？<end_line>
       どうして？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh<three_dots>?<end_line>
     You were following me?<end_line>
     Why?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1402,6 +1472,11 @@
       オレがミューノになんかするとでも<end_line>
       思ってたのか！？<end_line>
     </sjis>
+    <ascii>
+    Protect Murno<three_dots>?<end_line>
+    You thought I was gonna<end_line>
+    do something to Murno!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1409,12 +1484,12 @@
       わたしがミューノになんかするとでも<end_line>
       思ってたの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Protect Murno<three_dots>?<end_line>
     You thought I was gonna<end_line>
     do something to Murno!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1471,6 +1546,11 @@
       今日はいろいろあったんで<end_line>
       アタマを冷やしてたんだよ！<end_line>
     </sjis>
+    <ascii>
+    I can! Absolutely!<end_line>
+    A lot happened today, so<end_line>
+    I was just cooling my head!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1478,12 +1558,12 @@
       今日はいろいろあったんで<end_line>
       アタマを冷やしてたの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I can! Absolutely!<end_line>
     A lot happened today, so<end_line>
     I was just cooling my head!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1568,6 +1648,11 @@
       せっかくパートナーになったんだから<end_line>
       もっと仲良くしようぜ<end_line>
     </sjis>
+    <ascii>
+    Hey, what's with that!<end_line>
+    We finally became partners, so<end_line>
+    so let's get along better!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1575,12 +1660,12 @@
       せっかくパートナーになったんだから<end_line>
       もっと仲良くしようよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, what's with that!<end_line>
     We finally became partners, so<end_line>
     so let's get along better!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1607,6 +1692,11 @@
       大切なことなんだしさ<end_line>
       な<end_line>
     </sjis>
+    <ascii>
+    It's also important for<end_line>
+    making good weapons!<end_line>
+    Right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1614,12 +1704,12 @@
       大切なことなんだし<end_line>
       ね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's also important for<end_line>
     making good weapons!<end_line>
     Right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1646,6 +1736,11 @@
       これからよろしくな<end_line>
       <partner>！<end_line>
     </sjis>
+    <ascii>
+    Then, I'll say it again!<end_line>
+    Let's work together from now on,<end_line>
+    <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1653,12 +1748,12 @@
       これからよろしくね<end_line>
       <partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Then, I'll say it again!<end_line>
     Let's work together from now on,<end_line>
     <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1729,15 +1824,18 @@
     <sjis>
       <three_dots>ってどうしたんだよ？<end_line>
     </sjis>
+    <ascii>
+    <three_dots>Hey, what's the matter?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>ってどうしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots>Hey, what's the matter?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1763,15 +1861,19 @@
       あ<three_dots><end_line>
       そんなにはずかしいことか？<end_line>
     </sjis>
+    <ascii>
+    Ah<three_dots><end_line>
+    Is it really that embarassing?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ<three_dots><end_line>
       そんなにはずかしいこと？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah<three_dots><end_line>
     Is it really that embarassing?<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 00/035_24948364_17cae8c.xml
+++ b/Day 00/035_24948364_17cae8c.xml
@@ -48,6 +48,11 @@
       オレは今日はいろいろあったから<end_line>
       ここでアタマ冷やしてたんだけど<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah, me?<three_dots><end_line>
+    Well, a lot happened today,<end_line>
+    so I was just cooling my head<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -55,12 +60,12 @@
       わたしは今日はいろいろあったから<end_line>
       ここでアタマ冷やしてたんだけど<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, me?<three_dots><end_line>
     Well, a lot happened today,<end_line>
     so I was just cooling my head<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 00/036_24954300_17cc5bc.xml
+++ b/Day 00/036_24954300_17cc5bc.xml
@@ -311,17 +311,21 @@
       そうだね<end_line>
       オレ、がんばるよ！<end_line>
     </sjis>
+    <ascii>
+    That's right!<end_line>
+    I'll do my best!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そうだね<end_line>
       わたし、がんばるよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's right!<end_line>
     I'll do my best!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -372,6 +376,11 @@
       オレも<partner>を信頼する<end_line>
       <three_dots>ってことだよな<end_line>
     </sjis>
+    <ascii>
+    Trusting each other means that<end_line>
+    I need to trust <partner>, too.<end_line>
+    <three_dots>That's how it is, huh.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -379,11 +388,11 @@
       わたしも<partner>を信頼する<end_line>
       <three_dots>ってことだよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Trusting each other means that<end_line>
     I need to trust <partner>, too.<end_line>
     <three_dots>That's how it is, huh.<end_line>
   </ascii>
+  </female>
 </dialogue>
 

--- a/Day 01/000_24956700_17ccf1c.xml
+++ b/Day 01/000_24956700_17ccf1c.xml
@@ -32,17 +32,21 @@
       おそいって<end_line>
       さっき行ったばっかだろ？<end_line>
     </sjis>
+    <ascii>
+    Late?<end_line>
+    Didn't they leave just a second ago?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       おそいって<end_line>
       さっき行ったばっかじゃない？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Late?<end_line>
     Didn't they leave just a second ago?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -386,6 +390,11 @@
       ごめんごめん<end_line>
       泣くなよ～！<end_line>
     </sjis>
+    <ascii>
+    Uwah!<end_line>
+    Sorry, sorry.<end_line>
+    Don't cry~!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -393,12 +402,12 @@
       ごめんごめん<end_line>
       泣かないでよ～！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uwah!<end_line>
     Sorry, sorry.<end_line>
     Don't cry~!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -646,6 +655,11 @@
       じゃあなんか<end_line>
       おめかしでもすりゃいいだろ<end_line>
     </sjis>
+    <ascii>
+    I said I was sorry!<end_line>
+    Then, how about dressing up<end_line>
+    in something fancy?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -653,12 +667,12 @@
       じゃあなんかおめかしでも<end_line>
       すればいいじゃない<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I said I was sorry!<end_line>
     Then, how about dressing up<end_line>
     in something fancy?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -686,17 +700,21 @@
       え～っと<end_line>
       そうだな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Umm~<end_line>
+    Let's see<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え～っと<end_line>
       そうね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Umm~<end_line>
     Let's see<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -796,15 +814,18 @@
     <sjis>
       悪かったな<end_line>
     </sjis>
+    <ascii>
+    Well, sorry.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       悪かったわね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, sorry.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -1012,6 +1033,11 @@
       お前、見た目はこわくないからさ<end_line>
       何も言われないよ<end_line>
     </sjis>
+    <ascii>
+    It'll be fine.<end_line>
+    You don't look scary,<end_line>
+    the Chief won't have any complaints.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1019,12 +1045,12 @@
       あなた、見た目はこわくないから<end_line>
       何も言われないよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It'll be fine.<end_line>
     You don't look scary,<end_line>
     the Chief won't have any complaints.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1050,16 +1076,19 @@
       なんで怒るんだよ<end_line>
       こわい方がいいのかよ？<end_line>
     </sjis>
+    <ascii>
+    What are you getting angry for?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なんで怒るのよ<end_line>
       こわい方がいいの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What are you getting angry for?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1086,6 +1115,11 @@
       そんなにこわく見せたいんなら<end_line>
       へんな格好でもすりゃいいだろ？<end_line>
     </sjis>
+    <ascii>
+    Well, fine!<end_line>
+    If you wanna stand out so much,<end_line>
+    just wear something weird.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1093,12 +1127,12 @@
       そんなにこわく見せたいんなら<end_line>
       へんな格好でもすりゃいいでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, fine!<end_line>
     If you wanna stand out so much,<end_line>
     just wear something weird.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1213,6 +1247,11 @@
       どこいくんだよ<end_line>
       ミューノのところか<three_dots><end_line>
     </sjis>
+    <ascii>
+    Hey, wait a minute!<end_line>
+    Where are you going?!<end_line>
+    <three_dots>Murno's room, huh?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1220,12 +1259,12 @@
       どこいくの？<end_line>
       ミューノのところ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, wait a minute!<end_line>
     Where are you going?!<end_line>
     <three_dots>Murno's room, huh?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <player gender="male">
@@ -1343,17 +1382,21 @@
       ちゃんとした格好って<three_dots><end_line>
       別にそのままで大丈夫だろ？<end_line>
     </sjis>
+    <ascii>
+    In order<three_dots>?<end_line>
+    You look fine, what's the problem?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちゃんとした格好って<three_dots><end_line>
       別にそのままでいいんじゃないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     In order<three_dots>?<end_line>
     You look fine, what's the problem?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 01/001_24960652_17cde8c.xml
+++ b/Day 01/001_24960652_17cde8c.xml
@@ -110,15 +110,18 @@
     <sjis>
       オレは<three_dots><end_line>
     </sjis>
+    <ascii>
+    I<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしは<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <choice>
   <info box="left">
@@ -148,17 +151,21 @@
       みんな帰ってこないし<end_line>
       なにやってンのかなって<three_dots><end_line>
     </sjis>
+    <ascii>
+    You were taking a while, so I was<end_line>
+    wondering what you were doing<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       みんな帰ってこないし<end_line>
       なにやってるのかなって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You were taking a while, so I was<end_line>
     wondering what you were doing<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -212,17 +219,21 @@
       な、なんだよ！<end_line>
       オレは別に<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    W-What?!<end_line>
+    I wasn't<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な、なによ！<end_line>
       わたしは別に<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     W-What?!<end_line>
     I wasn't<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -378,7 +389,7 @@
   <ascii>
     Uwah~<end_line>
     This is too real~<end_line>
-  </ascii> 
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 01/002_24962924_17ce76c.xml
+++ b/Day 01/002_24962924_17ce76c.xml
@@ -68,17 +68,21 @@
       よし、やってみよう<end_line>
       たのむぜ、<partner><end_line>
     </sjis>
+    <ascii>
+    Alright, let's do this.<end_line>
+    I'm counting on you, <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よし、やってみよう<end_line>
       たのむよ、<partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright, let's do this.<end_line>
     I'm counting on you, <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 01/004_24965052_17cefbc.xml
+++ b/Day 01/004_24965052_17cefbc.xml
@@ -228,17 +228,21 @@
       なんだよ<three_dots>もう<three_dots>！<end_line>
       はりあいのないヤツだな！<end_line>
     </sjis>
+    <ascii>
+    Oh, c'mon<three_dots>!<end_line>
+    You don't get excited for anything!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ<three_dots>もう<three_dots>！<end_line>
       はりあいがないなぁ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, c'mon<three_dots>!<end_line>
     You don't get excited for anything!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -459,6 +463,11 @@
       ハンマーこわがってたのにな<end_line>
       よくがんばったよ<end_line>
     </sjis>
+    <ascii>
+    You were so afraid of<end_line>
+    the hammer yesterday, but you<end_line>
+    worked really hard to overcome it.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -466,12 +475,12 @@
       ハンマーこわがってたのにね<end_line>
       よくがんばったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You were so afraid of<end_line>
     the hammer yesterday, but you<end_line>
     worked really hard to overcome it.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -498,6 +507,11 @@
       いいがかりって<three_dots><end_line>
       昨日はキャーキャー言ってただろ<end_line>
     </sjis>
+    <ascii>
+    Oh, is that true?<end_line>
+    Weren't you screaming<end_line>
+    your head off just yesterday?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -505,12 +519,12 @@
       昨日はキャーキャー<end_line>
       言ってたじゃない<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, is that true?<end_line>
     Weren't you screaming<end_line>
     your head off just yesterday?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -799,15 +813,18 @@
     <sjis>
       オレも！？<end_line>
     </sjis>
+    <ascii>
+    Me too!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしも！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Me too!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -963,15 +980,18 @@
     <sjis>
       オレも！？<end_line>
     </sjis>
+    <ascii>
+    Me too!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしも！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Me too!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -1135,15 +1155,18 @@
     <sjis>
       オレも！？<end_line>
     </sjis>
+    <ascii>
+    Me too!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしも！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Me too!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1295,15 +1318,18 @@
     <sjis>
       オレも！？<end_line>
     </sjis>
+    <ascii>
+      Me too!?<end_line>
+    </ascii>
   </male>
   <female>
     <sjis>
       わたしも！？<end_line>
     </sjis>
-  </female>
     <ascii>
       Me too!?<end_line>
     </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 01/005_24968700_17cfdfc.xml
+++ b/Day 01/005_24968700_17cfdfc.xml
@@ -179,14 +179,17 @@
     <sjis>
       なんだよ！？<end_line>
     </sjis>
+    <ascii>
+    What's going on!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's going on!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 

--- a/Day 01/006_24969852_17d027c.xml
+++ b/Day 01/006_24969852_17d027c.xml
@@ -1,37 +1,50 @@
-<dialogue>
+<dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			入るぞ<end_line>
 			ミューノ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Murno,<end_line>
+    I'm coming in<three_dots><end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			入るよ<end_line>
 			ミューノ<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>    Murno,<end_line>
+    <ascii>
+    Murno,<end_line>
     I'm coming in<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノ！？<end_line>
 			どうしたんだ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Murno!?<end_line>
+    Are you okay?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			ミューノ！？<end_line>
 			どうしたの？<end_line>
 		</sjis>
-	</female>  <ascii>    Murno!?<end_line>    Are you okay?<end_line>  </ascii>
+    <ascii>
+    Murno!?<end_line>
+    Are you okay?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -41,7 +54,7 @@
 		大丈夫<three_dots><end_line>
 		ちょっと、クラっとしただけで<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'm fine<three_dots><end_line>
 		I'm just a little dizzy.<end_line>
 	</ascii>
@@ -55,7 +68,7 @@
 		みゅーの様ノ体温ガ　異常デス<end_line>
 		普段ヨリ　高クナッテイマス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Lady Murno's Temperature: Abnormal.<end_line>
 		She Is Overheating.<end_line>
 	</ascii>
@@ -69,7 +82,7 @@
 		え～っと<end_line>
 		ようするに<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Uhh~<end_line>
 		So in other words<three_dots><end_line>
 	</ascii>
@@ -82,7 +95,7 @@
 	<sjis>
 		熱があるのね<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I must have a fever<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -95,7 +108,7 @@
 		どうやらミューノは<three_dots><end_line>
 		少し熱があるみたいじゃな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Murno<three_dots><end_line>
 		She must have a fever<three_dots><end_line>
 	</ascii>
@@ -109,7 +122,7 @@
 		ちっ<three_dots><end_line>
 		熱があるじゃないか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Tch<three_dots><end_line>
 		She's got a fever<three_dots><end_line>
 	</ascii>
@@ -123,7 +136,7 @@
 		どうしましょう<end_line>
 		ミューノ様、すごい熱です！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What should we do!?<end_line>
 		Murno has a terrible fever!<end_line>
 	</ascii>
@@ -137,7 +150,7 @@
 		じゃあ、寝てなくちゃ！<end_line>
 		親方呼んでくるよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hm<three_dots><end_line>
 		Then, she should be in bed!<end_line>
 		I'll go get Master!<end_line>
@@ -151,7 +164,7 @@
 		ホントだ<end_line>
 		熱があるね<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You're right.<end_line>
 		It's definitely a fever.<end_line>
 	</ascii>
@@ -166,7 +179,7 @@
 		私ノ冷却水デ<end_line>
 		体ヲ冷ヤシマスカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We Must Perform Maintenance.<end_line>
 		I Will Reduce Her Body Temeprature<end_line>
 		With My Cooling Fluid.<end_line>
@@ -181,7 +194,7 @@
 		何言ってンだい！<end_line>
 		もっと悪くしたいのかい？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Stop right there!<end_line>
 		Are you trying to make it worse!?<end_line>
 	</ascii>
@@ -195,7 +208,7 @@
 		イイエ<three_dots><end_line>
 		デハ　ドウスレバ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I Am Not<three_dots><end_line>
 		Then What Action Should We-<end_line>
 	</ascii>
@@ -210,7 +223,7 @@
 		アンタに出番はないね<end_line>
 		おとなしくしてな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Right now,<end_line>
 		there's nothing you can do.<end_line>
 		Just stay quiet.<end_line>
@@ -224,7 +237,7 @@
 	<sjis>
 		了解デス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Roger.<end_line>
 	</ascii>
 </dialogue>
@@ -236,8 +249,9 @@
 		でも<end_line>
 		急に熱だなんて<three_dots><end_line>
 	</sjis>
-	<ascii>
-		But how could she develop<end_line>		a fever so suddenly<three_dots>?<end_line>
+  <ascii>
+		But how could she develop<end_line>
+		a fever so suddenly<three_dots>?<end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -250,7 +264,11 @@
 		相当ムリしてきたみたいだからね<three_dots><end_line>
 		安心したら一気にきたんだろうね<end_line>
 	</sjis>
-	<ascii>    She's been pushing herself so hard<three_dots><end_line>    All of the pent-up stress<end_line>    must have hit her all at once.<end_line>	</ascii>
+  <ascii>
+    She's been pushing herself so hard<three_dots><end_line>
+    All of the pent-up stress<end_line>
+    must have hit her all at once.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -261,7 +279,7 @@
 		ゆっくり休むのが一番だよ<end_line>
 		今はそっとしておいてやりな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It'll be best if she just rests.<end_line>
 		Leave her alone for now.<end_line>
 	</ascii>
@@ -275,7 +293,7 @@
 		そうだね<end_line>
 		わかった<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Okay.<end_line>
 	</ascii>
 </dialogue>
@@ -289,9 +307,10 @@
 		アンタは<partner>だけでも<end_line>
 		村長に紹介しといで<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Alright, leave this to me.<end_line>
-		You should go introduce <partner><end_line>		to the Chief.<end_line>
+		You should go introduce <partner><end_line>
+		to the Chief.<end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -303,9 +322,10 @@
 		近ごろはぐれもふえてきたし<end_line>
 		まちがわれないようにしなきゃね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There've been more strays lately,<end_line>
-		so we need to make sure<end_line>		<partner> isn't mistaken for one.<end_line>
+		so we need to make sure<end_line>
+		<partner> isn't mistaken for one.<end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -317,7 +337,8 @@
 		でも、紹介って<end_line>
 		なんて言ったらいいんだろ？<end_line>
 	</sjis>
-	<ascii>		Introduce, you say<three_dots><end_line>
+  <ascii>
+		Introduce, you say<three_dots><end_line>
 		What should I even say?<end_line>
 	</ascii>
 </dialogue>
@@ -331,7 +352,11 @@
 		アタシに召喚石をもらったとか<end_line>
 		そんな感じでいいんじゃない？<end_line>
 	</sjis>
-  <ascii>		Say something like,<end_line>	    "Master gave me a Summon Stone.<end_line>		This is my new partner."<end_line>	</ascii>
+  <ascii>
+		Say something like,<end_line>
+	    "Master gave me a Summon Stone.<end_line>
+		This is my new partner."<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -341,7 +366,7 @@
 	<sjis>
 		そんな感じでって<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That'll totally work<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -354,7 +379,7 @@
 		ソレハ真実ト　異ナリマス<end_line>
 		私ハみゅーの様ノ　召喚獣ダッタ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That Differs From The Truth.<end_line>
 		I Am Lady Murno's Summon Beast<three_dots><end_line>
 	</ascii>
@@ -368,8 +393,9 @@
 		本当のことを伝えてもいいのかい？<end_line>
 		ミューノはワケありなんだろ？<end_line>
 	</sjis>
-	<ascii>
-    Or would you rather tell the truth?<end_line>    Murno has her own issues, right?<end_line>
+  <ascii>
+    Or would you rather tell the truth?<end_line>
+    Murno has her own issues, right?<end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -380,7 +406,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -390,44 +416,54 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="vee" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだね<end_line>
 			わかったよ、親方<end_line>
 			行こう、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-			わかった、親方<end_line>
-			行こう、<partner><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You're right.<end_line>
     I understand, Master.<end_line>
     Let's get going, <partner><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+			わかった、親方<end_line>
+			行こう、<partner><end_line>
+		</sjis>
+    <ascii>
+    You're right.<end_line>
+    I understand, Master.<end_line>
+    Let's get going, <partner><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			<partner>？<end_line>
 			何してんだよ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    <partner>?<end_line>
+    Why aren't you saying anything?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			<partner>？<end_line>
 			何してんの？<end_line>
 		</sjis>
-	</female>
-  <ascii>
-    <partner>?<end_line>    Why aren't you saying anything?<end_line>
+    <ascii>
+    <partner>?<end_line>
+    Why aren't you saying anything?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -437,7 +473,7 @@
 		みゅーの様ノ熱ヲ　下ゲルタメニ<end_line>
 		オトナシクシテイマス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I Am Being Quiet<end_line>
 		To Lower Lady Murno's Fever.<end_line>
 	</ascii>
@@ -450,7 +486,7 @@
 	<sjis>
 		アンタ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -462,7 +498,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -476,7 +512,7 @@
 		元気にしたいのは<end_line>
 		よ～くわかったよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I get that you<end_line>
 		reaaallly want Murno<end_line>
 		to feel better.<end_line>
@@ -490,7 +526,7 @@
 	<sjis>
 		でもね、ジャマ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But you're being annoying!<end_line>
 	</ascii>
 </bigtext>
@@ -503,7 +539,10 @@
 		<player_nickname>といっしょに<end_line>
 		早く村長にあいさつしてきな！<end_line>
 	</sjis>
-	<ascii>    Come on, get out of here!<end_line>    Go meet the Chief!<end_line>	</ascii>
+  <ascii>
+    Come on, get out of here!<end_line>
+    Go meet the Chief!<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -514,7 +553,7 @@
 		お、親方！？<end_line>
 		ちょっとしずかに！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		M-Master!?<end_line>
 		You're too loud!<end_line>
 	</ascii>
@@ -526,7 +565,7 @@
 	<sjis>
 		うう<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hn<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -537,7 +576,7 @@
 	<sjis>
 		あ、ごめん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah. Sorry.<end_line>
 	</ascii>
 </dialogue>
@@ -549,7 +588,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -562,7 +601,7 @@
 		なんだい<end_line>
 		その目は<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey, what's up<end_line>
 		with your eyes?<end_line>
 	</ascii>
@@ -575,7 +614,7 @@
 	<sjis>
 		かめらデス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		They Are Cameras.<end_line>
 	</ascii>
 </dialogue>
@@ -587,7 +626,7 @@
 	<sjis>
 		そうじゃなくて<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's not what-<three_dots>!<end_line>
 	</ascii>
 </dialogue>
@@ -600,7 +639,7 @@
 		お、親方！？<end_line>
 		うるさいって<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		M-Master!?<end_line>
 		Keep it down<three_dots>!<end_line>
 	</ascii>
@@ -613,7 +652,7 @@
 	<sjis>
 		あ、ごめん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ahem~<end_line>
 	</ascii>
 </dialogue>
@@ -625,7 +664,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -639,7 +678,11 @@
 		アンタ、ジャマだから<end_line>
 		村長のところに行ってくれないか<end_line>
 	</sjis>
-	<ascii>		<three_dots>Anyway,<end_line>		you two are in the way.<end_line>		Just go and see the Chief already.<end_line>	</ascii>
+  <ascii>
+		<three_dots>Anyway,<end_line>
+		you two are in the way.<end_line>
+		Just go and see the Chief already.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -650,7 +693,7 @@
 		そうすればミューノもじき<end_line>
 		良くなるから、ね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Murno'll feel better in no time.<end_line>
 	</ascii>
 </dialogue>
@@ -664,7 +707,7 @@
 		出カケテイタ方ガ　イイ<end_line>
 		トイウコトデスカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So You Are Saying<end_line>
 		It Is Better To Go Out<end_line>
 		Than Stay Here?<end_line>
@@ -679,7 +722,12 @@
 		村長へのあいさつ以外にも<end_line>
 		アンタたちには修行があるだろ<end_line>
 		鍛冶師ってのはヒマじゃないよ<end_line>
-	</sjis>	<ascii>		Even if you didn't need to see him,<end_line>		I'd make you train instead.<end_line>		Craftknights are quite busy.<end_line>	</ascii>
+	</sjis>
+  <ascii>
+		Even if you didn't need to see him,<end_line>
+		I'd make you train instead.<end_line>
+		Craftknights are quite busy.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -687,20 +735,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="vee" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			うん、わかったよ、親方<end_line>
 			とりあえず村長のところに行こう<end_line>
 			な、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Alright, Master.<end_line>
+    We'll be on our way.<end_line>
+    Okay <partner>?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			うん、わかったよ、親方<end_line>
 			とりあえず村長のところに行こう<end_line>
 			ね、<partner><end_line>
 		</sjis>
-	</female>
-  <ascii>    Alright, Master.<end_line>    We'll be on our way.<end_line>    Okay <partner>?<end_line>  </ascii>
+    <ascii>
+    Alright, Master.<end_line>
+    We'll be on our way.<end_line>
+    Okay <partner>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -711,7 +768,7 @@
 		<three_dots><end_line>
 		了解デス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 		Roger.<end_line>
 	</ascii>
@@ -726,7 +783,7 @@
 		熱冷ましはないのか？<end_line>
 		ワガハイに何か、できることは<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Then we must cure her quickly.<end_line>
 		Do we have any medicine?<end_line>
 		Is there anything I can do<three_dots>?<end_line>
@@ -741,7 +798,7 @@
 		今アンタがすべきことは<end_line>
 		おとなしくすることだよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What you should do,<end_line>
 		is stay quiet.<end_line>
 	</ascii>
@@ -755,7 +812,7 @@
 		なんじゃとおぬし！<end_line>
 		ワガハイに向かって<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Excuse me!?<end_line>
 		How dare you<three_dots><end_line>
 	</ascii>
@@ -770,7 +827,7 @@
 		今のミューノに必要なのは<end_line>
 		休むことだよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I told you to keep it down.<end_line>
 		What Murno need right now is rest.<end_line>
 	</ascii>
@@ -784,7 +841,7 @@
 		そうなのか<three_dots><end_line>
 		すまぬ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hm, is that so<three_dots><end_line>
 		My apologies<three_dots><end_line>
 	</ascii>
@@ -797,7 +854,10 @@
 		でも<end_line>
 		急に熱だなんて<three_dots><end_line>
 	</sjis>
-	<ascii>		But how could she develop<end_line>		a fever so suddenly<three_dots>?<end_line>	</ascii>
+  <ascii>
+		But how could she develop<end_line>
+		a fever so suddenly<three_dots>?<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -809,7 +869,11 @@
 		相当ムリしてきたみたいだからね<three_dots><end_line>
 		安心したら一気にきたんだろうね<end_line>
 	</sjis>
-  <ascii>    She's been pushing herself so hard<three_dots><end_line>    All of the pent-up stress<end_line>    must have hit her all at once.<end_line>  </ascii>
+  <ascii>
+    She's been pushing herself so hard<three_dots><end_line>
+    All of the pent-up stress<end_line>
+    must have hit her all at once.<end_line>
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -820,7 +884,7 @@
 		ゆっくり休むのが一番だよ<end_line>
 		今はそっとしておいてやりな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It'll be best if she just rests.<end_line>
 		Leave her alone for now.<end_line>
 	</ascii>
@@ -834,7 +898,9 @@
 		そうだね<end_line>
 		わかった<end_line>
 	</sjis>
-	<ascii>		Okay.<end_line>	</ascii>
+  <ascii>
+		Okay.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -846,7 +912,11 @@
 		アンタは<partner>だけでも<end_line>
 		村長に紹介しといで<end_line>
 	</sjis>
-	<ascii>		Alright, leave this to me.<end_line>		You should go introduce <partner><end_line>		to the Chief.<end_line>	</ascii>
+  <ascii>
+		Alright, leave this to me.<end_line>
+		You should go introduce <partner><end_line>
+		to the Chief.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -857,7 +927,11 @@
 		近ごろはぐれもふえてきたし<end_line>
 		まちがわれないようにしなきゃね<end_line>
 	</sjis>
-	<ascii>		There've been more strays lately,<end_line>		so we need to make sure<end_line>		<partner> isn't mistaken for one.<end_line>	</ascii>
+  <ascii>
+		There've been more strays lately,<end_line>
+		so we need to make sure<end_line>
+		<partner> isn't mistaken for one.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -868,7 +942,9 @@
 		でも、紹介って<end_line>
 		なんて言ったらいいんだろ？<end_line>
 	</sjis>
-	<ascii>		What should I even say?<end_line>	</ascii>
+  <ascii>
+		What should I even say?<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -880,7 +956,11 @@
 		アタシに召喚石をもらったとか<end_line>
 		そんな感じでいいんじゃない？<end_line>
 	</sjis>
-  <ascii>		Say something like,<end_line>		"Master gave me a Summon Stone.<end_line>		This is my new partner."<end_line>	</ascii>
+  <ascii>
+		Say something like,<end_line>
+		"Master gave me a Summon Stone.<end_line>
+		This is my new partner."<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -890,7 +970,9 @@
 	<sjis>
 		そんな感じでって<three_dots><end_line>
 	</sjis>
-	<ascii>		That'll totally work<three_dots><end_line>	</ascii>
+  <ascii>
+		That'll totally work<three_dots><end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -901,7 +983,9 @@
 		しかし、本来のワガハイは<end_line>
 		ミューノの召喚獣で<three_dots><end_line>
 	</sjis>
-	<ascii>    But the truth is,<end_line>    I am Murno's Summon Beast<three_dots><end_line>
+  <ascii>
+    But the truth is,<end_line>
+    I am Murno's Summon Beast<three_dots><end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -913,8 +997,9 @@
 		本当のことを伝えてもいいのかい？<end_line>
 		ミューノはワケありなんだろ？<end_line>
 	</sjis>
-	<ascii>
-    Or would you rather tell the truth?<end_line>    Murno has her own issues, right?<end_line>
+  <ascii>
+    Or would you rather tell the truth?<end_line>
+    Murno has her own issues, right?<end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -925,7 +1010,7 @@
 	<sjis>
 		たしかに<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That is true<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -935,20 +1020,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="vee" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだね<end_line>
 			わかったよ、親方<end_line>
 			行こう、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    You're right.<end_line>
+    I understand, Master.<end_line>
+    Let's get going, <partner><end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<end_line>
 			わかった、親方<end_line>
 			行こう、<partner><end_line>
 		</sjis>
-	</female>
-  <ascii>    You're right.<end_line>    I understand, Master.<end_line>    Let's get going, <partner><end_line>  </ascii>
+    <ascii>
+    You're right.<end_line>
+    I understand, Master.<end_line>
+    Let's get going, <partner><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -959,7 +1053,7 @@
 		体の調子の悪いミューノを<end_line>
 		ひとりにしておくわけには<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		However<three_dots><end_line>
 		I cannot leave Murno alone<end_line>
 		when she is in such bad shape<three_dots><end_line>
@@ -974,7 +1068,7 @@
 		安心しな<end_line>
 		ちゃんとアタシがついてるからさ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Relax.<end_line>
 		I'll be here for her.<end_line>
 	</ascii>
@@ -987,7 +1081,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -999,7 +1093,7 @@
 	<sjis>
 		なんだい、その目は？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What's with that look?<end_line>
 	</ascii>
 </dialogue>
@@ -1011,7 +1105,7 @@
 	<sjis>
 		不安じゃ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'm even more worried<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1023,7 +1117,7 @@
 	<sjis>
 		なんだって！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Excuse me!?<end_line>
 	</ascii>
 </bigtext>
@@ -1036,7 +1130,10 @@
 		お、親方！？<end_line>
 		ちょっとしずかに！<end_line>
 	</sjis>
-	<ascii>		M-Master!?<end_line>		You're too loud!<end_line>	</ascii>
+  <ascii>
+		M-Master!?<end_line>
+		You're too loud!<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1045,7 +1142,7 @@
 	<sjis>
 		うう<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hn<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1056,7 +1153,7 @@
 	<sjis>
 		あ、ごめん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah. Sorry.<end_line>
 	</ascii>
 </dialogue>
@@ -1068,7 +1165,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1082,8 +1179,9 @@
 		さっきはアンタが変なこというから<end_line>
 		ついカッとなっちまって<three_dots><end_line>
 	</sjis>
-	<ascii>
-		Stop looking at me like that.<end_line>		This is all your fault, you know<three_dots><end_line>
+  <ascii>
+		Stop looking at me like that.<end_line>
+		This is all your fault, you know<three_dots><end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -1095,7 +1193,7 @@
 		ワガハイ、なにも変なことなど<end_line>
 		言っておらんがの？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh, I don't recall<end_line>
 		saying anything odd at all.<end_line>
 	</ascii>
@@ -1108,7 +1206,7 @@
 	<sjis>
 		なんだって！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh!?<end_line>
 	</ascii>
 </bigtext>
@@ -1120,7 +1218,7 @@
 	<sjis>
 		だから親方<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Master<three_dots>!<end_line>
 	</ascii>
 </dialogue>
@@ -1134,10 +1232,11 @@
 		アンタ、ジャマだから<end_line>
 		村長のところに行ってくれないか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Anyway,<end_line>
 		you two are in the way.<end_line>
-		Just go and see the Chief already.<end_line>	</ascii>
+		Just go and see the Chief already.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1148,7 +1247,7 @@
 		そうすればミューノもじき<end_line>
 		良くなるから、ね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Murno'll feel better in no time.<end_line>
 	</ascii>
 </dialogue>
@@ -1160,7 +1259,8 @@
 	<sjis>
 		ジャマじゃと<three_dots><end_line>
 	</sjis>
-	<ascii>		In the way<three_dots><end_line>
+  <ascii>
+		In the way<three_dots><end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -1172,7 +1272,12 @@
 		村長へのあいさつ以外にも<end_line>
 		アンタたちには修行があるだろ<end_line>
 		鍛冶師ってのはヒマじゃないよ<end_line>
-	</sjis>	<ascii>		Even if you didn't need to see him,<end_line>		I'd make you train instead.<end_line>		Craftknights are quite busy.<end_line>	</ascii>
+	</sjis>
+  <ascii>
+		Even if you didn't need to see him,<end_line>
+		I'd make you train instead.<end_line>
+		Craftknights are quite busy.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1180,24 +1285,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="vee" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			うん、わかったよ、親方<end_line>
 			とりあえず村長のところに行こう<end_line>
 			な、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん、わかったよ、親方<end_line>
-			とりあえず村長のところに行こう<end_line>
-			ね、<partner><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright, Master.<end_line>
     We'll be on our way.<end_line>
     Okay <partner>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん、わかったよ、親方<end_line>
+			とりあえず村長のところに行こう<end_line>
+			ね、<partner><end_line>
+		</sjis>
+    <ascii>
+    Alright, Master.<end_line>
+    We'll be on our way.<end_line>
+    Okay <partner>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1207,7 +1317,7 @@
 	<sjis>
 		わかった<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Alright.<end_line>
 	</ascii>
 </dialogue>
@@ -1219,7 +1329,7 @@
 	<sjis>
 		なんとかできるのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Is there anything we can do?<end_line>
 	</ascii>
 </dialogue>
@@ -1233,7 +1343,7 @@
 		おとなしく寝てれば<end_line>
 		よくなるよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No need to worry,<end_line>
 		let her get some rest and<end_line>
 		she should get better.<end_line>
@@ -1248,7 +1358,7 @@
 		なんだと<three_dots><end_line>
 		誰が心配など<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What<three_dots><end_line>
 		I didn't say I was worried<three_dots>!<end_line>
 	</ascii>
@@ -1263,7 +1373,7 @@
 		おとなしく寝かせてやれって<end_line>
 		言ってるだろ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Keep it down.<end_line>
 		You'll wake her up.<end_line>
 	</ascii>
@@ -1276,7 +1386,7 @@
 	<sjis>
 		ちっ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Tch<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1288,7 +1398,10 @@
 		でも<end_line>
 		急に熱だなんて<three_dots><end_line>
 	</sjis>
-  <ascii>    But how could she develop<end_line>    a fever so suddenly<three_dots>?<end_line>  </ascii>
+  <ascii>
+    But how could she develop<end_line>
+    a fever so suddenly<three_dots>?<end_line>
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1300,7 +1413,11 @@
 		相当ムリしてきたみたいだからね<three_dots><end_line>
 		安心したら一気にきたんだろうね<end_line>
 	</sjis>
-  <ascii>    She's been pushing herself so hard<three_dots><end_line>    All of the pent-up stress<end_line>    must have hit her all at once.<end_line>  </ascii>
+  <ascii>
+    She's been pushing herself so hard<three_dots><end_line>
+    All of the pent-up stress<end_line>
+    must have hit her all at once.<end_line>
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1311,7 +1428,10 @@
 		ということで、ココにいても<end_line>
 		アンタたちのやることはないよ<end_line>
 	</sjis>
-	<ascii>    There's nothing you two<end_line>    can do about it.<end_line>	</ascii>
+  <ascii>
+    There's nothing you two<end_line>
+    can do about it.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1322,7 +1442,7 @@
 		そっか<three_dots><end_line>
 		わかった<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I suppose so<three_dots><end_line>
 		Okay.<end_line>
 	</ascii>
@@ -1337,7 +1457,11 @@
 		アンタは<partner>だけでも<end_line>
 		村長に紹介しといで<end_line>
 	</sjis>
-  <ascii>		Alright, leave this to me.<end_line>		You should go introduce <partner><end_line>		to the Chief.<end_line>	</ascii>
+  <ascii>
+		Alright, leave this to me.<end_line>
+		You should go introduce <partner><end_line>
+		to the Chief.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1348,7 +1472,11 @@
 		近ごろはぐれもふえてきたし<end_line>
 		まちがわれないようにしなきゃね<end_line>
 	</sjis>
-	<ascii>		There've been more strays lately,<end_line>		so we need to make sure<end_line>		<partner> isn't mistaken for one.<end_line>	</ascii>
+  <ascii>
+		There've been more strays lately,<end_line>
+		so we need to make sure<end_line>
+		<partner> isn't mistaken for one.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1359,7 +1487,9 @@
 		でも、紹介って<end_line>
 		なんて言ったらいいんだろ？<end_line>
 	</sjis>
-  <ascii>		What should I even say?<end_line>	</ascii>
+  <ascii>
+		What should I even say?<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1371,7 +1501,11 @@
 		アタシに召喚石をもらったとか<end_line>
 		そんな感じでいいんじゃない？<end_line>
 	</sjis>
-  <ascii>		Say something like,<end_line>		"Master gave me a Summon Stone.<end_line>		This is my new partner."<end_line>	</ascii>
+  <ascii>
+		Say something like,<end_line>
+		"Master gave me a Summon Stone.<end_line>
+		This is my new partner."<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1381,7 +1515,9 @@
 	<sjis>
 		そんな感じでって<three_dots><end_line>
 	</sjis>
-	<ascii>		That'll totally work<three_dots><end_line>	</ascii>
+  <ascii>
+		That'll totally work<three_dots><end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1391,7 +1527,7 @@
 	<sjis>
 		コイツの相方か<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		This kid's partner, huh<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -1405,7 +1541,10 @@
 		いいのかい？<end_line>
 		ミューノはワケありなんだろ？<end_line>
 	</sjis>
-	<ascii>    Or would you rather tell the truth?<end_line>    Murno has her own issues, right?<end_line>	</ascii>
+  <ascii>
+    Or would you rather tell the truth?<end_line>
+    Murno has her own issues, right?<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1416,7 +1555,7 @@
 		ちっ<three_dots><end_line>
 		好きにしろ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hmph<three_dots><end_line>
 		Suit yourselves.<end_line>
 	</ascii>
@@ -1427,19 +1566,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="vee" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだね<end_line>
 			わかったよ、親方<end_line>
 			行こう、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    You're right.<end_line>
+    Alright, let's go,<end_line>
+    <partner>.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<end_line>
 			わかった、親方<end_line>
 			行こう、<partner><end_line>
 		</sjis>
-	</female>  <ascii>    You're right.<end_line>    Alright, let's go,<end_line>    <partner>.<end_line>  </ascii>
+    <ascii>
+    You're right.<end_line>
+    Alright, let's go,<end_line>
+    <partner>.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1450,8 +1599,9 @@
 		ミューノのメンドウは<end_line>
 		キサマひとりでみるつもりか<three_dots><end_line>
 	</sjis>
-	<ascii>
-		<three_dots><end_line>		Do you intend to take care<end_line>
+  <ascii>
+		<three_dots><end_line>
+		Do you intend to take care<end_line>
 		of her on your own<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -1464,7 +1614,7 @@
 		キサマじゃなくて、親方だろ？<end_line>
 		まったく、ちゃんとしなよ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Call me "Master", not "you".<end_line>
 		Seriously, show some respect<three_dots><end_line>
 	</ascii>
@@ -1479,7 +1629,9 @@
 		ひとりでも十分メンドウみられるよ<end_line>
 		安心して行ってきなって<end_line>
 	</sjis>
-	<ascii>    I'll be perfectly fine on my won.<end_line>    Hurry up and get out of here.<end_line>
+  <ascii>
+    I'll be perfectly fine on my won.<end_line>
+    Hurry up and get out of here.<end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -1490,7 +1642,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1502,7 +1654,7 @@
 	<sjis>
 		なんだい、その目は？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What's with the look?<end_line>
 	</ascii>
 </dialogue>
@@ -1514,7 +1666,7 @@
 	<sjis>
 		別に<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Nothing<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1528,8 +1680,10 @@
 		文句があるなら<end_line>
 		ハッキリ言いな！<end_line>
 	</sjis>
-	<ascii>
-		Huh<three_dots>?<end_line>		What, you got a problem!?<end_line>	</ascii>
+  <ascii>
+		Huh<three_dots>?<end_line>
+		What, you got a problem!?<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1540,7 +1694,10 @@
 		お、親方！？<end_line>
 		ちょっとしずかに！<end_line>
 	</sjis>
-  <ascii>		M-Master!?<end_line>		You're too loud!<end_line>	</ascii>
+  <ascii>
+		M-Master!?<end_line>
+		You're too loud!<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1549,7 +1706,7 @@
 	<sjis>
 		うう<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hn<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1560,7 +1717,9 @@
 	<sjis>
 		あ、ごめん<end_line>
 	</sjis>
-	<ascii>		Ah. Sorry.<end_line>	</ascii>
+  <ascii>
+		Ah. Sorry.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1570,7 +1729,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1584,7 +1743,10 @@
 		さっきはアンタが変なこというから<end_line>
 		ついカッとなっちまって<three_dots><end_line>
 	</sjis>
-	<ascii>		Stop looking at me like that.<end_line>		This is all your fault, you know<three_dots><end_line>	</ascii>
+  <ascii>
+		Stop looking at me like that.<end_line>
+		This is all your fault, you know<three_dots><end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1594,7 +1756,7 @@
 	<sjis>
 		私は何も言ってないが<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I didn't say anything<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1606,7 +1768,7 @@
 	<sjis>
 		なんだって！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh!?<end_line>
 	</ascii>
 </bigtext>
@@ -1618,7 +1780,9 @@
 	<sjis>
 		だから親方<three_dots>！<end_line>
 	</sjis>
-	<ascii>		Master<three_dots>!<end_line>	</ascii>
+  <ascii>
+		Master<three_dots>!<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1630,7 +1794,11 @@
 		アンタ、ジャマだから<end_line>
 		村長のところに行ってくれないか<end_line>
 	</sjis>
-	<ascii>		<three_dots>Anyway,<end_line>		you two are in the way.<end_line>		Just go and see the Chief already.<end_line>	</ascii>
+  <ascii>
+		<three_dots>Anyway,<end_line>
+		you two are in the way.<end_line>
+		Just go and see the Chief already.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1641,7 +1809,7 @@
 		そうすればミューノもじき<end_line>
 		良くなるから、ね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Murno'll feel better in no time.<end_line>
 	</ascii>
 </dialogue>
@@ -1653,7 +1821,7 @@
 	<sjis>
 		ジャマだと<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hmph<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1667,27 +1835,41 @@
 		アンタたちには修行があるだろ<end_line>
 		鍛冶師ってのはヒマじゃないよ<end_line>
 	</sjis>
-	<ascii>		Even if you didn't need to see him,<end_line>		I'd make you train instead.<end_line>		Craftknights are quite busy.<end_line>	</ascii></dialogue>
+  <ascii>
+		Even if you didn't need to see him,<end_line>
+		I'd make you train instead.<end_line>
+		Craftknights are quite busy.<end_line>
+	</ascii>
+</dialogue>
 <dialogue>
 	<partner name="killfith">
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="vee" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			うん、わかったよ、親方<end_line>
 			とりあえず村長のところに行こう<end_line>
 			な、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Alright, Master.<end_line>
+    We'll be on our way.<end_line>
+    Okay <partner>?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			うん、わかったよ、親方<end_line>
 			とりあえず村長のところに行こう<end_line>
 			ね、<partner><end_line>
 		</sjis>
-	</female>
-  <ascii>    Alright, Master.<end_line>    We'll be on our way.<end_line>    Okay <partner>?<end_line>  </ascii>
+    <ascii>
+    Alright, Master.<end_line>
+    We'll be on our way.<end_line>
+    Okay <partner>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1698,7 +1880,7 @@
 		ちっ<three_dots><end_line>
 		好きにしろ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah, yeah<three_dots><end_line>
 		Whatever<three_dots><end_line>
 	</ascii>
@@ -1712,7 +1894,7 @@
 		どうしましょう？<end_line>
 		はやくなんとかしないと<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What should we do!?<end_line>
 		We have to do something<three_dots>!<end_line>
 	</ascii>
@@ -1727,7 +1909,7 @@
 		私がミューノ様の体を<end_line>
 		あたためて<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh, that's right!<end_line>
 		I'll warm her up<end_line>
 		with my body<three_dots><end_line>
@@ -1741,7 +1923,7 @@
 	<sjis>
 		そんなことしなくていいから<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Y-You don't have to do that.<end_line>
 	</ascii>
 </dialogue>
@@ -1755,7 +1937,8 @@
 		ミューノ様を元気にすることが<end_line>
 		できるのですか？<end_line>
 	</sjis>
-	<ascii>		But what else can I do<end_line>
+  <ascii>
+		But what else can I do<end_line>
 		to make Lady Murno<end_line>
 		feel better?<end_line>
 	</ascii>
@@ -1769,7 +1952,7 @@
 		今のアンタにできることはひとつ<end_line>
 		おとなしくしてることだけだよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The only thing you can do<end_line>
 		now is stay quiet.<end_line>
 	</ascii>
@@ -1782,7 +1965,7 @@
 	<sjis>
 		そうなんですか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Is that so<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1794,7 +1977,10 @@
 		でも<end_line>
 		急に熱だなんて<three_dots><end_line>
 	</sjis>
-  <ascii>    But how could she develop<end_line>    a fever so suddenly<three_dots>?<end_line>  </ascii>
+  <ascii>
+    But how could she develop<end_line>
+    a fever so suddenly<three_dots>?<end_line>
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1806,7 +1992,11 @@
 		相当ムリしてきたみたいだからね<three_dots><end_line>
 		安心したら一気にきたんだろうね<end_line>
 	</sjis>
-  <ascii>    She's been pushing herself so hard<three_dots><end_line>    All of the pent-up stress<end_line>    must have hit her all at once.<end_line>  </ascii>
+  <ascii>
+    She's been pushing herself so hard<three_dots><end_line>
+    All of the pent-up stress<end_line>
+    must have hit her all at once.<end_line>
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1817,7 +2007,7 @@
 		ゆっくり休むのが一番だよ<end_line>
 		今はそっとしておいてやりな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It'll be best if she just rests.<end_line>
 		Leave her alone for now.<end_line>
 	</ascii>
@@ -1831,7 +2021,9 @@
 		そうだね<end_line>
 		わかった<end_line>
 	</sjis>
-  <ascii>		Okay.<end_line>	</ascii>
+  <ascii>
+		Okay.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1843,7 +2035,11 @@
 		アンタは<partner>だけでも<end_line>
 		村長に紹介しといで<end_line>
 	</sjis>
-  <ascii>		Alright, leave this to me.<end_line>		You should go introduce <partner><end_line>		to the Chief.<end_line>	</ascii>
+  <ascii>
+		Alright, leave this to me.<end_line>
+		You should go introduce <partner><end_line>
+		to the Chief.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1854,7 +2050,11 @@
 		近ごろはぐれもふえてきたし<end_line>
 		まちがわれないようにしなきゃね<end_line>
 	</sjis>
-  <ascii>		There've been more strays lately,<end_line>		so we need to make sure<end_line>		<partner> isn't mistaken for one.<end_line>	</ascii>
+  <ascii>
+		There've been more strays lately,<end_line>
+		so we need to make sure<end_line>
+		<partner> isn't mistaken for one.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1865,7 +2065,9 @@
 		でも、紹介って<end_line>
 		なんて言ったらいいんだろ？<end_line>
 	</sjis>
-  <ascii>		What should I even say?<end_line>	</ascii>
+  <ascii>
+		What should I even say?<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1877,7 +2079,11 @@
 		アタシに召喚石をもらったとか<end_line>
 		そんな感じでいいんじゃない？<end_line>
 	</sjis>
-  <ascii>		Say something like,<end_line>		"Master gave me a Summon Stone.<end_line>		This is my new partner."<end_line>	</ascii>
+  <ascii>
+		Say something like,<end_line>
+		"Master gave me a Summon Stone.<end_line>
+		This is my new partner."<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1887,7 +2093,9 @@
 	<sjis>
 		そんな感じでって<three_dots><end_line>
 	</sjis>
-	<ascii>		That'll totally work<three_dots><end_line>	</ascii>
+  <ascii>
+		That'll totally work<three_dots><end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1899,7 +2107,7 @@
 		私、本当は<end_line>
 		ミューノ様の召喚獣で<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But, that's not<three_dots><end_line>
 		I am really Lady Murno's partner<three_dots><end_line>
 	</ascii>
@@ -1914,7 +2122,10 @@
 		いいのかい？<end_line>
 		ミューノはワケありなんだろ？<end_line>
 	</sjis>
-	<ascii>    Or would you rather tell the truth?<end_line>    Murno has her own issues, right?<end_line>	</ascii>
+  <ascii>
+    Or would you rather tell the truth?<end_line>
+    Murno has her own issues, right?<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1925,7 +2136,8 @@
 		たしかに<three_dots><end_line>
 		そうですわ<three_dots><end_line>
 	</sjis>
-	<ascii>		<three_dots>I suppose you're right.<end_line>
+  <ascii>
+		<three_dots>I suppose you're right.<end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -1934,20 +2146,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだね<end_line>
 			わかったよ、親方<end_line>
 			行こう、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Alright, Master.<end_line>
+    We'll be on our way.<end_line>
+    Okay <partner>?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<end_line>
 			わかった、親方<end_line>
 			行こう、<partner><end_line>
 		</sjis>
-	</female>
-  <ascii>    Alright, Master.<end_line>    We'll be on our way.<end_line>    Okay <partner>?<end_line>  </ascii>
+    <ascii>
+    Alright, Master.<end_line>
+    We'll be on our way.<end_line>
+    Okay <partner>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1958,7 +2179,7 @@
 		ミューノ様は親方さんが<end_line>
 		ひとりでみているのですか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Um<three_dots><end_line>
 		Master, will you be looking after<end_line>
 		Lady Murno by yourself?<end_line>
@@ -1974,8 +2195,9 @@
 		ちゃんとアタシがついてるからさ<end_line>
 		安心しな<end_line>
 	</sjis>
-	<ascii>
-		That's right.<end_line>		I'll be here the whole time,<end_line>
+  <ascii>
+		That's right.<end_line>
+		I'll be here the whole time,<end_line>
 		so don't worry about it.<end_line>
 	</ascii>
 </dialogue>
@@ -1987,7 +2209,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1999,7 +2221,7 @@
 	<sjis>
 		心配ですわ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I am more worried now<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2011,7 +2233,7 @@
 	<sjis>
 		なんだって！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What was that!?<end_line>
 	</ascii>
 </bigtext>
@@ -2024,7 +2246,10 @@
 		お、親方！？<end_line>
 		ちょっとしずかに！<end_line>
 	</sjis>
-  <ascii>		M-Master!?<end_line>		You're too loud!<end_line>	</ascii>
+  <ascii>
+		M-Master!?<end_line>
+		You're too loud!<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2033,7 +2258,7 @@
 	<sjis>
 		うう<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hn<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2044,7 +2269,7 @@
 	<sjis>
 		あ、ごめん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah. Sorry.<end_line>
 	</ascii>
 </dialogue>
@@ -2056,7 +2281,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2070,7 +2295,10 @@
 		さっきはアンタが変なこというから<end_line>
 		ついカッとなっちまって<three_dots><end_line>
 	</sjis>
-	<ascii>		Stop looking at me like that.<end_line>		This is all your fault, you know<three_dots><end_line>	</ascii>
+  <ascii>
+		Stop looking at me like that.<end_line>
+		This is all your fault, you know<three_dots><end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2080,7 +2308,7 @@
 	<sjis>
 		やっぱり心配ですわ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I really am worried<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2092,7 +2320,7 @@
 	<sjis>
 		なんだって！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh!?<end_line>
 	</ascii>
 </bigtext>
@@ -2104,7 +2332,7 @@
 	<sjis>
 		だから親方<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Master<three_dots>!<end_line>
 	</ascii>
 </dialogue>
@@ -2118,7 +2346,11 @@
 		アンタ、ジャマだから<end_line>
 		村長のところに行ってくれないか<end_line>
 	</sjis>
-	<ascii>		<three_dots>Anyway,<end_line>		you two are in the way.<end_line>		Just go and see the Chief already.<end_line>	</ascii>
+  <ascii>
+		<three_dots>Anyway,<end_line>
+		you two are in the way.<end_line>
+		Just go and see the Chief already.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2129,7 +2361,7 @@
 		そうすればミューノもじき<end_line>
 		良くなるから、ね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Murno'll feel better in no time.<end_line>
 	</ascii>
 </dialogue>
@@ -2141,7 +2373,7 @@
 	<sjis>
 		私が、ジャマ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Me? I am not in<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2154,7 +2386,12 @@
 		村長へのあいさつ以外にも<end_line>
 		アンタたちには修行があるだろ<end_line>
 		鍛冶師ってのはヒマじゃないよ<end_line>
-	</sjis>	<ascii>		Even if you didn't need to see him,<end_line>		I'd make you train instead.<end_line>		Craftknights are quite busy.<end_line>	</ascii>
+	</sjis>
+  <ascii>
+		Even if you didn't need to see him,<end_line>
+		I'd make you train instead.<end_line>
+		Craftknights are quite busy.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2162,20 +2399,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			うん、わかったよ、親方<end_line>
 			とりあえず村長のところに行こう<end_line>
 			な、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Alright, Master.<end_line>
+    We'll be on our way.<end_line>
+    Okay <partner>?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			うん、わかったよ、親方<end_line>
 			とりあえず村長のところに行こう<end_line>
 			ね、<partner><end_line>
 		</sjis>
-	</female>
-  <ascii>    Alright, Master.<end_line>    We'll be on our way.<end_line>    Okay <partner>?<end_line>  </ascii>
+    <ascii>
+    Alright, Master.<end_line>
+    We'll be on our way.<end_line>
+    Okay <partner>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2186,7 +2432,7 @@
 		仕方ありませんわ<three_dots><end_line>
 		わかりました<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Very well<three_dots><end_line>
 		I understand<three_dots><end_line>
 	</ascii>

--- a/Day 01/008_24303596_172d7ec.xml
+++ b/Day 01/008_24303596_172d7ec.xml
@@ -1,10 +1,10 @@
 <location>
-	<sjis>
+  <sjis>
 		ディックル村<end_line>
 	</sjis>
 </location>
 <location>
-	<sjis>
+  <sjis>
 		ディックル村　住宅地<end_line>
 	</sjis>
 </location>
@@ -12,61 +12,73 @@
 	<info box="simple">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			外に出るより今は<end_line>
 			工房で修行の続きだな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			外に出るより今は<end_line>
-			工房で修行の続きね！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Forget going outside,<end_line>
     I need to continue training!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			外に出るより今は<end_line>
+			工房で修行の続きね！<end_line>
+		</sjis>
+    <ascii>
+    Forget going outside,<end_line>
+    I need to continue training!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			<partner>を紹介しに<end_line>
 			村長のとこに行かないと！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<partner>を紹介しに<end_line>
-			村長のとこに行かなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I need to introduce<end_line>
     <partner> to the Chief!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<partner>を紹介しに<end_line>
+			村長のとこに行かなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    I need to introduce<end_line>
+    <partner> to the Chief!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ザックにハンマーを<end_line>
 			届けてやらないと<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ザックにハンマーを<end_line>
-			届けてあげなくちゃ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I need to return this hammer<three_dots><end_line>
     Where's Zakk<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ザックにハンマーを<end_line>
+			届けてあげなくちゃ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I need to return this hammer<three_dots><end_line>
+    Where's Zakk<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">

--- a/Day 01/012_24301996_172d1ac.xml
+++ b/Day 01/012_24301996_172d1ac.xml
@@ -15,15 +15,18 @@
     <sjis>
       こっちには用はないな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Nothing to do here<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       こっちの方には用事はないよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Nothing to do here<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Day 01/021_24975868_17d19fc.xml
+++ b/Day 01/021_24975868_17d19fc.xml
@@ -21,6 +21,10 @@
       オレのパートナー<end_line>
       いっしょに鍛冶をするんだ！<end_line>
     </sjis>
+    <ascii>
+    Uh, this is <partner>, my partner!<end_line>
+    We'll be training together!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -28,11 +32,11 @@
       わたしのパートナー<end_line>
       いっしょに鍛冶をするんだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uh, this is <partner>, my partner!<end_line>
     We'll be training together!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -421,6 +425,11 @@
       お前が問題起こすと<end_line>
       ミューノまで困るんだぞ！<end_line>
     </sjis>
+    <ascii>
+    Cut it out<three_dots><end_line>
+    You'll just cause more<end_line>
+    trouble for Murno!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -428,12 +437,12 @@
       あなたが問題起こすと<end_line>
       ミューノまで困るんだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Cut it out<three_dots><end_line>
     You'll just cause more<end_line>
     trouble for Murno!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">

--- a/Day 01/022_24979820_17d296c.xml
+++ b/Day 01/022_24979820_17d296c.xml
@@ -15,15 +15,18 @@
     <sjis>
       なんだよ！？<end_line>
     </sjis>
+    <ascii>
+    What was that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なんなの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -33,16 +36,19 @@
       おい<end_line>
       大丈夫か！？<end_line>
     </sjis>
+    <ascii>
+    Hey, are you okay?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ねえ<end_line>
       大丈夫！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, are you okay?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -81,6 +87,11 @@
       はぐれって言うなよ<end_line>
       景気わる男の子分！<end_line>
     </sjis>
+    <ascii>
+    Hey, my name is <player_name>!<end_line>
+    Don't call my Master a Stray,<end_line>
+    when your leader is so unsociable!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -88,12 +99,12 @@
       はぐれって言わないでよ<end_line>
       景気わる男の子分！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, my name is <player_name>!<end_line>
     Don't call my Master a Stray,<end_line>
     when your leader is so unsociable!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -183,6 +194,10 @@
       こいつ、オレのパートナーの<end_line>
       <partner><end_line>
     </sjis>
+    <ascii>
+    Yeah.<end_line>
+    This my partner, <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -190,11 +205,11 @@
       この子、わたしのパートナーよ<end_line>
       <partner>っていうの<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah.<end_line>
     This my partner, <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -233,17 +248,21 @@
       知るかよ<end_line>
       勝手にコケてたんだよ<end_line>
     </sjis>
+    <ascii>
+    How should know?<end_line>
+    You tripped all on your own.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       知らないよ<end_line>
       勝手に転んでたんでしょ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How should know?<end_line>
     You tripped all on your own.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -267,15 +286,18 @@
     <sjis>
       いそがしいヤツだな<end_line>
     </sjis>
+    <ascii>
+    He seems busy.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       いそがしい子ね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     He seems busy.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -418,17 +440,21 @@
       しかたない<end_line>
       届けてやるか！<end_line>
     </sjis>
+    <ascii>
+    We don't have a choice.<end_line>
+    Let's return it!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       しかたない<end_line>
       届けてあげよう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We don't have a choice.<end_line>
     Let's return it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -604,17 +630,21 @@
       うおっ、村長！？<end_line>
       いつからそこに！？<end_line>
     </sjis>
+    <ascii>
+    Uwah, chief!?<end_line>
+    How long have you been there!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うわっ、村長！？<end_line>
       いつからそこに！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uwah, chief!?<end_line>
     How long have you been there!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -707,6 +737,11 @@
       ゴメン、親方<three_dots><end_line>
       オレ、カッコワルかったよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    <three_dots>Yes<end_line>
+    I'm sorry, Chief<three_dots><end_line>
+    I was wrong<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -714,12 +749,12 @@
       ゴメン、親方<three_dots><end_line>
       わたし、カッコワルかったよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots>Yes<end_line>
     I'm sorry, Chief<three_dots><end_line>
     I was wrong<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -765,17 +800,21 @@
       よし！<end_line>
       あいつに届けにいくぞ<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Let's go return his hammer.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       あの子に届けにいこう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Let's go return his hammer.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -800,6 +839,11 @@
       おー！<end_line>
       とか言ってくれないか？<end_line>
     </sjis>
+    <ascii>
+    Hey, at times like these,<end_line>
+    you should say something like,<end_line>
+    "Yes! Let's do this!"<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -807,12 +851,12 @@
       おー！<end_line>
       とか言ってくれない？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, at times like these,<end_line>
     you should say something like,<end_line>
     "Yes! Let's do this!"<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -872,6 +916,11 @@
       今、<partner>笑わなかった？<end_line>
       オレなにか、おかしなことした？<end_line>
     </sjis>
+    <ascii>
+    Eh<three_dots>?<end_line>
+    Did you smile just now, <partner>?<end_line>
+    What's so funny?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -879,12 +928,12 @@
       今、<partner>笑わなかった？<end_line>
       わたしなにか、おかしなことした？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh<three_dots>?<end_line>
     Did you smile just now, <partner>?<end_line>
     What's so funny?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -936,15 +985,18 @@
     <sjis>
       なんだよ？<end_line>
     </sjis>
+    <ascii>
+    What?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">

--- a/Day 01/023_24983580_17d381c.xml
+++ b/Day 01/023_24983580_17d381c.xml
@@ -6,17 +6,21 @@
       おい<end_line>
       どうかしたのかよ？<end_line>
     </sjis>
+    <ascii>
+    Hey,<end_line>
+    what's wrong?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ねえ<end_line>
       どうかしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey,<end_line>
     what's wrong?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -106,17 +110,21 @@
       悪かったな！<end_line>
       でも、コレを届けにきたんだよ<end_line>
     </sjis>
+    <ascii>
+    Well, sorry!<end_line>
+    Here.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       悪かったわね！<end_line>
       でも、コレを届けにきたんだから<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, sorry!<end_line>
     Here.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -142,18 +150,23 @@
       こんな大事なもん<end_line>
       ２度と落とすなよ！<end_line>
     </sjis>
+    <ascii>
+    Don't lose it again!<end_line>
+    A Craftknight's hammer is their<end_line>
+    livelihood, you know.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       こんな大事なもの<end_line>
       ２度と落としちゃダメだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't lose it again!<end_line>
     A Craftknight's hammer is their<end_line>
     livelihood, you know.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -189,6 +202,10 @@
       <partner>だから<end_line>
       礼なら<partner>に言ってくれよ<end_line>
     </sjis>
+    <ascii>
+    <partner> found it, not me.<end_line>
+    Thank them instead.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -196,11 +213,11 @@
       <partner>だよ<end_line>
       お礼なら<partner>に言ってあげて<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner> found it, not me.<end_line>
     Thank them instead.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -394,6 +411,10 @@
       じゃ、修行に行こうぜ<end_line>
       <partner><end_line>
     </sjis>
+    <ascii>
+    Yeah, sure.<end_line>
+    <partner>, let's go train.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -401,11 +422,11 @@
       じゃ、修行に行こう<end_line>
       <partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, sure.<end_line>
     <partner>, let's go train.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 01/024_25739244_188bfec.xml
+++ b/Day 01/024_25739244_188bfec.xml
@@ -26,11 +26,11 @@
       さっきの子はなんかあやしいよ<end_line>
       とにかく追いかけてみよう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That girl was way too suspicious.<end_line>
     I need to find her!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -64,17 +64,21 @@
       <partner>との勝負が待ってるし<end_line>
       遠くに行かない方がいいな<end_line>
     </sjis>
+    <ascii>
+    I have a match with <partner>,<end_line>
+    so I shouldn't stray too far.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner>との勝負が待ってるし<end_line>
       遠くに行かない方がいいよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I have a match with <partner>,<end_line>
     so I shouldn't stray too far.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Day 01/025_24985468_17d3f7c.xml
+++ b/Day 01/025_24985468_17d3f7c.xml
@@ -63,6 +63,11 @@
       鍛冶師は強くなくちゃいけないんだ<end_line>
       もしかしてお前、コワいのか？<end_line>
     </sjis>
+    <ascii>
+    Drive it away, I guess.<end_line>
+    Craftknights gotta be strong.<end_line>
+    You aren't scared, are you?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -70,12 +75,12 @@
       鍛冶師は強くなくちゃいけないの<end_line>
       もしかしてあなた、コワいの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Drive it away, I guess.<end_line>
     Craftknights gotta be strong.<end_line>
     You aren't scared, are you?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -145,16 +150,19 @@
       大丈夫だよ<end_line>
       オレがついてるし<end_line>
     </sjis>
+    <ascii>
+    Don't worry, I'll be here.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       大丈夫だよ<end_line>
       わたしがついてるし<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't worry, I'll be here.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -182,6 +190,11 @@
       んじゃ、今日はふたりだし<end_line>
       いつもより奥まで行ってみるか！<end_line>
     </sjis>
+    <ascii>
+    This is exciting!<end_line>
+    Now that there's two of us,<end_line>
+    let's try going deeper than usual.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -189,12 +202,12 @@
       んじゃ、今日はふたりだし<end_line>
       いつもより奥まで行ってみよう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This is exciting!<end_line>
     Now that there's two of us,<end_line>
     let's try going deeper than usual.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <popup>
   <sjis>

--- a/Day 01/026_24987116_17d45ec.xml
+++ b/Day 01/026_24987116_17d45ec.xml
@@ -46,6 +46,11 @@
       お前、重そうだもんな<three_dots><end_line>
       この橋わたれるのか？<end_line>
     </sjis>
+    <ascii>
+    I see.<end_line>
+    You look heavy, <partner><three_dots><end_line>
+    Can we even cross this bridge?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -53,12 +58,12 @@
       <partner>、重そうだもんね<three_dots><end_line>
       この橋わたれるかな？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see.<end_line>
     You look heavy, <partner><three_dots><end_line>
     Can we even cross this bridge?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -83,6 +88,10 @@
       オレにはどっちの橋も<end_line>
       かわらないように見えるけどな<end_line>
     </sjis>
+    <ascii>
+    Hmm<three_dots><end_line>
+    They look the same to me.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -90,11 +99,11 @@
       わたしにはどっちの橋も<end_line>
       かわらないように見えるけどなあ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hmm<three_dots><end_line>
     They look the same to me.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -131,6 +140,10 @@
       オレにはどっちの橋も<end_line>
       かわらないように見えるけどな<end_line>
     </sjis>
+    <ascii>
+    Really?<end_line>
+    They look the same to me.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -138,11 +151,11 @@
       わたしにはどっちの橋も<end_line>
       かわらないように見えるけど<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Really?<end_line>
     They look the same to me.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -280,6 +293,10 @@
       オレにはどっちの橋も<end_line>
       かわらないように見えるぜ<end_line>
     </sjis>
+    <ascii>
+    Really?<end_line>
+    They look the same to me.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -287,9 +304,9 @@
       けど、わたしにはどっちの橋も<end_line>
       かわらないように見えるけど<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Really?<end_line>
     They look the same to me.<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 01/027_24993324_17d5e2c.xml
+++ b/Day 01/027_24993324_17d5e2c.xml
@@ -83,15 +83,18 @@
     <sjis>
       なんだと！<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -259,6 +262,11 @@
       オレには橋のちがいが<end_line>
       わからなかったからさ<three_dots><end_line>
     </sjis>
+    <ascii>
+    No, it's just that<end_line>
+    I couldn't tell the<end_line>
+    difference, so<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -266,12 +274,12 @@
       わたしにはちがいが<end_line>
       わからなかったから<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No, it's just that<end_line>
     I couldn't tell the<end_line>
     difference, so<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -299,6 +307,11 @@
       しり<three_dots>！？<end_line>
       オレのしりは青くないぞ！<end_line>
     </sjis>
+    <ascii>
+    Wha<three_dots>!?<end_line>
+    Green where!?<end_line>
+    Oh no, am I sick or something!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -306,12 +319,12 @@
       わたしのおしりは<end_line>
       青くなんかないわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wha<three_dots>!?<end_line>
     Green where!?<end_line>
     Oh no, am I sick or something!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -338,15 +351,18 @@
     <sjis>
       半人前っていうな！<end_line>
     </sjis>
+    <ascii>
+    No I'm not!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       半人前っていわないでよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No I'm not!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -387,15 +403,18 @@
     <sjis>
       なんだと！<end_line>
     </sjis>
+    <ascii>
+    What the heck!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What the heck!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -494,17 +513,21 @@
       あぶねー<three_dots><end_line>
       橋が落ちたぞ<end_line>
     </sjis>
+    <ascii>
+    That was dangerous<three_dots><end_line>
+    The bridge collapsed<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あっぶない<three_dots><end_line>
       橋が落ちちゃった<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That was dangerous<three_dots><end_line>
     The bridge collapsed<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -532,6 +555,10 @@
       橋が落ちそうなの<end_line>
       気付いてたのか！<end_line>
     </sjis>
+    <ascii>
+    What?<end_line>
+    You knew that would happen!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -539,11 +566,11 @@
       橋が落ちそうなの<end_line>
       気付いてたの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What?<end_line>
     You knew that would happen!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -578,15 +605,18 @@
     <sjis>
       教えてくれないんだよ？<end_line>
     </sjis>
+    <ascii>
+    why didn't you tell me?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       教えてくれないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     why didn't you tell me?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -612,6 +642,11 @@
       お前、オレのパートナーだってこと<end_line>
       忘れてんのか？<end_line>
     </sjis>
+    <ascii>
+    Huh!?<end_line>
+    We're supposed to be<end_line>
+    partners, remember?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -619,12 +654,12 @@
       あなた、わたしのパートナーに<end_line>
       なったこと忘れてるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh!?<end_line>
     We're supposed to be<end_line>
     partners, remember?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -787,6 +822,10 @@
       あっちが落ちた！<end_line>
       あぶねー<three_dots><end_line>
     </sjis>
+    <ascii>
+    Oh, you were right.<end_line>
+    That was dangerous<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -794,11 +833,11 @@
       あっちが落ちたね！<end_line>
       あっぶなかった<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, you were right.<end_line>
     That was dangerous<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -824,6 +863,11 @@
       オレには橋のちがいが<end_line>
       わからなかったからさ<three_dots><end_line>
     </sjis>
+    <ascii>
+    No, it's just that<end_line>
+    I couldn't tell the<end_line>
+    difference, so<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -831,12 +875,12 @@
       わたしにはちがいが<end_line>
       わからなかったから<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No, it's just that<end_line>
     I couldn't tell the<end_line>
     difference, so<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 01/028_24996220_17d697c.xml
+++ b/Day 01/028_24996220_17d697c.xml
@@ -8,6 +8,11 @@
       はぐれだなんて<three_dots><end_line>
       大丈夫か、<partner>？<end_line>
     </sjis>
+    <ascii>
+    Your attacks didn't work<three_dots><end_line>
+    That was a stray<three_dots>?<end_line>
+    Are you alright, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -15,12 +20,12 @@
       はぐれだなんて<three_dots><end_line>
       大丈夫、<partner>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Your attacks didn't work<three_dots><end_line>
     That was a stray<three_dots>?<end_line>
     Are you alright, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -91,6 +96,11 @@
       お前とはパートナーなんだし<end_line>
       助け合うのは当然だろ！<end_line>
     </sjis>
+    <ascii>
+    You don't have to do that!<end_line>
+    We're partners.<end_line>
+    It's natural we help each other!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -98,12 +108,12 @@
       あなたとはパートナーなんだし<end_line>
       助け合うのは当然でしょ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You don't have to do that!<end_line>
     We're partners.<end_line>
     It's natural we help each other!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -225,17 +235,21 @@
       何だ！？<end_line>
       誰かが橋から落ちたぞ！？<end_line>
     </sjis>
+    <ascii>
+    What was that?<end_line>
+    Did someone fall off the bridge!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       何！？<end_line>
       誰かが橋から落ちた！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that?<end_line>
     Did someone fall off the bridge!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -317,6 +331,11 @@
       お前とはパートナーなんだし<end_line>
       助け合うのは当然だろ！<end_line>
     </sjis>
+    <ascii>
+    There's no need for that<three_dots>!<end_line>
+    We're partners.<end_line>
+    It's natural we help each other!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -324,12 +343,12 @@
       あなたとはパートナーなんだし<end_line>
       助け合うのは当然でしょ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There's no need for that<three_dots>!<end_line>
     We're partners.<end_line>
     It's natural we help each other!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -451,17 +470,21 @@
       何だ！？<end_line>
       誰かが橋から落ちたぞ！？<end_line>
     </sjis>
+    <ascii>
+    What was that?<end_line>
+    Did someone fall off the bridge!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       何！？<end_line>
       誰かが橋から落ちた！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that?<end_line>
     Did someone fall off the bridge!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -500,17 +523,21 @@
       お前<three_dots><end_line>
       まだそんなこと<three_dots><end_line>
     </sjis>
+    <ascii>
+    Oh, come on<three_dots><end_line>
+    You're still like that<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あなた<three_dots><end_line>
       まだそんなこと<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, come on<three_dots><end_line>
     You're still like that<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -534,17 +561,21 @@
       ははははは！<end_line>
       すげぇな、お前<end_line>
     </sjis>
+    <ascii>
+    Ahahahaha!<end_line>
+    You're amazing, you know!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あはははは！<end_line>
       すごいよ、あなた<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ahahahaha!<end_line>
     You're amazing, you know!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -569,6 +600,11 @@
       そんなこと言えるんなら<end_line>
       大丈夫だな、と思ってさ<end_line>
     </sjis>
+    <ascii>
+    Well, I figure<end_line>
+    if you can still say stuff<end_line>
+    like that, you must be fine.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -576,12 +612,12 @@
       そんなこと言えるんなら<end_line>
       大丈夫だな、と思って<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, I figure<end_line>
     if you can still say stuff<end_line>
     like that, you must be fine.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -610,6 +646,10 @@
       お前とはパートナーなんだし<end_line>
       助け合うのは当然だろ！<end_line>
     </sjis>
+    <ascii>
+    Nah, we're partners,<end_line>
+    so helping each other is natural!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -617,11 +657,11 @@
       あなたとはパートナーなんだし<end_line>
       助け合うのは当然でしょ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Nah, we're partners,<end_line>
     so helping each other is natural!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -743,17 +783,21 @@
       何だ！？<end_line>
       誰かが橋から落ちたぞ！？<end_line>
     </sjis>
+    <ascii>
+    What was that?<end_line>
+    Did someone fall off the bridge!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       何！？<end_line>
       誰かが橋から落ちた！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that?<end_line>
     Did someone fall off the bridge!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -794,6 +838,11 @@
       お前とはパートナーなんだし<end_line>
       助け合うのは当然だろ！<end_line>
     </sjis>
+    <ascii>
+    There's no need for that<three_dots>!<end_line>
+    We're partners.<end_line>
+    It's natural we help each other!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -801,12 +850,12 @@
       あなたとはパートナーなんだし<end_line>
       助け合うのは当然でしょ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There's no need for that<three_dots>!<end_line>
     We're partners.<end_line>
     It's natural we help each other!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -938,17 +987,21 @@
       何だ！？<end_line>
       誰かが橋から落ちたぞ！？<end_line>
     </sjis>
+    <ascii>
+    What was that?<end_line>
+    Did someone fall off the bridge!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       何！？<end_line>
       誰かが橋から落ちた！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that?<end_line>
     Did someone fall off the bridge!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -992,15 +1045,19 @@
       橋はもう、くずれていたハズ<end_line>
       それなのに落ちたのか！？<end_line>
     </sjis>
+    <ascii>
+    Couldn't he tell it was broken!?<end_line>
+    Jeez<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       橋はもう、くずれていたハズ<end_line>
       それなのに落ちたの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Couldn't he tell it was broken!?<end_line>
     Jeez<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 01/030_24998780_17d737c.xml
+++ b/Day 01/030_24998780_17d737c.xml
@@ -6,16 +6,19 @@
       おい、お前<end_line>
       大丈夫かよ？<end_line>
     </sjis>
+    <ascii>
+    Hey, you okay?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちょっと、あなた<end_line>
       大丈夫なの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, you okay?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -55,6 +58,11 @@
       あの橋、穴が空いてただろ？<end_line>
       なんで落ちるんだよ！？<end_line>
     </sjis>
+    <ascii>	
+    <three_dots>Hey.<end_line>
+    You seriously didn't see the gap<end_line>
+    where the bridge should've been?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -62,12 +70,12 @@
       あの橋、穴が空いてたよね？<end_line>
       なんで落ちるの！？<end_line>
     </sjis>
-  </female>
-  <ascii>	
+    <ascii>	
     <three_dots>Hey.<end_line>
     You seriously didn't see the gap<end_line>
     where the bridge should've been?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -91,17 +99,21 @@
       そんなに急いで<end_line>
       どうしたんだよ<end_line>
     </sjis>
+    <ascii>
+    What's so important you can't<end_line>
+    even look down once in a while?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなに急いで<end_line>
       何があったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's so important you can't<end_line>
     even look down once in a while?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -311,6 +323,11 @@
       あんなカオしてるけど<end_line>
       あいつも結構やるもんだな<end_line>
     </sjis>
+    <ascii>
+    Hmm<three_dots><end_line>
+    Despite how he looks,<end_line>
+    he's actually pretty cool.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -318,12 +335,12 @@
       あんなカオしてるけど<end_line>
       あいつも結構やるもんね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hmm<three_dots><end_line>
     Despite how he looks,<end_line>
     he's actually pretty cool.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -629,6 +646,11 @@
       大丈夫か！？<end_line>
       この先ははぐれ召喚獣も<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah<three_dots>Hey<three_dots>!<end_line>
+    Are you gonna be okay?<end_line>
+    There are Strays ahead<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -636,12 +658,12 @@
       大丈夫なの！？<end_line>
       この先ははぐれ召喚獣も<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah<three_dots>Hey<three_dots>!<end_line>
     Are you gonna be okay?<end_line>
     There are Strays ahead<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -676,6 +698,11 @@
       ミューノにあげたいってことだよな<end_line>
       <partner>？<end_line>
     </sjis>
+    <ascii>
+    So, you're gonna give that<end_line>
+    medicine to Murno to make<end_line>
+    her feel better, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -683,12 +710,12 @@
       ミューノにあげたいってことね<end_line>
       <partner>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So, you're gonna give that<end_line>
     medicine to Murno to make<end_line>
     her feel better, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -751,6 +778,11 @@
       ミューノにあげたいってことだよな<end_line>
       <partner>？<end_line>
     </sjis>
+    <ascii>
+    So, you're gonna give that<end_line>
+    medicine to Murno to make<end_line>
+    her feel better, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -758,12 +790,12 @@
       ミューノにあげたいってことね<end_line>
       <partner>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So, you're gonna give that<end_line>
     medicine to Murno to make<end_line>
     her feel better, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -938,6 +970,11 @@
       ミューノにあげたいってことだよな<end_line>
       <partner>？<end_line>
     </sjis>
+    <ascii>
+    So, you're gonna give that<end_line>
+    medicine to Murno to make<end_line>
+    her feel better, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -945,12 +982,12 @@
       ミューノにあげたいってことね<end_line>
       <partner>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So, you're gonna give that<end_line>
     medicine to Murno to make<end_line>
     her feel better, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 01/032_25001692_17d7edc.xml
+++ b/Day 01/032_25001692_17d7edc.xml
@@ -6,17 +6,21 @@
       あれ<three_dots>？<end_line>
       今度はどうしたんだ？<end_line>
     </sjis>
+    <ascii>
+    Huh<three_dots>?<end_line>
+    What is it this time?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あれ<three_dots>？<end_line>
       今度はどうしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh<three_dots>?<end_line>
     What is it this time?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -43,6 +47,11 @@
       さっきは最初っからくずれてる橋に<end_line>
       落ちたのに<end_line>
     </sjis>
+    <ascii>
+    I see you're being careful now.<end_line>
+    Though last time you fell,<end_line>
+    the bridge was already broken.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -50,12 +59,12 @@
       さっきは最初っからくずれてる橋に<end_line>
       落ちたのに<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see you're being careful now.<end_line>
     Though last time you fell,<end_line>
     the bridge was already broken.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -77,17 +86,21 @@
       どうだ、<partner><end_line>
       今度もわかるか？<end_line>
     </sjis>
+    <ascii>
+    Hey, <partner>.<end_line>
+    Any issues with the bridge?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どう、<partner><end_line>
       今度もわかるかな？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, <partner>.<end_line>
     Any issues with the bridge?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -136,6 +149,9 @@
       教えたくないとは思うんだけど<end_line>
       たのむぜ<three_dots><end_line>
     </sjis>
+    <ascii>
+    You know, don't you<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -143,10 +159,10 @@
       教えたくないとは思うんだけど<end_line>
       そこをなんとか<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You know, don't you<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -246,17 +262,21 @@
       あ、おい<end_line>
       ちょっと！<end_line>
     </sjis>
+    <ascii>
+    Ah, hey,<end_line>
+    wait a second!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、ねえ<end_line>
       ちょっと！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, hey,<end_line>
     wait a second!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="left" effect="big">
@@ -286,17 +306,21 @@
       だ<three_dots><end_line>
       大丈夫か！？<end_line>
     </sjis>
+    <ascii>
+    A<three_dots><end_line>
+    Are you okay!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       だ<three_dots><end_line>
       大丈夫！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     A<three_dots><end_line>
     Are you okay!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -328,17 +352,21 @@
       どういうことだよ！<end_line>
       大丈夫なんじゃなかったのか！？<end_line>
     </sjis>
+    <ascii>
+    What happened there?<end_line>
+    You said it'd be fine!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ねえ、どういうこと？<end_line>
       大丈夫じゃなかったの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What happened there?<end_line>
     You said it'd be fine!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -392,17 +420,21 @@
       お前<three_dots><end_line>
       ザックのせいだって言うのか<three_dots><end_line>
     </sjis>
+    <ascii>
+    <three_dots><end_line>
+    You're saying it's his fault<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あなた<three_dots><end_line>
       ザックのせいだって言うの<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots><end_line>
     You're saying it's his fault<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -592,17 +624,21 @@
       どういうことだよ！<end_line>
       大丈夫なんじゃなかったのか！？<end_line>
     </sjis>
+    <ascii>
+    What happened there?<end_line>
+    You said it'd be fine!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ねえ、どういうこと？<end_line>
       大丈夫じゃなかったの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What happened there?<end_line>
     You said it'd be fine!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -630,17 +666,21 @@
       言い訳かよ！<end_line>
       カッコワルイな！<end_line>
     </sjis>
+    <ascii>
+    I don't want to hear any excuses!<end_line>
+    That's so lame!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       言い訳なんて<end_line>
       カッコワルイわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I don't want to hear any excuses!<end_line>
     That's so lame!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -666,17 +706,21 @@
       あいつはお前の言葉を信じてたんだ<end_line>
       それなのに、なんだよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    He trusted you,<end_line>
+    and despite that<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あの子はあなたの言葉を信じてたのよ<end_line>
       それなのに、なによ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     He trusted you,<end_line>
     and despite that<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -701,6 +745,11 @@
       もういい！<end_line>
       あいつのトコへ行くぞ！<end_line>
     </sjis>
+    <ascii>
+    Ughh!<end_line>
+    Forget it!<end_line>
+    Let's go find him!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -708,12 +757,12 @@
       もういいわ！<end_line>
       あの子のトコへ行きましょう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ughh!<end_line>
     Forget it!<end_line>
     Let's go find him!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -725,16 +774,19 @@
       どういうことだよ！<end_line>
       もしかして、ダマしたのか？<end_line>
     </sjis>
+    <ascii>
+    Did you do that on purpose?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どういうこと？<end_line>
       もしかして、ダマしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Did you do that on purpose?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -760,17 +812,21 @@
       え？<end_line>
       お前、わざとじゃないのか？<end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    You didn't?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え？<end_line>
       わざとじゃないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     You didn't?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -925,17 +981,21 @@
       どういうことだよ！<end_line>
       大丈夫なんじゃなかったのか！？<end_line>
     </sjis>
+    <ascii>
+    What happened there?<end_line>
+    You said it'd be fine!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ねえ、どういうこと？<end_line>
       大丈夫じゃなかったの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What happened there?<end_line>
     You said it'd be fine!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -978,17 +1038,21 @@
       言い訳かよ！<end_line>
       カッコワルイな！<end_line>
     </sjis>
+    <ascii>
+    I don't want to hear any excuses!<end_line>
+    That's so lame!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       言い訳なんて<end_line>
       カッコワルイわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I don't want to hear any excuses!<end_line>
     That's so lame!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1014,17 +1078,21 @@
       あいつはお前の言葉を信じてたんだ<end_line>
       それなのに、なんだよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    He trusted you,<end_line>
+    and despite that<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あの子はあなたの言葉を信じてたのよ<end_line>
       それなのに、なによ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     He trusted you,<end_line>
     and despite that<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1049,6 +1117,11 @@
       もういい！<end_line>
       あいつのトコへ行くぞ！<end_line>
     </sjis>
+    <ascii>
+    Ughh!<end_line>
+    Forget it!<end_line>
+    Let's just go find him!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1056,12 +1129,12 @@
       もういいわ！<end_line>
       あの子のトコへ行きましょう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ughh!<end_line>
     Forget it!<end_line>
     Let's just go find him!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="left" effect="big">
@@ -1070,13 +1143,16 @@
     <sjis>
       うわっ！<end_line>
     </sjis>
+    <ascii>
+    Ah!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       きゃっ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah!<end_line>
   </ascii>
+  </female>
 </bigtext>

--- a/Day 01/033_25005052_17d8bfc.xml
+++ b/Day 01/033_25005052_17d8bfc.xml
@@ -7,6 +7,11 @@
       <partner>がいなかったら<end_line>
       いまごろオレは<three_dots><end_line>
     </sjis>
+    <ascii>
+    That was close<three_dots><end_line>
+    <partner>, if you weren't here,<end_line>
+    I'd be done for<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -14,12 +19,12 @@
       <partner>がいなかったら<end_line>
       いまごろわたし<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That was close<three_dots><end_line>
     <partner>, if you weren't here,<end_line>
     I'd be done for<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -100,6 +105,11 @@
       それにしても本当に<end_line>
       ブジでよかったぜ<end_line>
     </sjis>
+    <ascii>
+    So that's why you came from there<three_dots><end_line>
+    But more than that,<end_line>
+    I'm glad you're okay.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -107,12 +117,12 @@
       それにしても本当に<end_line>
       ブジでよかったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So that's why you came from there<three_dots><end_line>
     But more than that,<end_line>
     I'm glad you're okay.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -188,15 +198,18 @@
     <sjis>
       悪かったよ<end_line>
     </sjis>
+    <ascii>
+    I'm sorry too.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ごめんね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm sorry too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -223,6 +236,11 @@
       オレの失敗でもあるんだ<end_line>
       いっしょにあやまらなきゃな<end_line>
     </sjis>
+    <ascii>
+    My partner's mistake<end_line>
+    is my mistake too,<end_line>
+    so we apologize together.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -230,12 +248,12 @@
       わたしの失敗でもあるしね<end_line>
       いっしょにあやまらなきゃ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     My partner's mistake<end_line>
     is my mistake too,<end_line>
     so we apologize together.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -284,15 +302,18 @@
     <sjis>
       今度は落ちないみたいだ<end_line>
     </sjis>
+    <ascii>
+    Looks like he'll be okay now.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今度は大丈夫みたいだね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Looks like he'll be okay now.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -316,17 +337,21 @@
       よし！<end_line>
       オレたちも行こう！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Let's go too!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       わたしたちも行こう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Let's go too!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -396,6 +421,11 @@
       それにしても本当に<end_line>
       ブジでよかったぜ<end_line>
     </sjis>
+    <ascii>
+    So that's why you came from there<three_dots><end_line>
+    But more than that,<end_line>
+    I'm glad you're okay.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -403,12 +433,12 @@
       それにしても本当に<end_line>
       ブジでよかったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So that's why you came from there<three_dots><end_line>
     But more than that,<end_line>
     I'm glad you're okay.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -484,15 +514,18 @@
     <sjis>
       悪かったな<end_line>
     </sjis>
+    <ascii>
+    I'm sorry too.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ごめんね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm sorry too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -519,6 +552,11 @@
       オレの失敗でもあるんだ<end_line>
       いっしょにあやまらなきゃな<end_line>
     </sjis>
+    <ascii>
+    My partner's mistake<end_line>
+    is my mistake too,<end_line>
+    so we apologize together.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -526,12 +564,12 @@
       わたしの失敗でもあるしね<end_line>
       いっしょにあやまらなきゃ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     My partner's mistake<end_line>
     is my mistake too,<end_line>
     so we apologize together.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -580,15 +618,18 @@
     <sjis>
       今度は落ちないみたいだ<end_line>
     </sjis>
+    <ascii>
+    Looks like he'll be okay now.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今度は大丈夫みたいだね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Looks like he'll be okay now.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -614,17 +655,21 @@
       よし！<end_line>
       オレたちも行こう！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Let's go too!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       わたしたちも行こう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Let's go too!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -923,15 +968,18 @@
     <sjis>
       今度は落ちないみたいだ<end_line>
     </sjis>
+    <ascii>
+    Looks like he'll be okay now.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今度は大丈夫みたいだね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Looks like he'll be okay now.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -955,17 +1003,21 @@
       よし！<end_line>
       オレたちも行こう！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Let's get going!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       わたしたちも行こう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Let's get going!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1037,6 +1089,11 @@
       それにしても本当に<end_line>
       ブジでよかったぜ<end_line>
     </sjis>
+    <ascii>
+    So that's why you came from there<three_dots><end_line>
+    But more than that,<end_line>
+    I'm glad you're okay.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1044,12 +1101,12 @@
       それにしても本当に<end_line>
       ブジでよかったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So that's why you came from there<three_dots><end_line>
     But more than that,<end_line>
     I'm glad you're okay.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1122,15 +1179,18 @@
     <sjis>
       悪かったな<end_line>
     </sjis>
+    <ascii>
+    I'm sorry too.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ごめんね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm sorry too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1157,6 +1217,11 @@
       オレの失敗でもあるんだ<end_line>
       いっしょにあやまらなきゃな<end_line>
     </sjis>
+    <ascii>	
+    My partner's mistake<end_line>
+    is my mistake too,<end_line>
+    so we apologize together.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1164,12 +1229,12 @@
       わたしの失敗でもあるしね<end_line>
       いっしょにあやまらなきゃ<end_line>
     </sjis>
-  </female>
-  <ascii>	
+    <ascii>	
     My partner's mistake<end_line>
     is my mistake too,<end_line>
     so we apologize together.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1218,15 +1283,18 @@
     <sjis>
       今度は落ちないみたいだ<end_line>
     </sjis>
+    <ascii>
+    Looks like he'll be okay now.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今度は大丈夫みたいだね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Looks like he'll be okay now.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1250,16 +1318,20 @@
       よし！<end_line>
       オレたちも行こう！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Let's go too!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       わたしたちも行こう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Let's go too!<end_line>
   </ascii>
+  </female>
 </dialogue>
 

--- a/Day 01/036_25008348_17d98dc.xml
+++ b/Day 01/036_25008348_17d98dc.xml
@@ -7,18 +7,23 @@
       ヘンだな<three_dots>？<end_line>
       この辺だけ草が枯れてるぞ？<end_line>
     </sjis>
+    <ascii>
+    That's strange<three_dots><end_line>
+    The grass is withered,<end_line>
+    but only around here, see?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ヘンだね<three_dots>？<end_line>
       この辺だけ草が枯れてるよ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's strange<three_dots><end_line>
     The grass is withered,<end_line>
     but only around here, see?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 01/037_25009340_17d9cbc.xml
+++ b/Day 01/037_25009340_17d9cbc.xml
@@ -36,6 +36,11 @@
       きっとまだどこかに<end_line>
       残ってるはずだ！<end_line>
     </sjis>
+    <ascii>
+    It's too early to give up.<end_line>
+    There should still be<end_line>
+    some left somewhere!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -43,12 +48,12 @@
       きっとまだどこかに<end_line>
       残ってるって！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's too early to give up.<end_line>
     There should still be<end_line>
     some left somewhere!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -72,6 +77,10 @@
       大丈夫<end_line>
       オレたちが追っ払ってやる<end_line>
     </sjis>
+    <ascii>
+    It's alright.<end_line>
+    We'll drive it away.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -79,11 +88,11 @@
       わたしたちが<end_line>
       追っ払ってあげるわ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's alright.<end_line>
     We'll drive it away.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -107,17 +116,21 @@
       大丈夫だ<end_line>
       鍛冶師は強くなきゃいけないからな！<end_line>
     </sjis>
+    <ascii>
+    We'll be okay.<end_line>
+    A Craftknight must be strong!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       大丈夫<end_line>
       鍛冶師は強くなきゃいけないもん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We'll be okay.<end_line>
     A Craftknight must be strong!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -139,16 +152,19 @@
       よし！　いくぞ<end_line>
       <partner>！<end_line>
     </sjis>
+    <ascii>
+    Okay! Let's do this, <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よし！　いこう<end_line>
       <partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay! Let's do this, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 01/038_25010764_17da24c.xml
+++ b/Day 01/038_25010764_17da24c.xml
@@ -21,6 +21,10 @@
       オレたちの強さ、思い知ったか！<end_line>
       な、<partner>！<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+    Nice job, <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -28,11 +32,11 @@
       これがわたしたちの強さよ！<end_line>
       ね、<partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
     Nice job, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -56,17 +60,21 @@
       なんだよ<end_line>
       はりあいないなぁ<three_dots><end_line>
     </sjis>
+    <ascii>
+    What's with you?<end_line>
+    You're not into it at all<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ<end_line>
       はりあいないなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's with you?<end_line>
     You're not into it at all<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -201,6 +209,10 @@
       オレのことは<end_line>
       <player_nickname>でいいって<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah<three_dots> You're welcome<three_dots><end_line>
+    You can just call me <player_nickname><three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -208,11 +220,11 @@
       わたしのことは<end_line>
       <player_nickname>でいいよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah<three_dots> You're welcome<three_dots><end_line>
     You can just call me <player_nickname><three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 01/039_25012348_17da87c.xml
+++ b/Day 01/039_25012348_17da87c.xml
@@ -6,17 +6,21 @@
       あった！<end_line>
       あったぞ、キッカの実！<end_line>
     </sjis>
+    <ascii>
+    There!<end_line>
+    I found some!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あった！<end_line>
       あったよ、キッカの実！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There!<end_line>
     I found some!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -93,15 +97,18 @@
     <sjis>
       よかったな<end_line>
     </sjis>
+    <ascii>
+    That's great!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よかったね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's great!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -152,17 +159,21 @@
       本当か？<end_line>
       いいのか？<end_line>
     </sjis>
+    <ascii>
+    Wow, really?<end_line>
+    Is that okay?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       本当に？<end_line>
       いいの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wow, really?<end_line>
     Is that okay?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -189,6 +200,11 @@
       ありがとな<end_line>
       うれしいよ！<end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    Thank you, too.<end_line>
+    I'm so happy it all worked out!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -196,12 +212,12 @@
       ありがとね<end_line>
       うれしいよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     Thank you, too.<end_line>
     I'm so happy it all worked out!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -249,17 +265,21 @@
       おう！<end_line>
       たのんだぜ！<end_line>
     </sjis>
+    <ascii>	
+    Yeah!<end_line>
+    I'm counting on you!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん！<end_line>
       たのんだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>	
+    <ascii>	
     Yeah!<end_line>
     I'm counting on you!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -294,17 +314,21 @@
       うん<end_line>
       助かったよ<end_line>
     </sjis>
+    <ascii>
+    Yeah.<end_line>
+    He's a big help.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん<end_line>
       助かっちゃった<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah.<end_line>
     He's a big help.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -329,17 +353,21 @@
       そう言われると<end_line>
       なんか心配になってくるな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Now that you've said it,<end_line>
+    I'm kinda worried now<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そう言われると<end_line>
       なんか心配になってくるなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Now that you've said it,<end_line>
     I'm kinda worried now<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -375,17 +403,21 @@
       うん<end_line>
       助かったよ<end_line>
     </sjis>
+    <ascii>
+    Yeah.<end_line>
+    He's a big help.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん<end_line>
       助かっちゃった<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah.<end_line>
     He's a big help.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -412,17 +444,21 @@
       そう言われると<end_line>
       なんか心配になってくるな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Now that you've said it,<end_line>
+    I'm kinda worried now<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そう言われると<end_line>
       なんか心配になってくるなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Now that you've said it,<end_line>
     I'm kinda worried now<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -458,17 +494,21 @@
       え？<end_line>
       それってどういうことだよ？<end_line>
     </sjis>
+    <ascii>
+    Eh?<end_line>
+    About what?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え？<end_line>
       それってどういうこと？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh?<end_line>
     About what?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -509,6 +549,11 @@
       なんか心配になってくるな<three_dots><end_line>
       とにかく駅に行こう<end_line>
     </sjis>
+    <ascii>
+    Now that you've said it,<end_line>
+    I'm kinda worried now<three_dots><end_line>
+    Anyway, let's head to the station.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -516,12 +561,12 @@
       なんか心配になってくるなぁ<three_dots><end_line>
       とにかく駅に行こう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Now that you've said it,<end_line>
     I'm kinda worried now<three_dots><end_line>
     Anyway, let's head to the station.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -545,17 +590,21 @@
       うん<end_line>
       助かったよ<end_line>
     </sjis>
+    <ascii>
+    Yeah.<end_line>
+    He's a big help.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん<end_line>
       助かっちゃった<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah.<end_line>
     He's a big help.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -582,17 +631,21 @@
       そう言われると<end_line>
       なんか心配になってくるな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Now that you've said it,<end_line>
+    I'm kinda worried now<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そう言われると<end_line>
       なんか心配になってくるなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Now that you've said it,<end_line>
     I'm kinda worried now<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 01/040_25014412_17db08c.xml
+++ b/Day 01/040_25014412_17db08c.xml
@@ -108,6 +108,11 @@
       好きでコイツに会ってたんじゃないぞ<end_line>
       薬をうけとりに来ただけだよ<end_line>
     </sjis>
+    <ascii>
+    Yeah, he's right.<end_line>
+    We're only meeting up because<end_line>
+    he wanted to give me medicine.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -115,12 +120,12 @@
       好きでこの子に会ってたんじゃないの<end_line>
       薬をうけとりに来ただけだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, he's right.<end_line>
     We're only meeting up because<end_line>
     he wanted to give me medicine.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -224,6 +229,11 @@
       別にどーだっていいだろ<end_line>
       そんなこと<end_line>
     </sjis>
+    <ascii>
+    Now, now<three_dots><end_line>
+    It's really not as big a deal<end_line>
+    as you're making it out to be.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -231,12 +241,12 @@
       別にどーだっていいじゃない<end_line>
       そんなこと<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Now, now<three_dots><end_line>
     It's really not as big a deal<end_line>
     as you're making it out to be.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -520,15 +530,18 @@
     <sjis>
       なんだと！<end_line>
     </sjis>
+    <ascii>
+    What's that supposed to mean!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's that supposed to mean!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -569,17 +582,21 @@
       お前なぁ<three_dots><end_line>
       言わせておけば<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    You<three_dots><end_line>
+    I gave you an inch and you<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんた<three_dots><end_line>
       言わせておけば<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You<three_dots><end_line>
     I gave you an inch and you<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -619,15 +636,18 @@
     <sjis>
       だめだ！<end_line>
     </sjis>
+    <ascii>
+    No, it's not okay!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       だめだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No, it's not okay!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -650,6 +670,11 @@
       こうなったら絶対その薬を<end_line>
       受け取らせたくなったぜ<three_dots><end_line>
     </sjis>
+    <ascii>
+    This isn't just your problem now.<end_line>
+    He's taking the medicine,<end_line>
+    one way or another.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -657,12 +682,12 @@
       こうなったら絶対その薬を<end_line>
       受け取らせたくなったの<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This isn't just your problem now.<end_line>
     He's taking the medicine,<end_line>
     one way or another.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -712,15 +737,18 @@
     <sjis>
       ち<three_dots>！<end_line>
     </sjis>
+    <ascii>	
+    Tch<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       く<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>	
+    <ascii>	
     Tch<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -861,15 +889,18 @@
     <sjis>
       約束、だからな<end_line>
     </sjis>
+    <ascii>
+    Then it's a deal.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       約束、だからね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Then it's a deal.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 01/041_25018124_17dbf0c.xml
+++ b/Day 01/041_25018124_17dbf0c.xml
@@ -40,17 +40,21 @@
       病人には悪いが、この勝負<end_line>
       勝たせてもらうぜ<end_line>
     </sjis>
+    <ascii>
+    I know you're sick,<end_line>
+    but I intend to win.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       病人には悪いけど、この勝負<end_line>
       勝たせてもらうから<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know you're sick,<end_line>
     but I intend to win.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -72,17 +76,21 @@
       よしっ！<end_line>
       いくぜ、<partner>！<end_line>
     </sjis>
+    <ascii>
+    You're on!<end_line>
+    Let's do this <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       いくよ、<partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're on!<end_line>
     Let's do this <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 01/042_25019244_17dc36c.xml
+++ b/Day 01/042_25019244_17dc36c.xml
@@ -6,15 +6,18 @@
     <sjis>
       まいったか！<end_line>
     </sjis>
+    <ascii>
+    Well, had enough?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どう、まいった！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, had enough?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -61,16 +64,19 @@
       負けたんだから約束通り<end_line>
       ザックの薬、受け取れよな！<end_line>
     </sjis>
+    <ascii>
+    Alright, now take the medicine!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       負けたんだから約束通り<end_line>
       ザックの薬、受け取りなさいよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright, now take the medicine!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -121,6 +127,11 @@
       ザックの気持ちがこもってるんだ<end_line>
       大事に使えよ<end_line>
     </sjis>
+    <ascii>
+    Hey, you know Zakk worked <end_line>
+    hard to get you that medicine.<end_line>
+    You should appreciate it.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -128,12 +139,12 @@
       ザックの気持ちがこもってるんだから<end_line>
       大事に使いなさいよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, you know Zakk worked <end_line>
     hard to get you that medicine.<end_line>
     You should appreciate it.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -180,6 +191,10 @@
       こっちこそありがとな<end_line>
       ザック<end_line>
     </sjis>
+    <ascii>
+    Oh, right.<end_line>
+    You have my thanks too, Zakk.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -187,11 +202,11 @@
       こっちこそありがとね<end_line>
       ザック<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, right.<end_line>
     You have my thanks too, Zakk.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 01/043_25020972_17dca2c.xml
+++ b/Day 01/043_25020972_17dca2c.xml
@@ -212,6 +212,11 @@
       ほら、これ<three_dots><end_line>
       ミューノの熱にもきくかな？<end_line>
     </sjis>
+    <ascii>
+    Ah, right.<end_line>
+    Take a look at this.<end_line>
+    Will it work on Murno's fever?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -219,12 +224,12 @@
       はい、これ<end_line>
       ミューノの熱にもきくかな？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, right.<end_line>
     Take a look at this.<end_line>
     Will it work on Murno's fever?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -246,17 +251,21 @@
       <partner>といっしょにとってきた<end_line>
       キッカの実で作ったんだぜ<end_line>
     </sjis>
+    <ascii>
+    Yeah. <partner> and I<end_line>
+    thought it would help.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner>といっしょにとってきた<end_line>
       キッカの実で作ったんだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah. <partner> and I<end_line>
     thought it would help.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -401,17 +410,21 @@
       オレのことは<end_line>
       <player_nickname>でいいから<end_line>
     </sjis>
+    <ascii>
+    You can just<end_line>
+    call me <player_nickname>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしのことは<end_line>
       <player_nickname>でいいよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You can just<end_line>
     call me <player_nickname>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 01/044_25022924_17dd1cc.xml
+++ b/Day 01/044_25022924_17dd1cc.xml
@@ -20,17 +20,21 @@
       あれ？<end_line>
       そこにいるのは<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    That looks like<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あれ？<end_line>
       そこにいるのは<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     That looks like<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <menu>
   <option>

--- a/Day 01/045_25023628_17dd48c.xml
+++ b/Day 01/045_25023628_17dd48c.xml
@@ -46,6 +46,11 @@
       でも、本当によかったよ<end_line>
       元気になって<end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    I really am glad<end_line>
+    you're feeling better.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -53,12 +58,12 @@
       でも、本当によかったよ<end_line>
       元気になって<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     I really am glad<end_line>
     you're feeling better.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -85,6 +90,11 @@
       いいんだよ別に<end_line>
       好きでやったことなんだから<end_line>
     </sjis>
+    <ascii>
+    Don't apologize.<end_line>
+    I don't really mind.<end_line>
+    I just did it cause I wanted to.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -92,12 +102,12 @@
       いいのよ別に<end_line>
       好きでやったことなんだから<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't apologize.<end_line>
     I don't really mind.<end_line>
     I just did it cause I wanted to.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -120,6 +130,11 @@
       親方が看病してて<end_line>
       オレたちはジャマだって<three_dots><end_line>
     </sjis>
+    <ascii>
+    Uh, well<three_dots><end_line>
+    Master said we were in the way,<end_line>
+    and I had nothing to do anyway so<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -127,12 +142,12 @@
       親方が看病してて<end_line>
       わたしたちはジャマだって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uh, well<three_dots><end_line>
     Master said we were in the way,<end_line>
     and I had nothing to do anyway so<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -173,6 +188,11 @@
       ミューノだって熱出るくらい<end_line>
       大変なことがあったんだろ？<end_line>
     </sjis>
+    <ascii>
+    Don't worry about it.<end_line>
+    Murno, you got a fever because<end_line>
+    you wore yourself out, didn't you?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -180,12 +200,12 @@
       ミューノだって熱出るくらい<end_line>
       大変なことがあったんでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't worry about it.<end_line>
     Murno, you got a fever because<end_line>
     you wore yourself out, didn't you?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 01/046_25025260_17ddaec.xml
+++ b/Day 01/046_25025260_17ddaec.xml
@@ -77,15 +77,18 @@
     <sjis>
       よかったな、<partner><end_line>
     </sjis>
+    <ascii>
+    That's great!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よかったね、<partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's great!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -111,17 +114,21 @@
       な、なんだよ<end_line>
       あらたまって<three_dots><end_line>
     </sjis>
+    <ascii>
+    Wh-What's up with you?<end_line>
+    You sound almost normal<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な、なによ<end_line>
       あらたまって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wh-What's up with you?<end_line>
     You sound almost normal<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -160,6 +167,11 @@
       <partner>だってがんばったぜ<end_line>
       ザックにも手を貸してもらったし<end_line>
     </sjis>
+    <ascii>
+    Well, it wasn't just me,<end_line>
+    you worked hard too.<end_line>
+    And even Zakk helped out a lot.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -167,12 +179,12 @@
       <partner>だってがんばったよ<end_line>
       ザックにも手を貸してもらったし<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, it wasn't just me,<end_line>
     you worked hard too.<end_line>
     And even Zakk helped out a lot.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -269,17 +281,22 @@
     <sjis>
       そう言われるのもハラ立つけどな<end_line>
     </sjis>
+    <ascii>
+    <three_dots><end_line>
+    You know, sometimes you<end_line>
+    can be very irritating<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そう言われるのもハラ立つけどね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots><end_line>
     You know, sometimes you<end_line>
     can be very irritating<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -332,15 +349,18 @@
     <sjis>
       ああ、バッチリだぜ！<end_line>
     </sjis>
+    <ascii>
+    Yeah, exactly!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん、バッチリだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, exactly!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -364,17 +384,21 @@
       これからもよろしくたのむぜ<end_line>
       <partner><end_line>
     </sjis>
+    <ascii>
+    Let's keep getting along,<end_line>
+    <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       これからもよろしくたのむね<end_line>
       <partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Let's keep getting along,<end_line>
     <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -424,15 +448,18 @@
     <sjis>
       よかったな、<partner><end_line>
     </sjis>
+    <ascii>
+    That's great!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よかったね、<partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's great!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -542,16 +569,19 @@
       なんだよ<end_line>
       ハッキリ言うなぁ<end_line>
     </sjis>
+    <ascii>
+    Way to be blunt about it<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ<end_line>
       ハッキリ言うなぁ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Way to be blunt about it<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -665,17 +695,21 @@
       これからもよろしくたのむぜ<end_line>
       <partner><end_line>
     </sjis>
+    <ascii>
+    Let's keep getting along,<end_line>
+    <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       これからもよろしくたのむね<end_line>
       <partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Let's keep getting along,<end_line>
     <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -754,17 +788,21 @@
       なんだよ？<end_line>
       なんか用か？<end_line>
     </sjis>
+    <ascii>
+    What?<end_line>
+    Need something?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ？<end_line>
       なにか用？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What?<end_line>
     Need something?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -867,6 +905,11 @@
       素直になれよ<end_line>
       子供なんだから<three_dots><end_line>
     </sjis>
+    <ascii>
+    This again<three_dots><end_line>
+    No need to be so embarrassed.<end_line>
+    I guess you're still a kid.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -874,12 +917,12 @@
       素直じゃないんだから<end_line>
       子供なのに<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This again<three_dots><end_line>
     No need to be so embarrassed.<end_line>
     I guess you're still a kid.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -934,17 +977,21 @@
       でも大人だったらよけいに<end_line>
       もっと大人らしくしろよ！<end_line>
     </sjis>
+    <ascii>
+    But hey, if you're an adult,<end_line>
+    then you should act like one!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       でも大人だったらよけいに<end_line>
       もっと大人らしくしてよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     But hey, if you're an adult,<end_line>
     then you should act like one!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -969,6 +1016,11 @@
       <partner>がいてくれて<end_line>
       本当に助かってたんだ！<end_line>
     </sjis>
+    <ascii>
+    I got the Kicca Fruit only<end_line>
+    because you were there.<end_line>
+    You're a big help!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -976,12 +1028,12 @@
       <partner>がいてくれて<end_line>
       本当に助かってたのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I got the Kicca Fruit only<end_line>
     because you were there.<end_line>
     You're a big help!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1010,6 +1062,10 @@
       がんばってた<end_line>
       オレはそう思うぞ<end_line>
     </sjis>
+    <ascii>
+    So I think that you did<end_line>
+    work hard for this too.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1017,11 +1073,11 @@
       がんばってた<end_line>
       わたしはそう思うよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So I think that you did<end_line>
     work hard for this too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1203,15 +1259,18 @@
     <sjis>
       よかったな、<partner><end_line>
     </sjis>
+    <ascii>
+    That's great!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よかったね、<partner><end_line>
     </sjis>
-  </female>
     <ascii>
     That's great!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1237,17 +1296,21 @@
       そんなのいいよ<end_line>
       オレも好きでやったんだからさ<end_line>
     </sjis>
+    <ascii>
+    Don't worry about it,<end_line>
+    I did it cause I wanted to.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなのいいよ<end_line>
       わたしも好きでやったんだからさ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't worry about it,<end_line>
     I did it cause I wanted to.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1313,6 +1376,10 @@
       親方がミューノをみててくれたり<end_line>
       ザックが手伝ってくれたからだぜ<end_line>
     </sjis>
+    <ascii>
+    A-Anyway, Master and Zakk<end_line>
+    were there to help us out too.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1320,11 +1387,11 @@
       親方がミューノをみててくれたり<end_line>
       ザックが手伝ってくれたからだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     A-Anyway, Master and Zakk<end_line>
     were there to help us out too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1362,16 +1429,19 @@
       <partner><three_dots><end_line>
       お前<three_dots><end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner><three_dots><end_line>
       あなた<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1396,15 +1466,18 @@
     <sjis>
       そっちか！？<end_line>
     </sjis>
+    <ascii>
+    THAT'S what you care about!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっちなの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     THAT'S what you care about!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1415,17 +1488,21 @@
       まあ、親方のためにもさ<end_line>
       いっしょに修行をがんばろうぜ<end_line>
     </sjis>
+    <ascii>
+    Well anyway, let's just<end_line>
+    do our best with training.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       まあ、親方のためにもさ<end_line>
       いっしょに修行をがんばろうね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well anyway, let's just<end_line>
     do our best with training.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1448,6 +1525,11 @@
       <partner>がいてくれて<end_line>
       本当に助かってたんだよ！<end_line>
     </sjis>
+    <ascii>
+    You know,<end_line>
+    having you around<end_line>
+    is a huge help!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1455,12 +1537,12 @@
       <partner>がいてくれて<end_line>
       本当に助かってたんだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You know,<end_line>
     having you around<end_line>
     is a huge help!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1498,17 +1580,21 @@
       じゃ、これからもよろしくたのむぜ<end_line>
       <partner><end_line>
     </sjis>
+    <ascii>
+    Then, let's keep getting along,<end_line>
+    <partner><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       じゃ、これからもよろしくたのむね<end_line>
       <partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Then, let's keep getting along,<end_line>
     <partner><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 01/047_25029148_17dea1c.xml
+++ b/Day 01/047_25029148_17dea1c.xml
@@ -117,6 +117,11 @@
       絶対持って行くさ！<end_line>
       看病だってするよ！<end_line>
     </sjis>
+    <ascii>
+    T-That's not true!<end_line>
+    Of course I would!<end_line>
+    I'd even nurse you personally!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -124,12 +129,12 @@
       絶対持って行くって！<end_line>
       看病だってするよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     T-That's not true!<end_line>
     Of course I would!<end_line>
     I'd even nurse you personally!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -156,6 +161,11 @@
       でも、今まで親方が病気になったの<end_line>
       見たことない<three_dots><end_line>
     </sjis>
+    <ascii>
+    Leave it to me!<end_line>
+    You know, I've never actually<end_line>
+    seen you sick before, Master.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -163,12 +173,12 @@
       でも、今まで親方が病気になったの<end_line>
       見たことない<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Leave it to me!<end_line>
     You know, I've never actually<end_line>
     seen you sick before, Master.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -179,17 +189,21 @@
       いった！<end_line>
       なんでだよ！？<end_line>
     </sjis>
+    <ascii>
+    Ow!<end_line>
+    What was that for?!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       いった！<end_line>
       なんでよ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ow!<end_line>
     What was that for?!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 01/048_25030796_17df08c.xml
+++ b/Day 01/048_25030796_17df08c.xml
@@ -106,6 +106,11 @@
       ちゃんとザックの薬のんだのか？<end_line>
       約束だぜ？<end_line>
     </sjis>
+    <ascii>
+    It's okay if you're feeling better.<end_line>
+    Did you drink Zakk's medicine?<end_line>
+    You promised, you know.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -113,12 +118,12 @@
       ちゃんとザックの薬のんだ？<end_line>
       約束だよ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's okay if you're feeling better.<end_line>
     Did you drink Zakk's medicine?<end_line>
     You promised, you know.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -140,17 +145,21 @@
       じゃあ、それが効いたんだな<end_line>
       ザックもよろこぶぞ<end_line>
     </sjis>
+    <ascii>
+    I guess it worked then.<end_line>
+    Zakk will be happy to hear that.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       じゃあ、それが効いたんだね<end_line>
       ザックもよろこぶよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I guess it worked then.<end_line>
     Zakk will be happy to hear that.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -172,17 +181,21 @@
       でも、たおれるまで仕事とはね<end_line>
       お前も大変なんだなぁ<three_dots><end_line>
     </sjis>
+    <ascii>
+    But man, you work way too hard<three_dots><end_line>
+    I guess you've got your reasons.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       でも、たおれるまで仕事とは<three_dots><end_line>
       あなたも大変なんだね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     But man, you work way too hard<three_dots><end_line>
     I guess you've got your reasons.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -229,6 +242,10 @@
       なんだよ、その言い方<end_line>
       知らないから聞いただけだろ？<end_line>
     </sjis>
+    <ascii>
+    Hey, calm down.<end_line>
+    I was just curious<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -236,11 +253,11 @@
       なによ、その言い方<end_line>
       知らないから聞いただけでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, calm down.<end_line>
     I was just curious<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 01/24319036_173143c.xml
+++ b/Day 01/24319036_173143c.xml
@@ -30,24 +30,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			使い込んだ武器を解体して<end_line>
 			もう一度鍛え直すと<end_line>
 			もっと強い武器ができるんだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			使い込んだ武器を解体して<end_line>
-			もう一度鍛え直すと<end_line>
-			もっと強い武器ができるんだよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     If you disassemble a weapon you've<end_line>
     used for a while and reforge it,<end_line>
     the it'll come out stronger.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			使い込んだ武器を解体して<end_line>
+			もう一度鍛え直すと<end_line>
+			もっと強い武器ができるんだよ<end_line>
+		</sjis>
+    <ascii>
+    If you disassemble a weapon you've<end_line>
+    used for a while and reforge it,<end_line>
+    the it'll come out stronger.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -71,23 +76,27 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そっ、そんなことないぞ！<end_line>
 			お前も修行をつめば<end_line>
 			わかるって！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    U-Uh, this is for practice!<end_line>
+    You'll understand if you just do it!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そっ、そんなことないよ！<end_line>
 			あなたも修行をつめば<end_line>
 			わかるって！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     U-Uh, this is for practice!<end_line>
     You'll understand if you just do it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -121,24 +130,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			使い込んだ武器を解体して<end_line>
 			もう一度鍛え直すと<end_line>
 			もっと強い武器ができるんだぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			使い込んだ武器を解体して<end_line>
-			もう一度鍛え直すと<end_line>
-			もっと強い武器ができるんだよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     If you disassemble a weapon you've<end_line>
     used for a while and reforge it,<end_line>
     the it'll come out stronger.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			使い込んだ武器を解体して<end_line>
+			もう一度鍛え直すと<end_line>
+			もっと強い武器ができるんだよ<end_line>
+		</sjis>
+    <ascii>
+    If you disassemble a weapon you've<end_line>
+    used for a while and reforge it,<end_line>
+    the it'll come out stronger.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -162,23 +176,27 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			そっ、そんなことないぞ！<end_line>
 			お前も修行をつめば<end_line>
 			わかるって！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    U-Uh, this is for practice!<end_line>
+    You'll understand if you just do it!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そっ、そんなことないよ！<end_line>
 			あなたも修行をつめば<end_line>
 			わかるって！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     U-Uh, this is for practice!<end_line>
     You'll understand if you just do it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -212,24 +230,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			でも使い込んだ武器を解体して<end_line>
 			もう一度鍛え直すと<end_line>
 			もっと強い武器ができるんだぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも使い込んだ武器を解体して<end_line>
-			もう一度鍛え直すと<end_line>
-			もっと強い武器ができるんだよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     But if you disassemble a weapon<end_line>
     you've used for a while and <end_line>
     reforge it, it'll come out stronger.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でも使い込んだ武器を解体して<end_line>
+			もう一度鍛え直すと<end_line>
+			もっと強い武器ができるんだよ<end_line>
+		</sjis>
+    <ascii>
+    But if you disassemble a weapon<end_line>
+    you've used for a while and <end_line>
+    reforge it, it'll come out stronger.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -251,23 +274,27 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			じ、十分使い込んでるよ！<end_line>
 			お前も修行をつめば<end_line>
 			わかるって！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    I-It's good enough!<end_line>
+    This is just for practice anyway!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			じ、十分使い込んでますっ！<end_line>
 			あなたも修行をつめば<end_line>
 			わかるって！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I-It's good enough!<end_line>
     This is just for practice anyway!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -300,24 +327,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			でも使い込んだ武器を解体して<end_line>
 			もう一度鍛え直すと<end_line>
 			もっと強い武器ができるんだぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも使い込んだ武器を解体して<end_line>
-			もう一度鍛え直すと<end_line>
-			もっと強い武器ができるんだよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     But if you disassemble a weapon<end_line>
     you've used for a while and <end_line>
     reforge it, it'll come out stronger.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でも使い込んだ武器を解体して<end_line>
+			もう一度鍛え直すと<end_line>
+			もっと強い武器ができるんだよ<end_line>
+		</sjis>
+    <ascii>
+    But if you disassemble a weapon<end_line>
+    you've used for a while and <end_line>
+    reforge it, it'll come out stronger.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -339,19 +371,19 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そっ、そんなことないぞ！<end_line>
 			お前も修行をつめば<end_line>
 			わかるって！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			そっ、そんなことないよ！<end_line>
 			あなたも修行をつめば<end_line>
 			わかるって！<end_line>
 		</sjis>
-	</female>
+  </female>
 </dialogue>
   <ascii>
     U-Uh, this is for practice!<end_line>
@@ -433,21 +465,25 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			まあな<end_line>
 			でも、それが修行だよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			まあね<end_line>
-			でも、それが修行なの<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I guess.<end_line>
     That's practice for you.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			まあね<end_line>
+			でも、それが修行なの<end_line>
+		</sjis>
+    <ascii>
+    I guess.<end_line>
+    That's practice for you.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -493,21 +529,25 @@
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なに言ってんだよ！<end_line>
 			お前もいっしょにやるんだよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なに言ってるの！<end_line>
-			あなたもいっしょにやるの<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey, come on!<end_line>
     You have to help me!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なに言ってるの！<end_line>
+			あなたもいっしょにやるの<end_line>
+		</sjis>
+    <ascii>
+    Hey, come on!<end_line>
+    You have to help me!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -538,18 +578,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			それが修行だよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			それが修行なの<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, we are practicing.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			それが修行なの<end_line>
+		</sjis>
+    <ascii>
+    Well, we are practicing.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -607,18 +650,21 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			素直なんだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			素直なのね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     when it comes to Murno<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			素直なのね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    when it comes to Murno<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -652,24 +698,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			いっしょに行った方が<end_line>
 			ミューノが安心するって<end_line>
 			親方が言ってただろ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いっしょに行った方が<end_line>
-			ミューノが安心するって<end_line>
-			親方が言ってたでしょ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Murno would be more relaxed<end_line>
     if we went together.<end_line>
     Didn't Master say so?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いっしょに行った方が<end_line>
+			ミューノが安心するって<end_line>
+			親方が言ってたでしょ<end_line>
+		</sjis>
+    <ascii>
+    Murno would be more relaxed<end_line>
+    if we went together.<end_line>
+    Didn't Master say so?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -693,18 +744,21 @@
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、それ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     W-What's that supposed to mean?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ<end_line>
+		</sjis>
+    <ascii>
+    W-What's that supposed to mean?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -737,23 +791,27 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ<end_line>
 			そんなカオしてると<end_line>
 			ミューノが心配するぞ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Don't make that face.<end_line>
+    Murno will be worried about you.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			なによ<end_line>
 			そんなカオしてると<end_line>
 			ミューノが心配するよ？<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Don't make that face.<end_line>
     Murno will be worried about you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -776,24 +834,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なるほど<end_line>
 			いつもどおりのカオでミューノを<end_line>
 			安心させようってことだな？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なるほど<end_line>
-			いつもどおりのカオでミューノを<end_line>
-			安心させようってワケね？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I see.<end_line>
     You're trying to act normal<end_line>
     so she can relax, right?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なるほど<end_line>
+			いつもどおりのカオでミューノを<end_line>
+			安心させようってワケね？<end_line>
+		</sjis>
+    <ascii>
+    I see.<end_line>
+    You're trying to act normal<end_line>
+    so she can relax, right?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -849,24 +912,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ちょ、ひっぱるなよ<end_line>
 			あわてなくてもミューノは<end_line>
 			逃げないよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ちょ、ひっぱらないで！<end_line>
-			あわてなくてもミューノは<end_line>
-			逃げないってば！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey, don't pull my arm!<end_line>
     No need to rush,<end_line>
     I'm sure she's fine!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ちょ、ひっぱらないで！<end_line>
+			あわてなくてもミューノは<end_line>
+			逃げないってば！<end_line>
+		</sjis>
+    <ascii>
+    Hey, don't pull my arm!<end_line>
+    No need to rush,<end_line>
+    I'm sure she's fine!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -913,24 +981,29 @@
 	<portrait_l entry="player" eye="happy" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノの事なら<end_line>
 			親方にまかせておけば<end_line>
 			大丈夫だって<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノの事なら<end_line>
-			親方にまかせておけば<end_line>
-			大丈夫だよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm sure Master will<end_line>
     take care of Murno.<end_line>
     Don't worry about it.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノの事なら<end_line>
+			親方にまかせておけば<end_line>
+			大丈夫だよ<end_line>
+		</sjis>
+    <ascii>
+    I'm sure Master will<end_line>
+    take care of Murno.<end_line>
+    Don't worry about it.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -950,21 +1023,25 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			親方はああ見えても<end_line>
 			面倒見はいいから大丈夫だって<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			親方はあんな風だけど<end_line>
-			面倒見はいいから大丈夫だよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Despite how she looks,<end_line>
     she's good at tending to others.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			親方はあんな風だけど<end_line>
+			面倒見はいいから大丈夫だよ<end_line>
+		</sjis>
+    <ascii>
+    Despite how she looks,<end_line>
+    she's good at tending to others.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -984,20 +1061,23 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ<end_line>
 			ジッと見て<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Don't just stare at me<three_dots><end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			なによ<end_line>
 			ジロジロ見ないでよ<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Don't just stare at me<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1019,20 +1099,23 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ど、どういうイミだよ<end_line>
 			それ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    What's that supposed to mean?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			ど、どういうイミよ<end_line>
 			それ？<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What's that supposed to mean?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1064,24 +1147,29 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノの事？<end_line>
 			たしかに、親方は口は悪いけど<end_line>
 			面倒見はいいから大丈夫だって<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノの事？<end_line>
-			まあ、親方って口は悪いけど<end_line>
-			面倒見はいいから大丈夫だよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     About Murno?<end_line>
     Sure, Master can be rude,<end_line>
     but she's good at tending to others.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノの事？<end_line>
+			まあ、親方って口は悪いけど<end_line>
+			面倒見はいいから大丈夫だよ<end_line>
+		</sjis>
+    <ascii>
+    About Murno?<end_line>
+    Sure, Master can be rude,<end_line>
+    but she's good at tending to others.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1105,20 +1193,23 @@
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ど、どういうイミだよ<end_line>
 			それ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    What's that supposed to mean?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			ど、どういうイミよ<end_line>
 			それ？<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What's that supposed to mean?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1150,18 +1241,21 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノの事が気になるのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノの事が気になる？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Worried about Murno?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノの事が気になる？<end_line>
+		</sjis>
+    <ascii>
+    Worried about Murno?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1183,24 +1277,29 @@
 	<portrait_l entry="player" eye="serious" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			あの女って、親方のこと？<end_line>
 			それって要するに<end_line>
 			ミューノが心配ってことだろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あの女って、親方のこと？<end_line>
-			それって要するに<end_line>
-			ミューノが心配ってことだよね？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You mean Master?<end_line>
     Doesn't that mean you really<end_line>
     are worried about Murno?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あの女って、親方のこと？<end_line>
+			それって要するに<end_line>
+			ミューノが心配ってことだよね？<end_line>
+		</sjis>
+    <ascii>
+    You mean Master?<end_line>
+    Doesn't that mean you really<end_line>
+    are worried about Murno?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1257,18 +1356,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノの事が気になるのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノの事が気になる？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Worried about Murno?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノの事が気になる？<end_line>
+		</sjis>
+    <ascii>
+    Worried about Murno?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1290,24 +1392,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			大丈夫だって<end_line>
 			たしかに、親方はチョット短気だけど<end_line>
 			面倒見はいいから<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			大丈夫だよ<end_line>
-			まあ、親方ってチョット短気だけど<end_line>
-			面倒見はいいんだから<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     It'll be fine.<end_line>
     Yeah, she's a bit short tempered,<end_line>
     but she's good at tending to others.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			大丈夫だよ<end_line>
+			まあ、親方ってチョット短気だけど<end_line>
+			面倒見はいいんだから<end_line>
+		</sjis>
+    <ascii>
+    It'll be fine.<end_line>
+    Yeah, she's a bit short tempered,<end_line>
+    but she's good at tending to others.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1457,18 +1564,21 @@
 	<portrait_l entry="player" eye="happy" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			素直なんだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			素直なのね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     care about, huh<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			素直なのね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    care about, huh<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1516,21 +1626,25 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			言うことはすごく<end_line>
 			カッコイイな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			言うことはすごく<end_line>
-			カッコイイね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     The way you say things<end_line>
     always sounds so cool.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			言うことはすごく<end_line>
+			カッコイイね<end_line>
+		</sjis>
+    <ascii>
+    The way you say things<end_line>
+    always sounds so cool.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1576,24 +1690,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノが心配なのはわかるけどさ<end_line>
 			戻ってもジャマになるだけだし<end_line>
 			今は修行しようぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノが心配なのはわかるけど<end_line>
-			戻ってもジャマになるだけだし<end_line>
-			今は修行しようよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I know you're worried about Murno,<end_line>
     but we'd just be a bother.<end_line>
     Bear with it for now.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノが心配なのはわかるけど<end_line>
+			戻ってもジャマになるだけだし<end_line>
+			今は修行しようよ<end_line>
+		</sjis>
+    <ascii>
+    I know you're worried about Murno,<end_line>
+    but we'd just be a bother.<end_line>
+    Bear with it for now.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1702,21 +1821,25 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ザックにハンマーを届けよう！<end_line>
 			さっき駅に行くって言ってたぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ザックにハンマーを届けよう！<end_line>
-			さっき駅に行くって言ってたよね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I have to return Zakk's hammer!<end_line>
     He said he was going to the station.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ザックにハンマーを届けよう！<end_line>
+			さっき駅に行くって言ってたよね<end_line>
+		</sjis>
+    <ascii>
+    I have to return Zakk's hammer!<end_line>
+    He said he was going to the station.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1800,21 +1923,25 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ザックにハンマーを届けよう！<end_line>
 			さっき駅に行くって言ってたぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ザックにハンマーを届けよう！<end_line>
-			さっき駅に行くって言ってたよね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I have to return Zakk's hammer!<end_line>
     He said he was going to the station.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ザックにハンマーを届けよう！<end_line>
+			さっき駅に行くって言ってたよね<end_line>
+		</sjis>
+    <ascii>
+    I have to return Zakk's hammer!<end_line>
+    He said he was going to the station.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1898,21 +2025,25 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ザックにハンマーを届けよう！<end_line>
 			さっき駅に行くって言ってたぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ザックにハンマーを届けよう！<end_line>
-			さっき駅に行くって言ってたよね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I have to return Zakk's hammer!<end_line>
     He said he was going to the station.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ザックにハンマーを届けよう！<end_line>
+			さっき駅に行くって言ってたよね<end_line>
+		</sjis>
+    <ascii>
+    I have to return Zakk's hammer!<end_line>
+    He said he was going to the station.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1995,21 +2126,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ザックにハンマーを届けよう！<end_line>
 			さっき駅に行くって言ってたぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ザックにハンマーを届けよう！<end_line>
-			さっき駅に行くって言ってたよね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I have to return Zakk's hammer!<end_line>
     He said he was going to the station.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ザックにハンマーを届けよう！<end_line>
+			さっき駅に行くって言ってたよね<end_line>
+		</sjis>
+    <ascii>
+    I have to return Zakk's hammer!<end_line>
+    He said he was going to the station.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2223,21 +2358,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんか素直だな<three_dots><end_line>
 			気味悪いぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			な、なんで素直なの？<end_line>
-			ちょっとこわいよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You didn't complain?<end_line>
     That's a first<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			な、なんで素直なの？<end_line>
+			ちょっとこわいよ<end_line>
+		</sjis>
+    <ascii>
+    You didn't complain?<end_line>
+    That's a first<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2377,21 +2516,25 @@
 	<portrait_l entry="player" eye="serious" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだぞ<end_line>
 			気をつけなきゃ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-			気をつけなきゃ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah<three_dots><end_line>
     We have to be careful<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+			気をつけなきゃ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Yeah<three_dots><end_line>
+    We have to be careful<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -2415,18 +2558,21 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			たのむよ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			たのむね、<partner>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm counting on you!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			たのむね、<partner>！<end_line>
+		</sjis>
+    <ascii>
+    I'm counting on you!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2450,21 +2596,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			へえ、わかるんだ<end_line>
 			やっぱり匂いとかでわかるのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			へえ、わかるんだ<end_line>
-			やっぱり匂いとかでわかるの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Oh, you can tell?<end_line>
     Do they smell or something?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			へえ、わかるんだ<end_line>
+			やっぱり匂いとかでわかるの？<end_line>
+		</sjis>
+    <ascii>
+    Oh, you can tell?<end_line>
+    Do they smell or something?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2550,21 +2700,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうなんだ<end_line>
 			ヒゲとか物音とかじゃないんだな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうなんだ<end_line>
-			ヒゲとか物音とかじゃないんだね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I see. So you're not using<end_line>
     your whiskers or hearing either.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうなんだ<end_line>
+			ヒゲとか物音とかじゃないんだね<end_line>
+		</sjis>
+    <ascii>
+    I see. So you're not using<end_line>
+    your whiskers or hearing either.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2602,21 +2756,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			おお！<end_line>
 			たのもしいな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			へえ！<end_line>
-			たのもしいね！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ohh!<end_line>
     How reliable!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			へえ！<end_line>
+			たのもしいね！<end_line>
+		</sjis>
+    <ascii>
+    Ohh!<end_line>
+    How reliable!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2638,18 +2796,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="stressed">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだって！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Even if they attack us!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ！？<end_line>
+		</sjis>
+    <ascii>
+    Even if they attack us!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2671,18 +2832,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+		</sjis>
+    <ascii>
+    Yeah.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2715,21 +2879,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			わかってるって<end_line>
 			よろしくたのむぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わかってるって<end_line>
-			よろしくたのむよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm sure it will.<end_line>
     I'm counting on you.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わかってるって<end_line>
+			よろしくたのむよ<end_line>
+		</sjis>
+    <ascii>
+    I'm sure it will.<end_line>
+    I'm counting on you.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">

--- a/Day 01/24324844_1732aec.xml
+++ b/Day 01/24324844_1732aec.xml
@@ -7,7 +7,7 @@
 		えっと<three_dots><end_line>
 		どっちの橋なら渡れそうだっけ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Umm<three_dots><end_line>
 		Which bridge did you say was fine?<end_line>
 	</ascii>
@@ -21,7 +21,7 @@
 		下ノ橋ハ大丈夫デス<end_line>
 		上ノ橋ハ問題ガアルヨウデス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The Bottom Bridge.<end_line>
 		The Upper Bridge Is Problematic.<end_line>
 	</ascii>
@@ -35,7 +35,7 @@
 		えっと<three_dots><end_line>
 		どっちの橋なら渡れそうだっけ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Umm<three_dots><end_line>
 		Which bridge did you say was fine?<end_line>
 	</ascii>
@@ -48,7 +48,7 @@
 	<sjis>
 		下の橋なら大丈夫じゃろう<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The bottom bridge should be fine.<end_line>
 	</ascii>
 </dialogue>
@@ -58,18 +58,21 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			橋に何かあるのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			橋に何かあるの？<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Is there something wrong?<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			橋に何かあるの？<end_line>
+		</sjis>
+    <ascii>
+		Is there something wrong?<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -80,7 +83,7 @@
 		ふ<three_dots><end_line>
 		行けばわかる<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hmph<three_dots><end_line>
 		You'll know soon enough.<end_line>
 	</ascii>
@@ -91,18 +94,21 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、それ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		That's not helpful at all!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ！<end_line>
+		</sjis>
+    <ascii>
+		That's not helpful at all!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -112,7 +118,7 @@
 		えっと<three_dots><end_line>
 		どっちの橋なら渡れそうだっけ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Umm<three_dots><end_line>
 		Which bridge did you say was fine?<end_line>
 	</ascii>
@@ -125,7 +131,7 @@
 		下の橋ですわ<end_line>
 		上の橋はイヤな予感がするんです<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The bottom bridge.<end_line>
 		I don't trust the other one<three_dots><end_line>
 	</ascii>
@@ -138,7 +144,7 @@
 	<sjis>
 		ザックのところへ行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's go find Zakk!<end_line>
 	</ascii>
 </dialogue>
@@ -150,7 +156,7 @@
 	<sjis>
 		了解デス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Roger.<end_line>
 	</ascii>
 </dialogue>
@@ -163,7 +169,7 @@
 		けど、橋はくずれていたのに<end_line>
 		なんで落ちるかな？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Really though, how could he fall in<end_line>
 		when the bridge was clearly broken?<end_line>
 	</ascii>
@@ -177,7 +183,7 @@
 		<three_dots><end_line>
 		アナタモ　落チマシタガ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 		Did You Not Also Fall In?<end_line>
 	</ascii>
@@ -188,24 +194,29 @@
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			オレが渡った時はまだ<end_line>
 			くずれてなかったし<three_dots><end_line>
 			仕方ないだろ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしの時はまだ<end_line>
-			くずれてなかったんだから<end_line>
-			仕方ないでしょ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Well it hadn't collapsed<end_line>
 		when I walked on it!<end_line>
 		What am I supposed to do!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしの時はまだ<end_line>
+			くずれてなかったんだから<end_line>
+			仕方ないでしょ！<end_line>
+		</sjis>
+    <ascii>
+		Well it hadn't collapsed<end_line>
+		when I walked on it!<end_line>
+		What am I supposed to do!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -215,7 +226,7 @@
 	<sjis>
 		落チタ事ニ　変ワリハアリマセン<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		However, You Still Fell In.<end_line>
 	</ascii>
 </dialogue>
@@ -227,7 +238,7 @@
 	<sjis>
 		むっ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ugh<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -239,7 +250,7 @@
 	<sjis>
 		ザックのところへ行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's go find Zakk!<end_line>
 	</ascii>
 </dialogue>
@@ -251,7 +262,7 @@
 	<sjis>
 		うむ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Mhm.<end_line>
 	</ascii>
 </dialogue>
@@ -264,7 +275,7 @@
 		けど、橋はくずれていたのに<end_line>
 		なんで落ちるかな？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Really though, how could he fall in<end_line>
 		when the bridge was clearly broken?<end_line>
 	</ascii>
@@ -278,7 +289,7 @@
 		何を言っておる<end_line>
 		おぬしも落ちたじゃろ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hmm?<end_line>
 		Did you not also fall in?<end_line>
 	</ascii>
@@ -289,24 +300,29 @@
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			オレが渡った時はまだ<end_line>
 			くずれてなかったし<three_dots><end_line>
 			仕方ないだろ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしの時はまだ<end_line>
-			くずれてなかったんだから<end_line>
-			仕方ないでしょ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Well it hadn't collapsed<end_line>
 		when I walked on it!<end_line>
 		What am I supposed to do!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしの時はまだ<end_line>
+			くずれてなかったんだから<end_line>
+			仕方ないでしょ！<end_line>
+		</sjis>
+    <ascii>
+		Well it hadn't collapsed<end_line>
+		when I walked on it!<end_line>
+		What am I supposed to do!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -317,7 +333,7 @@
 		やれやれ、五十歩百歩と言ってな<end_line>
 		落ちた事に変わりは<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Perhaps, but that does not change<end_line>
 		the fact that you did<three_dots><end_line>
 	</ascii>
@@ -328,21 +344,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			はやく行こうぜ、<partner><end_line>
 			置いてくぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			はやく行こうよ、<partner><end_line>
-			置いてっちゃうよ<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Hurry it up, <partner>,<end_line>
 		or I'll leave you behind.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			はやく行こうよ、<partner><end_line>
+			置いてっちゃうよ<end_line>
+		</sjis>
+    <ascii>
+		Hurry it up, <partner>,<end_line>
+		or I'll leave you behind.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -352,7 +372,7 @@
 	<sjis>
 		ザックのところへ行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's go find Zakk!<end_line>
 	</ascii>
 </dialogue>
@@ -364,7 +384,7 @@
 	<sjis>
 		<three_dots>好きにしろ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Whatever you say.<end_line>
 	</ascii>
 </dialogue>
@@ -377,7 +397,7 @@
 		けど、橋はくずれていたのに<end_line>
 		なんで落ちるかな？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Really though, how could he fall in<end_line>
 		when the bridge was clearly broken?<end_line>
 	</ascii>
@@ -392,7 +412,7 @@
 		だが、私としては<end_line>
 		なかなか楽しいぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>No idea.<end_line>
 		But I found it quite entertaining.<end_line>
 	</ascii>
@@ -403,18 +423,21 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、それ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Hey!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ！<end_line>
+		</sjis>
+    <ascii>
+		Hey!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -426,7 +449,7 @@
 		どうした？<end_line>
 		早く行った方がいいんじゃないのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Heh<three_dots><end_line>
 		What's wrong?<end_line>
 		Didn't you want to help him?<end_line>
@@ -438,21 +461,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			待てよ！<end_line>
 			まだ話は終わってないぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			待ってよ！<end_line>
-			まだ話は終わってないってば<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Wait!<end_line>
 		This conversation isn't over!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			待ってよ！<end_line>
+			まだ話は終わってないってば<end_line>
+		</sjis>
+    <ascii>
+		Wait!<end_line>
+		This conversation isn't over!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -461,7 +488,7 @@
 	<sjis>
 		ザックのところへ行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's go find Zakk!<end_line>
 	</ascii>
 </dialogue>
@@ -472,7 +499,7 @@
 	<sjis>
 		そうですね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Okay.<end_line>
 	</ascii>
 </dialogue>
@@ -483,8 +510,8 @@
 	<sjis>
 		けど、橋はくずれていたのに<end_line>
 		なんで落ちるかな？<end_line>
-	</sjis>	
-	<ascii>
+	</sjis>
+  <ascii>
 		Really though, how could he fall in<end_line>
 		when the bridge was clearly broken?<end_line>
 	</ascii>
@@ -497,7 +524,7 @@
 		あなたのように、注意力が<end_line>
 		足りていない証拠ですわ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		He is not aware of his<end_line>
 		surroundings, just like you.<end_line>
 	</ascii>
@@ -507,24 +534,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			オレが渡った時はまだ<end_line>
 			くずれてなかったし<three_dots><end_line>
 			仕方ないだろ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしの時はまだ<end_line>
-			くずれてなかったんだから<end_line>
-			仕方ないでしょ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Well it hadn't collapsed<end_line>
 		when I walked on it!<end_line>
 		What am I supposed to do!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしの時はまだ<end_line>
+			くずれてなかったんだから<end_line>
+			仕方ないでしょ！<end_line>
+		</sjis>
+    <ascii>
+		Well it hadn't collapsed<end_line>
+		when I walked on it!<end_line>
+		What am I supposed to do!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -535,7 +567,7 @@
 		落ちた事に変わりは<end_line>
 		ありませんわ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That does not change<end_line>
 		the fact that you<end_line>
 		also fell in.<end_line>
@@ -550,7 +582,7 @@
 		注意深く行動して下さいね！<end_line>
 		わかりましたか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Take a lesson from me and<end_line>
 		proceed with care!<end_line>
 		Understood?<end_line>
@@ -563,7 +595,7 @@
 	<sjis>
 		<partner>を見習う<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Learn from <partner><three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -574,7 +606,7 @@
 	<sjis>
 		わかりましたか！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Understood!?<end_line>
 	</ascii>
 </dialogue>
@@ -585,7 +617,7 @@
 	<sjis>
 		は、はい<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Y-yeah<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -595,24 +627,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			キッカの実はマニグ採掘場の<end_line>
 			奥の森にあるみたいだ<end_line>
 			行ってみよう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			キッカの実はマニグ採掘場の<end_line>
-			奥の森にあるみたい<end_line>
-			行ってみよう<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		We'll find the Kicca Ffuit in<end_line>
 		the forest past Manig Mine.<end_line>
 		Let's go.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			キッカの実はマニグ採掘場の<end_line>
+			奥の森にあるみたい<end_line>
+			行ってみよう<end_line>
+		</sjis>
+    <ascii>
+		We'll find the Kicca Ffuit in<end_line>
+		the forest past Manig Mine.<end_line>
+		Let's go.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -624,7 +661,7 @@
 		アリマセン<end_line>
 		ドンナ果物デスカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No Data Found On<end_line>
 		Kicca Fruit.<end_line>
 		What Kind Of Fruit Is It?<end_line>
@@ -636,24 +673,29 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだなぁ<three_dots><end_line>
 			甘いのも、しぶいのもあるんだ<end_line>
 			オレはドロドロくらいが好きだな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだなぁ<three_dots><end_line>
-			甘いのも、しぶいのもあるよ<end_line>
-			わたしはドロドロくらいが好き<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Let's see<three_dots><end_line>
 		It's sweet, but also bitter.<end_line>
 		I like how the juice is syrupy.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだなぁ<three_dots><end_line>
+			甘いのも、しぶいのもあるよ<end_line>
+			わたしはドロドロくらいが好き<end_line>
+		</sjis>
+    <ascii>
+		Let's see<three_dots><end_line>
+		It's sweet, but also bitter.<end_line>
+		I like how the juice is syrupy.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -665,7 +707,7 @@
 		どろどろガ　オイシイ<three_dots><end_line>
 		ワカリマセン<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Sweet, Bitter,<end_line>
 		Syrupy, Tasty<three_dots><end_line>
 		I Do Not Understand<three_dots><end_line>
@@ -677,24 +719,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ま、おいしい果物だな<end_line>
 			あれから薬ができるなんて<end_line>
 			知らなかったけど<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ま、おいしい果物だね<end_line>
-			あれから薬ができるなんて<end_line>
-			知らなかったけど<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Anyway, its delicious.<end_line>
 		But I didnt know you could<end_line>
 		make medicine out of it.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			ま、おいしい果物だね<end_line>
+			あれから薬ができるなんて<end_line>
+			知らなかったけど<end_line>
+		</sjis>
+    <ascii>
+		Anyway, its delicious.<end_line>
+		But I didnt know you could<end_line>
+		make medicine out of it.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -702,24 +749,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			キッカの実はマニグ採掘場の<end_line>
 			奥の森にあるみたいだ<end_line>
 			行ってみよう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			キッカの実はマニグ採掘場の<end_line>
-			奥の森にあるみたい<end_line>
-			行ってみよう<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		We'll find the Kicca fruit in<end_line>
 		the forest past Manig Mine.<end_line>
 		Let's go.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			キッカの実はマニグ採掘場の<end_line>
+			奥の森にあるみたい<end_line>
+			行ってみよう<end_line>
+		</sjis>
+    <ascii>
+		We'll find the Kicca fruit in<end_line>
+		the forest past Manig Mine.<end_line>
+		Let's go.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -731,7 +783,7 @@
 		あまりくわしくなくての<three_dots><end_line>
 		一体どんなものなのじゃ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I don't know much<end_line>
 		about fruits<three_dots><end_line>
 		What kind of fruit is it?<end_line>
@@ -743,24 +795,29 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そうだなぁ<three_dots><end_line>
 			甘いのも、しぶいのもあるんだ<end_line>
 			オレはドロドロくらいが好きだな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだなぁ<three_dots><end_line>
-			甘いのも、しぶいのもあるよ<end_line>
-			わたしはドロドロくらいが好き<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Let's see<three_dots><end_line>
 		It's sweet, but also bitter.<end_line>
 		I like how the juice is syrupy.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだなぁ<three_dots><end_line>
+			甘いのも、しぶいのもあるよ<end_line>
+			わたしはドロドロくらいが好き<end_line>
+		</sjis>
+    <ascii>
+		Let's see<three_dots><end_line>
+		It's sweet, but also bitter.<end_line>
+		I like how the juice is syrupy.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -770,7 +827,7 @@
 	<sjis>
 		さっぱりわからん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's not very helpful.<end_line>
 	</ascii>
 </dialogue>
@@ -780,24 +837,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ま、おいしい果物だな<end_line>
 			あれから薬ができるなんて<end_line>
 			知らなかったけど<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ま、おいしい果物だよ<end_line>
-			あれから薬ができるなんて<end_line>
-			知らなかったけど<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Anyway, its delicious.<end_line>
 		But I didnt know you could<end_line>
 		make medicine out of it.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			ま、おいしい果物だよ<end_line>
+			あれから薬ができるなんて<end_line>
+			知らなかったけど<end_line>
+		</sjis>
+    <ascii>
+		Anyway, its delicious.<end_line>
+		But I didnt know you could<end_line>
+		make medicine out of it.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -805,24 +867,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			キッカの実はマニグ採掘場の<end_line>
 			奥の森にあるみたいだから<end_line>
 			さがすの手伝ってくれよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			キッカの実はマニグ採掘場の<end_line>
-			奥の森にあるみたいだから<end_line>
-			さがすの手伝ってね<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		We'll find the Kicca fruit in<end_line>
 		the forest past Manig Mine.<end_line>
 		Let's go.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			キッカの実はマニグ採掘場の<end_line>
+			奥の森にあるみたいだから<end_line>
+			さがすの手伝ってね<end_line>
+		</sjis>
+    <ascii>
+		We'll find the Kicca fruit in<end_line>
+		the forest past Manig Mine.<end_line>
+		Let's go.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -832,7 +899,7 @@
 	<sjis>
 		ムリだ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I can't.<end_line>
 	</ascii>
 </dialogue>
@@ -842,21 +909,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ！<end_line>
 			お前だって本当は<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ！<end_line>
-			あなただって本当は<three_dots><end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		What?<end_line>
 		Come on, I'm sure you really<three_dots><end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ！<end_line>
+			あなただって本当は<three_dots><end_line>
+		</sjis>
+    <ascii>
+		What?<end_line>
+		Come on, I'm sure you really<three_dots><end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -867,7 +938,7 @@
 		知らないからな<end_line>
 		キッカの実なんて<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I don't know what it is,<end_line>
 		this Kicca fruit.<end_line>
 	</ascii>
@@ -883,7 +954,7 @@
 		そうだなぁ<three_dots><end_line>
 		木になってて<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah, right<three_dots><end_line>
 		Let's see<three_dots><end_line>
 		It grows on trees<three_dots><end_line>
@@ -899,7 +970,7 @@
 		甘いのも、しぶいのもあるんだ<end_line>
 		オレはドロドロくらいが好きだな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's sweet, but also bitter.<end_line>
 		I like how the juice is syrupy.<end_line>
 	</ascii>
@@ -915,7 +986,7 @@
 		そうだなぁ<three_dots><end_line>
 		木になってて<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah, right<three_dots><end_line>
 		Let's see<three_dots><end_line>
 		It grows on trees<three_dots><end_line>
@@ -931,7 +1002,7 @@
 		甘いのも、しぶいのもあるよ<end_line>
 		わたしはドロドロくらいが好き<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's sweet, but also bitter.<end_line>
 		I like how the juice is syrupy.<end_line>
 	</ascii>
@@ -944,7 +1015,7 @@
 	<sjis>
 		さっぱりわからん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You lost me.<end_line>
 	</ascii>
 </dialogue>
@@ -953,24 +1024,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			キッカの実はマニグ採掘場の<end_line>
 			奥の森にあるみたいだ<end_line>
 			行ってみよう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			キッカの実はマニグ採掘場の<end_line>
-			奥の森にあるみたい<end_line>
-			行ってみよう<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		We'll find the Kicca fruit in<end_line>
 		the forest past Manig Mine.<end_line>
 		Let's go.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			キッカの実はマニグ採掘場の<end_line>
+			奥の森にあるみたい<end_line>
+			行ってみよう<end_line>
+		</sjis>
+    <ascii>
+		We'll find the Kicca fruit in<end_line>
+		the forest past Manig Mine.<end_line>
+		Let's go.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -981,7 +1057,7 @@
 		どんなものなんですか？<end_line>
 		こちらの果物にはくわしくなくて<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		By the way, what<end_line>
 		exactly is a Kicca fruit?<end_line>
 		I'm not familiar with fruits here.<end_line>
@@ -992,24 +1068,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだなぁ<three_dots><end_line>
 			甘いのも、しぶいのもあるんだ<end_line>
 			オレはドロドロくらいが好きだな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだなぁ<three_dots><end_line>
-			甘いのも、しぶいのもあるよ<end_line>
-			わたしはドロドロくらいが好き<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Let's see<three_dots><end_line>
 		It's sweet, but also bitter.<end_line>
 		I like how the juice is syrupy.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだなぁ<three_dots><end_line>
+			甘いのも、しぶいのもあるよ<end_line>
+			わたしはドロドロくらいが好き<end_line>
+		</sjis>
+    <ascii>
+		Let's see<three_dots><end_line>
+		It's sweet, but also bitter.<end_line>
+		I like how the juice is syrupy.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1018,7 +1099,7 @@
 	<sjis>
 		さっぱりわかりませんわ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's not helpful at all.<end_line>
 	</ascii>
 </dialogue>
@@ -1027,24 +1108,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ま、おいしい果物だな<end_line>
 			あれから薬ができるなんて<end_line>
 			知らなかったけど<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ま、おいしい果物だよ<end_line>
-			あれから薬ができるなんて<end_line>
-			知らなかったけど<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Anyway, its delicious.<end_line>
 		But I didnt know you could<end_line>
 		make medicine out of it.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			ま、おいしい果物だよ<end_line>
+			あれから薬ができるなんて<end_line>
+			知らなかったけど<end_line>
+		</sjis>
+    <ascii>
+		Anyway, its delicious.<end_line>
+		But I didnt know you could<end_line>
+		make medicine out of it.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1055,7 +1141,7 @@
 		マニグ採掘場の奥の森に<end_line>
 		大きなはぐれ召喚獣が！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There's a huge Stray in the<end_line>
 		forest past Manig Mine!<end_line>
 	</ascii>
@@ -1069,9 +1155,10 @@
 		ざっくトイウ　少年ガ　オソワレルト<end_line>
 		危険デス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The Boy Zakk Is In<end_line>
 		Danger Of Being Attacked.<end_line>
+</ascii>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1079,18 +1166,21 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			急ぐぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			急がなきゃ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Let's hurry!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			急がなきゃ！<end_line>
+		</sjis>
+    <ascii>
+		Let's hurry!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1101,7 +1191,7 @@
 		マニグ採掘場の奥の森に<end_line>
 		大きなはぐれ召喚獣が！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There's a huge Stray in the<end_line>
 		forest past Manig Mine!<end_line>
 	</ascii>
@@ -1115,7 +1205,7 @@
 		ザックという少年が<end_line>
 		おそわれるかもしれんぞ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Zakk may<end_line>
 		be in danger!<end_line>
 	</ascii>
@@ -1126,18 +1216,21 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			急ぐぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			急がなきゃ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Let's hurry!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			急がなきゃ！<end_line>
+		</sjis>
+    <ascii>
+		Let's hurry!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1148,7 +1241,7 @@
 		マニグ採掘場の奥の森に<end_line>
 		大きなはぐれ召喚獣が！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There's a huge Stray in the<end_line>
 		forest past Manig Mine!<end_line>
 	</ascii>
@@ -1163,7 +1256,7 @@
 		ザックというニンゲンも<end_line>
 		やられてしまうかもな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hmph<three_dots><end_line>
 		Zakk may not make it out<end_line>
 		if we leave him alone<three_dots><end_line>
@@ -1175,18 +1268,21 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			急ぐぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			急がなきゃ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Let's hurry!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			急がなきゃ！<end_line>
+		</sjis>
+    <ascii>
+		Let's hurry!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1196,7 +1292,7 @@
 		マニグ採掘場の奥の森に<end_line>
 		大きなはぐれ召喚獣が！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There's a huge Stray in the<end_line>
 		forest past Manig Mine!<end_line>
 	</ascii>
@@ -1210,7 +1306,7 @@
 		このままではザックという少年も<end_line>
 		あぶないですわ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Uu<three_dots><end_line>
 		That means Zakk must<end_line>
 		be in danger!<end_line>
@@ -1221,18 +1317,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			急ぐぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			急がなきゃ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Let's hurry!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			急がなきゃ！<end_line>
+		</sjis>
+    <ascii>
+		Let's hurry!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1242,7 +1341,7 @@
 	<sjis>
 		キッカの実をさがそう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now to find the Kicca fruit!<end_line>
 	</ascii>
 </dialogue>
@@ -1256,7 +1355,7 @@
 		私ハ　下ノ方ヲ　サガシマスカラ<end_line>
 		アナタハ　上ノ方ヲ　見テクダサイ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There Must Be A Remaining Tree.<end_line>
 		I Will Search Down Here.<end_line>
 		You Search The Upper Area.<end_line>
@@ -1268,24 +1367,29 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なるほど！<end_line>
 			言いたいことはよくわかった！<end_line>
 			上はオレにまかせておけって！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なるほど！<end_line>
-			言いたいことはよくわかったわ！<end_line>
-			上はわたしにまかせてよ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Got it!<end_line>
 		We're splitting up then!<end_line>
 		Leave it to me!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			なるほど！<end_line>
+			言いたいことはよくわかったわ！<end_line>
+			上はわたしにまかせてよ！<end_line>
+		</sjis>
+    <ascii>
+		Got it!<end_line>
+		We're splitting up then!<end_line>
+		Leave it to me!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1295,7 +1399,7 @@
 	<sjis>
 		キッカの実をさがそう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now to find the Kicca fruit!<end_line>
 	</ascii>
 </dialogue>
@@ -1305,18 +1409,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			たよりにしてるぜ、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			たよりにしてるよ、<partner><end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		I'm counting on you, <partner>.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			たよりにしてるよ、<partner><end_line>
+		</sjis>
+    <ascii>
+		I'm counting on you, <partner>.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1327,7 +1434,7 @@
 		しかしワガハイは<end_line>
 		どんな実なのか知らんのじゃ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I still don't know what<end_line>
 		this fruit looks like.<end_line>
 	</ascii>
@@ -1340,7 +1447,7 @@
 	<sjis>
 		甘いニオイだよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It smells sweet.<end_line>
 	</ascii>
 </dialogue>
@@ -1353,7 +1460,7 @@
 		ええい、ワガハイはトラじゃ！<end_line>
 		イヌのような扱いをするでない！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey, I'm a tiger!<end_line>
 		Don't treat me like a dog!<end_line>
 	</ascii>
@@ -1367,7 +1474,7 @@
 		そっか<three_dots><end_line>
 		わからないんだ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh<three_dots><end_line>
 		Alright<three_dots><end_line>
 	</ascii>
@@ -1381,7 +1488,7 @@
 		そ、そんなに落ち込む事は無いじゃろ<end_line>
 		一応努力するぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		D-don't get so depressed.<end_line>
 		I'll do what I can.<end_line>
 	</ascii>
@@ -1394,7 +1501,7 @@
 	<sjis>
 		キッカの実をさがそう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now to find the Kicca fruit!<end_line>
 	</ascii>
 </dialogue>
@@ -1407,7 +1514,7 @@
 		私はどんな実か知らないからな<end_line>
 		キサマがさがせ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You still haven't told me<end_line>
 		what kind of fruit it is.<end_line>
 	</ascii>
@@ -1418,24 +1525,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			そっか<end_line>
 			キッカの実はな<end_line>
 			甘いのがウマイんだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そっか<end_line>
-			キッカの実はね<end_line>
-			甘いのがおいしいよ<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Right.<end_line>
 		Kicca fruit is<end_line>
 		sweet and tasty.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そっか<end_line>
+			キッカの実はね<end_line>
+			甘いのがおいしいよ<end_line>
+		</sjis>
+    <ascii>
+		Right.<end_line>
+		Kicca fruit is<end_line>
+		sweet and tasty.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1446,7 +1558,7 @@
 		教えるつもりなら<end_line>
 		せめて色とかにしろ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		At least tell me<end_line>
 		what color it is.<end_line>
 	</ascii>
@@ -1458,7 +1570,7 @@
 	<sjis>
 		キッカの実をさがそう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now to find the Kicca fruit!<end_line>
 	</ascii>
 </dialogue>
@@ -1470,7 +1582,7 @@
 		私はどんな実か知りませんわ<end_line>
 		教えてください<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I don't know what I'm looking for.<end_line>
 		How can I tell it apart?<end_line>
 	</ascii>
@@ -1480,24 +1592,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 			シブイ実はマズイから<end_line>
 			食べちゃダメだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだな<three_dots><end_line>
-			シブイ実はマズイから<end_line>
-			食べちゃダメだよ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Hmm<three_dots><end_line>
 		Bitter fruits taste bad,<end_line>
 		so don't eat them!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだな<three_dots><end_line>
+			シブイ実はマズイから<end_line>
+			食べちゃダメだよ！<end_line>
+		</sjis>
+    <ascii>
+		Hmm<three_dots><end_line>
+		Bitter fruits taste bad,<end_line>
+		so don't eat them!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1506,7 +1623,7 @@
 	<sjis>
 		私に食べて調べろと？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You want me to compare the taste?<end_line>
 	</ascii>
 </dialogue>
@@ -1518,7 +1635,7 @@
 	<sjis>
 		薬をもらいに駅まで行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's meet Zakk at the station!<end_line>
 	</ascii>
 </dialogue>
@@ -1531,7 +1648,7 @@
 		最適経路検索中<end_line>
 		<three_dots><three_dots><three_dots><three_dots><three_dots><three_dots><three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Finding Optimal Route.<end_line>	
 		<three_dots><three_dots><three_dots><three_dots><three_dots><three_dots><three_dots><end_line>
 	</ascii>
@@ -1542,21 +1659,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ちょっと、<partner><end_line>
 			どうしたんだ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ちょっと、<partner><end_line>
-			どうしたの？<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Hey, <partner>,<end_line>
 		what are you doing?<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			ちょっと、<partner><end_line>
+			どうしたの？<end_line>
+		</sjis>
+    <ascii>
+		Hey, <partner>,<end_line>
+		what are you doing?<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1568,7 +1689,7 @@
 		みゅーの様ニ　薬ヲ届ケル為ニ<end_line>
 		最適ト思ワレル　道ヲ検索シマシタ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Complete.<end_line>
 		Determined Most Optimal Route To<end_line>
 		Pick Up And Deliver The Medicine.<end_line>
@@ -1582,7 +1703,7 @@
 	<sjis>
 		？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		?<end_line>
 	</ascii>
 </dialogue>
@@ -1592,25 +1713,25 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			おお！<end_line>
 			どうすればいいんだ？<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Ohh!<end_line>
 			So, what now?<end_line>
 		</ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			本当！？<end_line>
 			で、どうすればいいの？<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Really!?<end_line>
 			So, where to next?<end_line>
 		</ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1621,7 +1742,7 @@
 		マズハ駅ニ行キ　薬ヲ受ケ取リマス<end_line>
 		次ニ　みゅーの様ニ薬ヲ届ケマス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		First, Pick Up At The Station.<end_line>
 		Then, Deliver To Lady Murno.<end_line>
 	</ascii>
@@ -1634,7 +1755,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1644,21 +1765,25 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			何というか<three_dots><end_line>
 			その通りだな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			何というか<three_dots><end_line>
-			その通りだね<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Umm<three_dots><end_line>
 		Right<three_dots><end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			何というか<three_dots><end_line>
+			その通りだね<end_line>
+		</sjis>
+    <ascii>
+		Umm<three_dots><end_line>
+		Right<three_dots><end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1668,7 +1793,7 @@
 	<sjis>
 		じゃあ、行こうか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Okay, let's go then.<end_line>
 	</ascii>
 </dialogue>
@@ -1680,7 +1805,7 @@
 	<sjis>
 		了解デス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Understood.<end_line>
 	</ascii>
 </dialogue>
@@ -1692,7 +1817,7 @@
 	<sjis>
 		薬をもらいに駅まで行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's meet Zakk at the station!<end_line>
 	</ascii>
 </dialogue>
@@ -1706,7 +1831,7 @@
 		何があるかわからんからのう<end_line>
 		気を抜くなよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's not over until<end_line>
 		Murno has the medicine.<end_line>
 		Don't lose focus.<end_line>
@@ -1720,7 +1845,7 @@
 	<sjis>
 		たしかにそうだね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Right.<end_line>
 	</ascii>
 </dialogue>
@@ -1733,7 +1858,7 @@
 		仏作って魂入れず、と言っての<end_line>
 		最後の仕上げを欠いては<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There's a saying,<end_line>
 		"to plow but not to plant"<three_dots><end_line>
 	</ascii>
@@ -1746,7 +1871,7 @@
 	<sjis>
 		ホトケ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Plant?<end_line>
 	</ascii>
 </dialogue>
@@ -1756,18 +1881,21 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			作ってもらうのは薬だろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			作ってもらうのは薬でしょ？<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Aren't we making medicine?<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			作ってもらうのは薬でしょ？<end_line>
+		</sjis>
+    <ascii>
+		Aren't we making medicine?<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1777,7 +1905,7 @@
 	<sjis>
 		ええい、そういう事ではなく<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No, that's not what I meant<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1787,18 +1915,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="surprised" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			そんな事より薬をもらいに行こうぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そんな事より薬をもらいに行こ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Forget it, let's go!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そんな事より薬をもらいに行こ！<end_line>
+		</sjis>
+    <ascii>
+		Forget it, let's go!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1808,7 +1939,7 @@
 	<sjis>
 		薬をもらいに駅まで行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's meet Zakk at the station!<end_line>
 	</ascii>
 </dialogue>
@@ -1822,7 +1953,7 @@
 		来ると思っているのか？<end_line>
 		クズ男たちの仲間だぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Think he's really going<end_line>
 		to make it for us?<end_line>
 		He's friends with that scum.<end_line>
@@ -1834,21 +1965,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			来るよ、絶対！<end_line>
 			オレはあいつを信じてる<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			来るよ、絶対！<end_line>
-			わたしはあの子を信じてる<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		He will, I'm sure!<end_line>
 		I believe in him.<end_line>
 	</ascii>s
+</male>
+  <female>
+    <sjis>
+			来るよ、絶対！<end_line>
+			わたしはあの子を信じてる<end_line>
+		</sjis>
+    <ascii>
+		He will, I'm sure!<end_line>
+		I believe in him.<end_line>
+	</ascii>s
+</female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1860,7 +1995,7 @@
 		やめろ<three_dots><end_line>
 		寒気がする<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Don't say that with<end_line>
 		such a straight face<three_dots><end_line>
 		Ugh<three_dots>!<end_line>
@@ -1872,21 +2007,25 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			行こうぜ！<end_line>
 			オレたちの友情をたしかめに！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			行こう！<end_line>
-			わたしたちの友情をたしかめに！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Let's go!<end_line>
 		This'll be proof for our friendship!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			行こう！<end_line>
+			わたしたちの友情をたしかめに！<end_line>
+		</sjis>
+    <ascii>
+		Let's go!<end_line>
+		This'll be proof for our friendship!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1897,7 +2036,7 @@
 		キ、キサマ<three_dots><end_line>
 		わざとやっているな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Urgh<three_dots><end_line>
 		You must be doing this on purpose<three_dots><end_line>
 	</ascii>
@@ -1909,7 +2048,7 @@
 	<sjis>
 		薬をもらいに駅まで行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's meet Zakk at the station!<end_line>
 	</ascii>
 </dialogue>
@@ -1922,7 +2061,7 @@
 		無事に薬を作って<end_line>
 		やってくるでしょうか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I wonder if he'll be okay<three_dots><end_line>
 		Will he be able to<end_line>
 		make the medicine?<end_line>
@@ -1936,7 +2075,7 @@
 		<partner>さあ<end_line>
 		ちょっと心配しすぎじゃないの？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<partner>, don't you think<end_line>
 		you're worrying too much?<end_line>
 	</ascii>
@@ -1950,7 +2089,7 @@
 		また橋から落ちて<end_line>
 		大切なキッカの実を<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What if he fell off<end_line>
 		the bridge again,<end_line>
 		then our Kicca fruit would be<three_dots><end_line>
@@ -1965,7 +2104,7 @@
 		とは言い切れないところが<three_dots><end_line>
 		とにかく駅に行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's impossible!<end_line>
 		I hope<three_dots><end_line>
 		Anyways, to the station!<end_line>
@@ -1977,21 +2116,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			レミィのヤツ<three_dots><end_line>
 			絶対、薬を受け取らせてやる！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レミィったら<three_dots><end_line>
-			絶対、薬を受け取らせてやるんだから！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		That Lemmy<three_dots><end_line>
 		I'll make him take the medicine!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			レミィったら<three_dots><end_line>
+			絶対、薬を受け取らせてやるんだから！<end_line>
+		</sjis>
+    <ascii>
+		That Lemmy<three_dots><end_line>
+		I'll make him take the medicine!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -2003,7 +2146,7 @@
 		戦闘能力ニ　大キナ差ガ<end_line>
 		アルヨウデス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There Is A Large <end_line>
 		Difference In Strength<end_line>
 		Between You And Him.<end_line>
@@ -2017,7 +2160,7 @@
 	<sjis>
 		えっと、それってつまり？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Umm, meaning what?<end_line>
 	</ascii>
 </dialogue>
@@ -2030,7 +2173,7 @@
 		今ノアナタデハ　彼ニ勝利スルノハ<end_line>
 		困難ダ　トイウコトデス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It Would Be Difficult For You<end_line>
 		To Force Him As You Are Now.<end_line>
 	</ascii>
@@ -2041,18 +2184,21 @@
 	<portrait_l entry="player" eye="decided" mouth="stressed">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			お前まで、そんな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あなたまで、そんな<three_dots><end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Even you<three_dots><end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			あなたまで、そんな<three_dots><end_line>
+		</sjis>
+    <ascii>
+		Even you<three_dots><end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -2064,7 +2210,7 @@
 		協力スレバ　勝利デキナイ相手デハ<end_line>
 		アリマセン<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		However, Together,<end_line>
 		There Is No Enemy We<end_line>
 		Cannot Defeat.<end_line>
@@ -2076,24 +2222,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そういうことか<three_dots><end_line>
 			わかったよ<end_line>
 			行くぞ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そういうことね<three_dots><end_line>
-			わかったよ<end_line>
-			行くよ、<partner>！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		So that's what you meant<three_dots><end_line>
 		Okay.<end_line>
 		Let's do it, <partner>!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そういうことね<three_dots><end_line>
+			わかったよ<end_line>
+			行くよ、<partner>！<end_line>
+		</sjis>
+    <ascii>
+		So that's what you meant<three_dots><end_line>
+		Okay.<end_line>
+		Let's do it, <partner>!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2101,21 +2252,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			レミィのヤツ<three_dots><end_line>
 			絶対、薬を受け取らせてやる！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レミィったら<three_dots><end_line>
-			絶対、薬を受け取らせてやるんだから！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		That Lemmy<three_dots><end_line>
 		I'll make him take the medicine!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			レミィったら<three_dots><end_line>
+			絶対、薬を受け取らせてやるんだから！<end_line>
+		</sjis>
+    <ascii>
+		That Lemmy<three_dots><end_line>
+		I'll make him take the medicine!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2127,7 +2282,7 @@
 		そんなに熱くなっては<end_line>
 		勝てる勝負にも勝てんぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Calm down.<end_line>
 		Anger will distract you from<end_line>
 		what you need to do.<end_line>
@@ -2141,7 +2296,7 @@
 	<sjis>
 		うっ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ugh<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2155,7 +2310,7 @@
 		かなりの使い手のようじゃ！<end_line>
 		今のおぬしでは勝てぬかもしれん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Also, he is quite the<end_line>
 		formidable opponent!<end_line>
 		You may not be able to win.<end_line>
@@ -2167,21 +2322,25 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだと！<end_line>
 			お前まで、そんな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ！<end_line>
-			あなたまで、そんな<three_dots><end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		What!?<end_line>
 		Even you<three_dots><end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ！<end_line>
+			あなたまで、そんな<three_dots><end_line>
+		</sjis>
+    <ascii>
+		What!?<end_line>
+		Even you<three_dots><end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2192,7 +2351,7 @@
 		案ずるな<end_line>
 		おぬしにはワガハイがおる<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Have no fear.<end_line>
 		I am here to support you.<end_line>
 	</ascii>
@@ -2206,7 +2365,7 @@
 		おぬしとワガハイで力を合わせれば<end_line>
 		勝つこともできようぞ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		With our combined strength,<end_line>
 		we can win!<end_line>
 	</ascii>
@@ -2217,24 +2376,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			そういうことか<three_dots><end_line>
 			わかったよ<end_line>
 			行くぞ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そういうことね<three_dots><end_line>
-			わかったよ<end_line>
-			行くよ、<partner>！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		So that's what you meant<three_dots><end_line>
 		Okay.<end_line>
 		Let's do it, <partner>!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そういうことね<three_dots><end_line>
+			わかったよ<end_line>
+			行くよ、<partner>！<end_line>
+		</sjis>
+    <ascii>
+		So that's what you meant<three_dots><end_line>
+		Okay.<end_line>
+		Let's do it, <partner>!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2242,21 +2406,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			レミィのヤツ<three_dots><end_line>
 			絶対、薬を受け取らせてやる！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レミィったら<three_dots><end_line>
-			絶対、薬を受け取らせてやるんだから！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		That Lemmy<three_dots><end_line>
 		I'll make him take the medicine!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			レミィったら<three_dots><end_line>
+			絶対、薬を受け取らせてやるんだから！<end_line>
+		</sjis>
+    <ascii>
+		That Lemmy<three_dots><end_line>
+		I'll make him take the medicine!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2268,7 +2436,7 @@
 		あいつに勝てるとでも<end_line>
 		考えているのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Do you<end_line>
 		really think you<end_line>
 		can beat him?<end_line>
@@ -2280,21 +2448,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			勝てるかどうかじゃない<end_line>
 			絶対に勝つんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			勝てるかどうかじゃないよ<end_line>
-			絶対に勝つんだから！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		It's not a question of can or can't.<end_line>
 		I will!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			勝てるかどうかじゃないよ<end_line>
+			絶対に勝つんだから！<end_line>
+		</sjis>
+    <ascii>
+		It's not a question of can or can't.<end_line>
+		I will!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2305,7 +2477,7 @@
 		ふっ<three_dots>、面白い<three_dots><end_line>
 		だがキサマが勝てるかな？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hm<three_dots> Interesting<three_dots><end_line>
 		You? Win against him?<end_line>
 	</ascii>
@@ -2316,18 +2488,21 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			それ、どういうことだよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			それ、どういうこと！？<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		What's that supposed to mean!?<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			それ、どういうこと！？<end_line>
+		</sjis>
+    <ascii>
+		What's that supposed to mean!?<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2338,7 +2513,7 @@
 		私の手にかかれば<end_line>
 		キサマの出番などないぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		With my help, I'll end it<end_line>
 		before you can even move.<end_line>
 	</ascii>
@@ -2348,21 +2523,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			レミィのヤツ<three_dots><end_line>
 			絶対、薬を受け取らせてやる！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レミィったら<three_dots><end_line>
-			絶対、薬を受け取らせてやるんだから！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		That Lemmy<three_dots><end_line>
 		I'll make him take the medicine!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			レミィったら<three_dots><end_line>
+			絶対、薬を受け取らせてやるんだから！<end_line>
+		</sjis>
+    <ascii>
+		That Lemmy<three_dots><end_line>
+		I'll make him take the medicine!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2372,7 +2551,7 @@
 		そうですわ！<end_line>
 		あんな態度、絶対許せません！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Agreed!<end_line>
 		He can't treat us like that!<end_line>
 	</ascii>
@@ -2386,7 +2565,7 @@
 		一度、イタイ目にあった方が<end_line>
 		いいと思いますわ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Someone as rude as him<end_line>
 		deserves to be punished<end_line>
 		at least once!<end_line>
@@ -2401,7 +2580,7 @@
 		すっごい気合い入ってるけど<end_line>
 		相手は一応病人なんだし<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ummm<three_dots><end_line>
 		I appreciate the energy,<end_line>
 		but he's sick, you know<three_dots><end_line>
@@ -2416,7 +2595,7 @@
 		でもザックさんのためにも<end_line>
 		やっつけてあげましょう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I know that.<end_line>
 		But we must defeat him,<end_line>
 		for Zakk's sake too!<end_line>
@@ -2431,7 +2610,7 @@
 		あこがれの人だから<three_dots><end_line>
 		あれ<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But Zakk looks<end_line>
 		up to Lemmy, so<three_dots><end_line>
 		Huh<three_dots>?<end_line>
@@ -2445,7 +2624,7 @@
 		なんかフクザツな感じに<end_line>
 		なってるような<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		This is getting<end_line>
 		really complicated<three_dots><end_line>
 	</ascii>
@@ -2458,7 +2637,7 @@
 	<sjis>
 		よし、ミューノに薬を届けよう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Okay, let's deliver this to Murno!<end_line>
 	</ascii>
 </dialogue>
@@ -2472,7 +2651,7 @@
 		予想以上ニ　時間ガカカッテイマス<end_line>
 		急ギマショウ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It Took Longer To Acquire<end_line>
 		The Medicine Than<end_line>
 		I Had Expected.<end_line>
@@ -2484,21 +2663,27 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			たしかにミューノの熱は<end_line>
 			心配だよな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+		Yeah, I hope her fever<end_line>
+		has not gotten worse.<end_line>
+	
+</ascii>
+  </male>
+  <female>
+    <sjis>
 			たしかにミューノの熱は<end_line>
 			心配だよね<end_line>
 		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Yeah, I hope her fever<end_line>
 		has not gotten worse.<end_line>
-	</screen>
+	
+</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -2508,7 +2693,7 @@
 	<sjis>
 		親方モ　デス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Master Too.<end_line>
 	</ascii>
 </dialogue>
@@ -2518,18 +2703,21 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そこは信用しろよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そこは信用しようよ<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Have some faith in her!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そこは信用しようよ<end_line>
+		</sjis>
+    <ascii>
+		Have some faith in her!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2539,7 +2727,7 @@
 	<sjis>
 		よし、ミューノに薬を届けよう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Okay, let's deliver this to Murno!<end_line>
 	</ascii>
 </dialogue>
@@ -2551,7 +2739,7 @@
 	<sjis>
 		その前に落ち着くのじゃ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Before that, calm down.<end_line>
 	</ascii>
 </dialogue>
@@ -2561,21 +2749,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ！<end_line>
 			置いてくぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ！<end_line>
-			置いてくわよ<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Come on!<end_line>
 		I'll leave you behind.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ！<end_line>
+			置いてくわよ<end_line>
+		</sjis>
+    <ascii>
+		Come on!<end_line>
+		I'll leave you behind.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2586,7 +2778,7 @@
 		急がば回れ、と言っての<end_line>
 		急いでおる時こそゆっくり安全に<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Slow and steady wins the race.<end_line>
 		One can never be too careful<three_dots><end_line>
 	</ascii>
@@ -2599,7 +2791,7 @@
 	<sjis>
 		ん？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hm?<end_line>
 	</ascii>
 </dialogue>
@@ -2609,25 +2801,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			急ぐ時は回るのか？<end_line>
 			なんだそれ？<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Slow and steady?<end_line>
 			What's that?<end_line>
 		</ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			急ぐ時は回るの？<end_line>
 			ヘンなの<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Slow and steady?<end_line>
 			How strange.<end_line>
 		</ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2637,7 +2829,7 @@
 	<sjis>
 		そうではなくて<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's not it<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2650,7 +2842,7 @@
 		まあよい、善は急げ、とも言うからの<end_line>
 		早くミューノに薬を届けるぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Perhaps, strike while the iron<end_line>
 		is hot would be more appropriate.<end_line>
 	</ascii>
@@ -2661,18 +2853,21 @@
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			もう、なんなんだよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			もう、なんなのよ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Jeez, come on!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			もう、なんなのよ！<end_line>
+		</sjis>
+    <ascii>
+		Jeez, come on!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2694,7 +2889,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2704,25 +2899,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ちょっと待てよ！<end_line>
 			そんなに急ぐなよ<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Hold on!<end_line>
 			No need to rush.<end_line>
 		</ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			ちょっと待ってよ！<end_line>
 			そんなに急がなくったって<three_dots><end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Hold on!<end_line>
 			No need to rush<three_dots><end_line>
 		</ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2734,7 +2929,7 @@
 		私は急いでなどいない<three_dots><end_line>
 		キサマがおそいだけでは<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Wha<three_dots><end_line>
 		I'm not particularly fast<three_dots><end_line>
 		You're just slow<three_dots><end_line>
@@ -2746,18 +2941,21 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="special" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			はいはい、わかったよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			はいはい、わかりましたよ<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Okay, okay, I know.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			はいはい、わかりましたよ<end_line>
+		</sjis>
+    <ascii>
+		Okay, okay, I know.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2767,7 +2965,7 @@
 	<sjis>
 		早くミューノのところへ行こう<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's go find Murno.<end_line>
 	</ascii>
 </dialogue>
@@ -2780,7 +2978,7 @@
 		ちっ<three_dots><end_line>
 		キサマがそうしたいなら仕方ない<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Tch<three_dots><end_line>
 		If you want to, then fine.<end_line>
 	</ascii>
@@ -2792,7 +2990,7 @@
 	<sjis>
 		よし、ミューノに薬を届けよう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Okay, let's deliver this to Murno!<end_line>
 	</ascii>
 </dialogue>
@@ -2804,7 +3002,7 @@
 		ちょっと待ってください<end_line>
 		その薬の入れ物が<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Please wait a moment.<end_line>
 		The medicine's container<three_dots><end_line>
 	</ascii>
@@ -2814,18 +3012,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			入れ物がどうかしたのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			入れ物がどうかしたの？<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Container? What about it?<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			入れ物がどうかしたの？<end_line>
+		</sjis>
+    <ascii>
+		Container? What about it?<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2836,7 +3037,7 @@
 		もっとその、上品と言うか<end_line>
 		気品のある入れ物のほうが<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We should use something more<end_line>
 		refined, more elegant.<end_line>
 		It's only fitting for Lady Murno<three_dots><end_line>
@@ -2847,21 +3048,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そんなこと言ってないで<end_line>
 			早く行こうぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そんなこと言ってないで<end_line>
-			早く行こうよ<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		<three_dots>We don't have time for that.<end_line>
 		Come on.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そんなこと言ってないで<end_line>
+			早く行こうよ<end_line>
+		</sjis>
+    <ascii>
+		<three_dots>We don't have time for that.<end_line>
+		Come on.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2870,7 +3075,7 @@
 	<sjis>
 		では、せめて花束をつけて<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Then at least a bouquet<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2883,7 +3088,7 @@
 		ミューノ様に似合う<end_line>
 		花束は<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Umm<three_dots><end_line>
 		Where could we find<end_line>
 		flowers that fit her<three_dots><end_line>
@@ -2894,18 +3099,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そんなことしてる場合かよ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そんなことしてる場合なの<three_dots><end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Seriously, this isn't the time<three_dots><end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そんなことしてる場合なの<three_dots><end_line>
+		</sjis>
+    <ascii>
+		Seriously, this isn't the time<three_dots><end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2916,7 +3124,7 @@
 		そんな場合じゃありませんわ<end_line>
 		急ぎますよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's right!<end_line>
 		Let us not waste time.<end_line>
 		Let's go!<end_line>
@@ -2929,7 +3137,7 @@
 	<sjis>
 		えーと<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Umm<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2938,16 +3146,19 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			うん、そうだな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん、そうだね<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Alright, whatever.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			うん、そうだね<end_line>
+		</sjis>
+    <ascii>
+		Alright, whatever.<end_line>
+	</ascii>
+  </female>
 </dialogue>

--- a/Day 01/24989612_17d4fac.xml
+++ b/Day 01/24989612_17d4fac.xml
@@ -43,17 +43,21 @@
       ああ、大丈夫<end_line>
       すぐもどるよ<end_line>
     </sjis>
+    <ascii>
+    Yeah, I'm fine.<end_line>
+    I'll be right up.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん、大丈夫<end_line>
       すぐもどるよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, I'm fine.<end_line>
     I'll be right up.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -101,17 +105,21 @@
       ああ、大丈夫<end_line>
       すぐもどるよ<end_line>
     </sjis>
+    <ascii>
+    Yeah, I'm fine.<end_line>
+    I'll be right up.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん、大丈夫<end_line>
       すぐもどるよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, I'm fine.<end_line>
     I'll be right up.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -187,15 +195,18 @@
     <sjis>
       どういうことだよ！<end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どういうこと！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -242,15 +253,19 @@
       ああ、大丈夫<end_line>
       すぐもどるよ<end_line>
     </sjis>
+    <ascii>
+    Yeah, I'm fine.<end_line>
+    I'll be right up.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん、大丈夫<end_line>
       すぐもどるよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, I'm fine.<end_line>
     I'll be right up.<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 01/24990556_17d535c.xml
+++ b/Day 01/24990556_17d535c.xml
@@ -48,6 +48,11 @@
       聞いてたけど<end_line>
       わからなかったからさ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I was, but<three_dots><end_line>
+    I wasn't sure what you meant,<end_line>
+    so I just kept going<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -55,12 +60,12 @@
       聞いてたけど<end_line>
       わからなかったから<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I was, but<three_dots><end_line>
     I wasn't sure what you meant,<end_line>
     so I just kept going<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -87,15 +92,18 @@
     <sjis>
       なんだと！<end_line>
     </sjis>
+    <ascii>
+    What's that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -258,6 +266,10 @@
       オレには橋のちがいが<end_line>
       わからなかったからさ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I couldn't see any<end_line>
+    differences, so<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -265,11 +277,11 @@
       わたしにはちがいが<end_line>
       わからなかったから<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I couldn't see any<end_line>
     differences, so<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -296,6 +308,11 @@
       しり<three_dots>！？<end_line>
       オレのしりは青くないぞ！<end_line>
     </sjis>
+    <ascii>
+    Wha<three_dots>!?<end_line>
+    I'm green!?<end_line>
+    Where!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -303,12 +320,12 @@
       わたしのおしりは<end_line>
       青くなんかないわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wha<three_dots>!?<end_line>
     I'm green!?<end_line>
     Where!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -335,15 +352,18 @@
     <sjis>
       半人前っていうな！<end_line>
     </sjis>
+    <ascii>
+    I'm not an amateur!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       半人前っていわないでよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm not an amateur!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -384,15 +404,18 @@
     <sjis>
       なんだと！<end_line>
     </sjis>
+    <ascii>
+    No way I'm doing that!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No way I'm doing that!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -505,17 +528,21 @@
       おい<three_dots><end_line>
       どういうことだよ！？<end_line>
     </sjis>
+    <ascii>
+    Hey<three_dots><end_line>
+    What was that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ねぇ<three_dots><end_line>
       どういうこと！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey<three_dots><end_line>
     What was that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -540,6 +567,10 @@
       橋が落ちそうなの<end_line>
       気付いてたのか！？<end_line>
     </sjis>
+    <ascii>
+    You knew I was going to fall,<end_line>
+    didn't you!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -547,11 +578,11 @@
       橋が落ちそうなの気付いてて<end_line>
       だまってたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You knew I was going to fall,<end_line>
     didn't you!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -575,16 +606,19 @@
       だったらどうして<end_line>
       教えてくれないんだよ！？<end_line>
     </sjis>
+    <ascii>
+    So why didn't tell me!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんな<three_dots><end_line>
       なんで教えてくれないのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So why didn't tell me!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -610,6 +644,11 @@
       お前、オレのパートナーだってこと<end_line>
       忘れてんのか？<end_line>
     </sjis>
+    <ascii>
+    Huh!?<end_line>
+    We're supposed to be<end_line>
+    partners, remember?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -617,12 +656,12 @@
       あんた、わたしのパートナーに<end_line>
       なったこと忘れてるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh!?<end_line>
     We're supposed to be<end_line>
     partners, remember?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">

--- a/Day 02/001_25033116_17df99c.xml
+++ b/Day 02/001_25033116_17df99c.xml
@@ -34,15 +34,18 @@
     <sjis>
       お<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Huh<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -69,17 +72,21 @@
       それなら<end_line>
       もう大丈夫そうだったぜ<end_line>
     </sjis>
+    <ascii>
+    Oh, don't worry about that.<end_line>
+    She looked fine.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       それなら<end_line>
       もう大丈夫そうだったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, don't worry about that.<end_line>
     She looked fine.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -104,17 +111,21 @@
       夜に会ったんだよ<end_line>
       元気そうだったぜ<end_line>
     </sjis>
+    <ascii>
+    I saw her last night.<end_line>
+    She seemed fine to me.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       夜に会ったんだ<end_line>
       元気そうだったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I saw her last night.<end_line>
     She seemed fine to me.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -141,17 +152,21 @@
       ぐっすり眠ってたみたいだし<end_line>
       もう大丈夫だろ？<end_line>
     </sjis>
+    <ascii>
+    I'm pretty sure she slept well.<end_line>
+    Murno's fine, okay?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ぐっすり眠ってたみたいだし<end_line>
       もう大丈夫でしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm pretty sure she slept well.<end_line>
     Murno's fine, okay?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -178,6 +193,11 @@
       とにかくミューノのところへ<end_line>
       行きたいってことだろ？<end_line>
     </sjis>
+    <ascii>
+    Alright, alright.<end_line>
+    So you wanna head over<end_line>
+    to Murno's room, right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -185,12 +205,12 @@
       とにかくミューノのところへ<end_line>
       行きたいってことでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright, alright.<end_line>
     So you wanna head over<end_line>
     to Murno's room, right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -216,17 +236,21 @@
       な<three_dots><end_line>
       なんでだよ！？<end_line>
     </sjis>
+    <ascii>
+    Wh<three_dots><end_line>
+    Why do you think that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な<three_dots><end_line>
       なんでよ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wh<three_dots><end_line>
     Why do you think that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -309,17 +333,21 @@
       う<three_dots><end_line>
       仕方ないなあ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Hn<three_dots><end_line>
+    Fine<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       う<three_dots><end_line>
       仕方ないわねぇ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hn<three_dots><end_line>
     Fine<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -344,17 +372,21 @@
       なんだ<end_line>
       気になるのか？<end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    Are you worried?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに<end_line>
       気になるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     Are you worried?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -370,7 +402,7 @@
     Of course.<end_line>
     The cure might not be permanent.<end_line>
     Her fever may have returned.<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -382,17 +414,21 @@
       それなら<end_line>
       もう大丈夫そうだったぜ<end_line>
     </sjis>
+    <ascii>
+    Oh, don't worry about that.<end_line>
+    She looked fine.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       それなら<end_line>
       もう大丈夫そうだったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, don't worry about that.<end_line>
     She looked fine.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -418,6 +454,9 @@
       元気そうだったから<end_line>
       きっと大丈夫だろ？<end_line>
     </sjis>
+    <ascii>
+    We went out for a walk last night.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -425,10 +464,10 @@
       元気そうだったから<end_line>
       きっと大丈夫だよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We went out for a walk last night.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -456,17 +495,21 @@
       いや<end_line>
       オレが連れ出したんじゃなくて<three_dots><end_line>
     </sjis>
+    <ascii>
+    I didn't do anything<three_dots><end_line>
+    It was just a coincidence<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       いや<end_line>
       わたしが連れ出したんじゃなくて<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I didn't do anything<three_dots><end_line>
     It was just a coincidence<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -493,6 +536,10 @@
       ぐっすり眠ってたみたいだし<end_line>
       今日はもう、元気になってンだろ<end_line>
     </sjis>
+    <ascii>
+    She's sleeping soundly right now.<end_line>
+    That means she's fine, right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -500,11 +547,11 @@
       今日はもう、元気になってるんじゃ<end_line>
       ないかな？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     She's sleeping soundly right now.<end_line>
     That means she's fine, right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -530,17 +577,21 @@
       う<three_dots><end_line>
       悪かったよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    <three_dots><end_line>
+    Sorry<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       う<three_dots><end_line>
       悪かったわよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots><end_line>
     Sorry<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -602,15 +653,18 @@
     <sjis>
       なんだよ、それ！<end_line>
     </sjis>
+    <ascii>
+    Wh-What!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wh-What!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -676,6 +730,11 @@
       悪い悪い<end_line>
       気になってたんだな<end_line>
     </sjis>
+    <ascii>
+    Oh, you mean Murno!<end_line>
+    Right, sorry.<end_line>
+    You must be worried sick.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -683,12 +742,12 @@
       ごめんごめん<end_line>
       気になってたんだ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, you mean Murno!<end_line>
     Right, sorry.<end_line>
     You must be worried sick.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -717,6 +776,10 @@
       じゃあミューノの様子を<end_line>
       見に行こうぜ<end_line>
     </sjis>
+    <ascii>
+    Yeah, yeah, I got it.<end_line>
+    Let's go see how she's doing.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -724,11 +787,11 @@
       じゃあミューノの様子を<end_line>
       見に行こっか<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, yeah, I got it.<end_line>
     Let's go see how she's doing.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -811,17 +874,21 @@
       なんだ<end_line>
       気になるのか？<end_line>
     </sjis>
+    <ascii>
+    Hm?<end_line>
+    Are you worried?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに<end_line>
       気になるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hm?<end_line>
     Are you worried?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -885,16 +952,19 @@
       夜に会ったんだよ<end_line>
       元気そうだったぜ<end_line>
     </sjis>
+    <ascii>
+    We went out for a walk last night.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       夜に会ったんだ<end_line>
       元気そうだったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We went out for a walk last night.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -920,17 +990,21 @@
       いや<end_line>
       オレが連れ出したんじゃなくて<three_dots><end_line>
     </sjis>
+    <ascii>
+    I didn't do anything<three_dots><end_line>
+    It was just a coincidence<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       いや<end_line>
       わたしが連れ出したんじゃなくて<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I didn't do anything<three_dots><end_line>
     It was just a coincidence<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -956,17 +1030,21 @@
       しっかりしてる人は<end_line>
       ちゃんと人の話を聞くもんだよな<end_line>
     </sjis>
+    <ascii>
+    If you wanna be responsible,<end_line>
+    maybe you should listen to others.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       しっかりしてる人は<end_line>
       ちゃんと人の話を聞くもんだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     If you wanna be responsible,<end_line>
     maybe you should listen to others.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1002,17 +1080,21 @@
       ぐっすり眠ってたみたいだし<end_line>
       きっと元気になってるさ<end_line>
     </sjis>
+    <ascii>
+    Anyway, she was sleeping soundly,<end_line>
+    so I'm sure she's fine.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ぐっすり眠ってたみたいだし<end_line>
       きっと元気になってるって<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Anyway, she was sleeping soundly,<end_line>
     so I'm sure she's fine.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -1082,14 +1164,17 @@
     <sjis>
       お、おう！<end_line>
     </sjis>
+    <ascii>
+    Right<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       う、うん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 

--- a/Day 02/002_25036124_17e055c.xml
+++ b/Day 02/002_25036124_17e055c.xml
@@ -1133,15 +1133,18 @@
     <sjis>
       なんだ、このフンイキ<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    The atmosphere feels different<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに、このフンイキ<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The atmosphere feels different<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -1576,16 +1579,20 @@
       <three_dots>しかし<end_line>
       あんなんで大丈夫なんだろうか？<end_line>
     </sjis>
+    <ascii>
+    Are they<three_dots><end_line>
+    Really going to be okay<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>うーん<end_line>
       あんなんで大丈夫なのかな？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Are they<three_dots><end_line>
     Really going to be okay<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 

--- a/Day 02/005_25041820_17e1b9c.xml
+++ b/Day 02/005_25041820_17e1b9c.xml
@@ -15,15 +15,18 @@
     <sjis>
       またか<three_dots><end_line>
     </sjis>
+    <ascii>
+    There he goes again<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       まただ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There he goes again<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -92,16 +95,19 @@
       今日は何してんだ？<end_line>
       こんなとこで<end_line>
     </sjis>
+    <ascii>
+    What are you doing here?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今日は何してんの？<end_line>
       こんなとこで<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What are you doing here?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -126,15 +132,18 @@
     <sjis>
       オレたちに負けたけどな<end_line>
     </sjis>
+    <ascii>
+    You know I beat him<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしたちに負けたけどね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You know I beat him<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -276,17 +285,21 @@
       スゴイはぐれ？<end_line>
       どういうことだよ！？<end_line>
     </sjis>
+    <ascii>
+    Huge Stray<three_dots>?<end_line>
+    What are you talking about?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       スゴイはぐれ？<end_line>
       どういうこと！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huge Stray<three_dots>?<end_line>
     What are you talking about?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -312,17 +325,21 @@
       あいつが、そんな<three_dots><end_line>
       じゃあ、オレたちも<three_dots><end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    Then we're gonna go too.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あいつが、そんな<three_dots><end_line>
       じゃあ、わたしたちも<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     Then we're gonna go too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -348,17 +365,21 @@
       なんだと！<end_line>
       そんなこと<three_dots><end_line>
     </sjis>
+    <ascii>
+    What?!<end_line>
+    How do you know that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！<end_line>
       そんなこと<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What?!<end_line>
     How do you know that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -430,6 +451,11 @@
       どうしても行って<end_line>
       はぐれをたおしてやる！<end_line>
     </sjis>
+    <ascii>
+    I'll make it work!<end_line>
+    No matter what,<end_line>
+    I'm gonna beat that Stray!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -437,12 +463,12 @@
       どうしても行って<end_line>
       はぐれをたおすんだから！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'll make it work!<end_line>
     No matter what,<end_line>
     I'm gonna beat that Stray!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -652,6 +678,11 @@
       お前にそこまで言われちゃ<end_line>
       行くしかないぜ！<end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots><end_line>
+    If you're willing to go for it,<end_line>
+    then I guess I am too!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -659,12 +690,12 @@
       あなたにそこまで言われちゃ<end_line>
       行くしかないね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots><end_line>
     If you're willing to go for it,<end_line>
     then I guess I am too!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -690,6 +721,11 @@
       どうしても行って<end_line>
       はぐれをたおしてやる！<end_line>
     </sjis>
+    <ascii>
+    I'll make it work!<end_line>
+    No matter what,<end_line>
+    I'm gonna beat that Stray!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -697,12 +733,12 @@
       どうしても行って<end_line>
       はぐれをたおしちゃうから！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'll make it work!<end_line>
     No matter what,<end_line>
     I'm gonna beat that Stray!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -726,6 +762,11 @@
       なんとかして、町の方へ<end_line>
       行ってやる！<end_line>
     </sjis>
+    <ascii>
+    Now then!<end_line>
+    I have to find a way<end_line>
+    past the gatekeeper!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -733,11 +774,11 @@
       なんとかして、町の方へ<end_line>
       行かなくちゃ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Now then!<end_line>
     I have to find a way<end_line>
     past the gatekeeper!<end_line>
   </ascii>
+  </female>
 </dialogue>
 

--- a/Day 02/013_25044764_17e271c.xml
+++ b/Day 02/013_25044764_17e271c.xml
@@ -6,7 +6,7 @@
 		あぶないから退治できるまで<end_line>
 		通行禁止だよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Strays have appeared just ahead.<end_line>
     It's too dangerous to go outside.<end_line>
     Come back another time.<end_line>
@@ -16,20 +16,23 @@
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			オレもそのはぐれ退治を<end_line>
 			手伝いたいんだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    I want to help hunt the Strays too.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			わたしもそのはぐれ退治を<end_line>
 			手伝いたいんです<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I want to help hunt the Strays too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
@@ -38,7 +41,7 @@
 		なに言ってるんだ<end_line>
 		やめときな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What are you talking about?<end_line>
 		You're not on the list.<end_line>
 	</ascii>
@@ -49,7 +52,7 @@
 	<sjis>
 		でも<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But<three_dots>!<end_line>
 	</ascii>
 </dialogue>
@@ -61,7 +64,7 @@
 		修行ならいつものところで<end_line>
 		やりな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		If you want to train,<end_line>
 		just go to your usual place.<end_line>
 	</ascii>
@@ -72,7 +75,7 @@
 	<sjis>
 		うぅ<three_dots><end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		Ugh<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -85,7 +88,7 @@
 		許可ハ　オリマセンデシタネ<end_line>
 		ドウスルンデスカ？<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		We Have Been Denied.<end_line>
 		What Will We Do?<end_line>
 	</ascii>
@@ -100,7 +103,7 @@
 		ムリだったようじゃな<end_line>
 		他に外に出る方法はないのか？<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		As expected,<end_line>
 		a frontal assault<end_line>
     seems impossible.<end_line>
@@ -116,7 +119,7 @@
 		というのはダメなんだろ？<end_line>
 		どうするつもりだ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I can't just erase him, can I<three_dots>?<end_line>
 		What do you intend to do?<end_line>
 	</ascii>
@@ -131,7 +134,7 @@
 		ムリみたいですわ<three_dots><end_line>
 		どうしましょう<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Looks like we can't<end_line>
 		just barge in, huh<three_dots>?<end_line>
     What shall we do<three_dots>?<end_line>
@@ -145,7 +148,7 @@
 		おとなしく修行するしか<end_line>
 		ないのかなぁ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     <three_dots>I guess I'll just<end_line>
     have to go train<three_dots><end_line>
 	</ascii>
@@ -157,7 +160,7 @@
 		今この道は通行止めだ<end_line>
 		修行ならよそでやりな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The road is closed for now.<end_line>
 		If you want to train,<end_line>
 		do it elsewhere.<end_line>

--- a/Day 02/014_25045980_17e2bdc.xml
+++ b/Day 02/014_25045980_17e2bdc.xml
@@ -6,7 +6,7 @@
 	<sjis>
 		ドウシタノデスカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Is Something Wrong?<end_line>
 	</ascii>
 </dialogue>
@@ -18,7 +18,7 @@
 	<sjis>
 		なにごとじゃ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What is it?<end_line>
 	</ascii>
 </dialogue>
@@ -30,7 +30,7 @@
 	<sjis>
 		なんだ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What now?<end_line>
 	</ascii>
 </dialogue>
@@ -42,7 +42,7 @@
 	<sjis>
 		どうしたんですか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Is there something wrong?<end_line>
 	</ascii>
 </dialogue>
@@ -51,24 +51,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだ<three_dots>！<end_line>
 			たしかこの先のディックル鉱洞に<end_line>
 			街道への抜け道があったはずだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだ<three_dots>！<end_line>
-			たしかこの先のディックル鉱洞に<end_line>
-			街道への抜け道があったはず！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     That's it<three_dots>!<end_line>
     There should be a way around<end_line>
     through Deikle Mine!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだ<three_dots>！<end_line>
+			たしかこの先のディックル鉱洞に<end_line>
+			街道への抜け道があったはず！<end_line>
+		</sjis>
+    <ascii>
+    That's it<three_dots>!<end_line>
+    There should be a way around<end_line>
+    through Deikle Mine!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -79,7 +84,7 @@
 		タシカ？<end_line>
 		確実デハ　ナイノデスカ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Should?<end_line>
 		That Is Not A Guarantee.<end_line>
 	</ascii>
@@ -93,7 +98,7 @@
 		たしか<three_dots>じゃと？<end_line>
 		なにやらたよりないが<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Should<three_dots> You say?<end_line>
 		That's not reliable<three_dots><end_line>
 	</ascii>
@@ -107,7 +112,7 @@
 		たしか<three_dots>？<end_line>
 		ムダ足にならんといいが<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Should<three_dots>?<end_line>
 		This better not be a fool's errand<three_dots><end_line>
 	</ascii>
@@ -121,7 +126,7 @@
 		たしか<three_dots>ですか？<end_line>
 		あなたのカンは、ちょっと<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There<three_dots>'should' be?<end_line>
 		Your intuition is a bit flaky<three_dots><end_line>
 	</ascii>
@@ -131,21 +136,25 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ！<end_line>
 			行ってみれば思い出すって！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ！<end_line>
-			行ってみれば思い出すって！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     S-Shut up!<end_line>
     I'll remember when we get there!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ！<end_line>
+			行ってみれば思い出すって！<end_line>
+		</sjis>
+    <ascii>
+    S-Shut up!<end_line>
+    I'll remember when we get there!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -155,7 +164,7 @@
 		門番さんにみつからないで<end_line>
 		外に行けるぞ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		If we use the secret path,<end_line>
 		we can go outside without<end_line>
 		the guard noticing us!<end_line>

--- a/Day 02/015_25746892_188ddcc.xml
+++ b/Day 02/015_25746892_188ddcc.xml
@@ -1,10 +1,10 @@
 <location>
-	<sjis>
+  <sjis>
 		ディックル鉱洞<end_line>
 	</sjis>
 </location>
 <location>
-	<sjis>
+  <sjis>
 		ディックル鉱洞　エリア１<end_line>
 	</sjis>
 </location>
@@ -12,21 +12,25 @@
 	<info box="simple">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			うーん<end_line>
 			開かないなぁ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うーん<end_line>
-			開かないよぉ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hnnnn<three_dots>!<end_line>
     It won't open<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うーん<end_line>
+			開かないよぉ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Hnnnn<three_dots>!<end_line>
+    It won't open<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 
 

--- a/Day 02/016_25047132_17e305c.xml
+++ b/Day 02/016_25047132_17e305c.xml
@@ -62,6 +62,11 @@
       きっとこの道を行けば<end_line>
       村の外に出られたはず<end_line>
     </sjis>
+    <ascii>
+    I remember coming here before<three_dots><end_line>
+    If we go through here,<end_line>
+    we should be able to get outside.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -69,12 +74,12 @@
       きっとこの道を行けば<end_line>
       村の外に出られるはず<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I remember coming here before<three_dots><end_line>
     If we go through here,<end_line>
     we should be able to get outside.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -144,6 +149,11 @@
       行けばわかるって<end_line>
       ここまでは合ってたんだし<end_line>
     </sjis>
+    <ascii>
+    Hey, I've been right<end_line>
+    at least up until now.<end_line>
+    Let's just go and find out.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -151,12 +161,12 @@
       行けばわかるって<end_line>
       ここまでは合ってたんだし<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, I've been right<end_line>
     at least up until now.<end_line>
     Let's just go and find out.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 02/017_25048492_17e35ac.xml
+++ b/Day 02/017_25048492_17e35ac.xml
@@ -6,7 +6,7 @@
 	<sjis>
 		ハグレ召喚獣ノ　ヨウデス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It Is A Stray Summon.<end_line>
 	</ascii>
 </dialogue>
@@ -19,7 +19,7 @@
 		はぐれ召喚獣じゃな<three_dots><end_line>
 		やつが<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		A Stray Summon<three_dots><end_line>
     Is that the one Zakk mentioned<three_dots>?<end_line>
 	</ascii>
@@ -33,7 +33,7 @@
 		ちっ<three_dots><end_line>
 		はぐれ召喚獣、か<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 		A Stray Summon<three_dots><end_line>
 	</ascii>
@@ -47,7 +47,7 @@
 		は、はぐれ召喚獣ですわ<end_line>
 		ちょっと強そう、かも<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I-It's a Stray Summon.<end_line>
 		It seems kinda strong<three_dots><end_line>
 	</ascii>
@@ -57,24 +57,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="surprised" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			町につながる道にはまだ出てないし<end_line>
 			みんなが追ってるのとは<end_line>
 			たぶん別のやつだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			町につながる道にはまだ出てないから<end_line>
-			みんなが追ってるのとは<end_line>
-			たぶん別のやつね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We haven't gotten to the road,<end_line>
     so this is probably different<end_line>
     from the one everyone else is after.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			町につながる道にはまだ出てないから<end_line>
+			みんなが追ってるのとは<end_line>
+			たぶん別のやつね<end_line>
+		</sjis>
+    <ascii>
+    We haven't gotten to the road,<end_line>
+    so this is probably different<end_line>
+    from the one everyone else is after.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -84,7 +89,7 @@
 	<sjis>
 		ドウシマスカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What Should We Do?<end_line>
 	</ascii>
 </dialogue>
@@ -94,23 +99,27 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			外に出るには<end_line>
 			この道を進むしかないんだ<three_dots>！<end_line>
 			ここをどいてもらうしかない<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    This is the way out<three_dots><end_line>
+    We have to make it move<three_dots>!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			外に出るには<end_line>
 			この道を進むしかないんだ<three_dots>！<end_line>
 			ここをどいてもらうしかないよ<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     This is the way out<three_dots><end_line>
     We have to make it move<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -122,7 +131,7 @@
 		私タチナラ　問題ナク<end_line>
 		勝利デキルト　判断シマス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Understood.<end_line>
 		I Conclude That Our Likelyhood<end_line>
 		Of Victory is 100%.<end_line>
@@ -137,7 +146,7 @@
 		<partner><three_dots><end_line>
 		よし！　行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<partner><three_dots><end_line>
 		Yeah! Let's do this!<end_line>
 	</ascii>
@@ -152,7 +161,7 @@
 		あやつにどいてもらわねば<end_line>
 		先へは進めぬぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So, unless we make it move,<end_line>
 		we cannot continue forward.<end_line>
 	</ascii>
@@ -163,21 +172,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			戦うしかなさそうだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-			戦うしかなさそうだ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah.<end_line>
     Looks like we'll have to fight.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+			戦うしかなさそうだ<end_line>
+		</sjis>
+    <ascii>
+    Yeah.<end_line>
+    Looks like we'll have to fight.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -189,7 +202,7 @@
 		我らの敵ではなさそうじゃ<end_line>
 		けちらしてやろうぞ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Mm.<end_line>
 		From what I can see,<end_line>
 		it should be no match for us!<end_line>
@@ -203,7 +216,7 @@
 	<sjis>
 		よおし！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Alright!<end_line>
 		Let's do this!<end_line>
 	</ascii>
@@ -217,7 +230,7 @@
 		ジャマなヤツだということは<end_line>
 		たしかだな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So we have to fight, right?<end_line>
 	</ascii>
 </dialogue>
@@ -227,24 +240,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			先へ進むには<end_line>
 			戦うしかなさそうだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-			先へ進むには<end_line>
-			戦うしかなさそうだよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah.<end_line>
     If we want to keep going,<end_line>
     we have to take it down.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+			先へ進むには<end_line>
+			戦うしかなさそうだよ<end_line>
+		</sjis>
+    <ascii>
+    Yeah.<end_line>
+    If we want to keep going,<end_line>
+    we have to take it down.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -254,7 +272,7 @@
 	<sjis>
 		好きにすればいい<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Fine.<end_line>
 	</ascii>
 </dialogue>
@@ -264,20 +282,23 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			うん<end_line>
 			オレたちなら、勝てる！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Yeah! Let's do it!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			うん<end_line>
 			わたしたちなら、勝てる！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah! Let's do it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -289,7 +310,7 @@
 		サラっと通しては<end_line>
 		もらえなさそうですけど<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What should we do?<end_line>
 		It doesn't seem like<end_line>
 		it'll just let us through<three_dots><end_line>
@@ -301,23 +322,27 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			先へ進むには<end_line>
 			戦うしかなさそうだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Yeah.<end_line>
+    We'll have to take it down.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<end_line>
 			先へ進むには<end_line>
 			戦うしかなさそうだよ<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah.<end_line>
     We'll have to take it down.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -329,7 +354,7 @@
 		私たちなら<three_dots><end_line>
 		絶対に勝てますわ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I-it's okay.<end_line>
     Together<three_dots><end_line>
 		We'll definitely win!<end_line>
@@ -343,7 +368,7 @@
 	<sjis>
 		よおし！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah! Let's do this!<end_line>
 	</ascii>
 </dialogue>

--- a/Day 02/018_25050076_17e3bdc.xml
+++ b/Day 02/018_25050076_17e3bdc.xml
@@ -3,21 +3,25 @@
 	<portrait_l entry="player" eye="happy" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			楽勝！<end_line>
 			やっぱオレたちは強いな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			楽勝！<end_line>
-			やっぱわたしたちって強いね！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Easy!<end_line>
     We really are strong!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			楽勝！<end_line>
+			やっぱわたしたちって強いね！<end_line>
+		</sjis>
+    <ascii>
+    Easy!<end_line>
+    We really are strong!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -27,7 +31,7 @@
 	<sjis>
 		当然ノ結果デス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		As Expected.<end_line>
 	</ascii>
 </dialogue>
@@ -40,7 +44,7 @@
 		うむ<end_line>
 		もう少し歯ごたえが欲しかったな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Indeed.<end_line>
 		Though I wouldn't have minded<end_line>
 		if it lasted a bit longer.<end_line>
@@ -55,7 +59,7 @@
 		<three_dots>ふっ<end_line>
 		うかれやがって<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Hmph.<end_line>
 		It was a mere weakling.<end_line>
 	</ascii>
@@ -69,7 +73,7 @@
 		そのとおりですわ<end_line>
 		私たちは強いのです！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Of course!<end_line>
 	</ascii>
 </dialogue>
@@ -78,38 +82,44 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			それじゃ<end_line>
 			先に進もうぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Let's keep going then!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			それじゃ<end_line>
 			先に行きましょう！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's keep going then!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ちょっと油断したぜ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ちょっと油断したかな<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I let my guard down<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ちょっと油断したかな<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I let my guard down<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -121,7 +131,7 @@
 		アンナ相手　問題デハ<end_line>
 		アリマセンデシタ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		If I Was Able To Use My Real Power,<end_line>
 		That Opponent Would Not<end_line>
     Have Stood A Chance.<end_line>
@@ -136,7 +146,7 @@
 		あの程度の相手に苦戦するとは<end_line>
 		情けないのぉ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Having a close fight with<end_line>
 		such an opponent is a bit saddening.<end_line>
 	</ascii>
@@ -151,7 +161,7 @@
 		あの程度の相手に<end_line>
 		好き勝手やられるなどと<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Tch<three_dots><end_line>
     Letting an opponent like that<end_line>
     throw you around so easily<three_dots><end_line>
@@ -166,7 +176,7 @@
 		す、少しだけですけど<end_line>
 		あぶなかったですわ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Th-That was just<end_line>
 		a liiiitle bit dangerous<three_dots><end_line>
 	</ascii>
@@ -176,39 +186,46 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			気を取り直して<end_line>
 			先に進もうぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			気を取り直して<end_line>
-			先に行きましょう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We can't let this get us down.<end_line>
     Come on, let's go!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			気を取り直して<end_line>
+			先に行きましょう！<end_line>
+		</sjis>
+    <ascii>
+    We can't let this get us down.<end_line>
+    Come on, let's go!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="happy" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ざっとこんなもんだな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ざっとこんなもんね！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We really did it!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ざっとこんなもんね！<end_line>
+		</sjis>
+    <ascii>
+    We really did it!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -219,7 +236,7 @@
 		アノ程度ノ相手ナラバ<end_line>
 		問題デハアリマセン<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		An Opponent Of That Level<end_line>
 		Is No Problem.<end_line>
 	</ascii>
@@ -233,7 +250,7 @@
 		うむ<three_dots><end_line>
 		まあまあというところか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hm<three_dots><end_line>
 		That went alright.<end_line>
 	</ascii>
@@ -248,7 +265,7 @@
 		あの程度の相手に<end_line>
 		モタモタするとは<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Tch<three_dots><end_line>
     Should've been an easy win<three_dots><end_line>
 	</ascii>
@@ -261,7 +278,7 @@
 	<sjis>
 		結構、余裕でしたわ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That wasn't too bad.<end_line>
 	</ascii>
 </dialogue>
@@ -270,18 +287,21 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			それじゃ<end_line>
 			先に進もうぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    C'mon, let's keep moving!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			それじゃ<end_line>
 			先に行きましょう！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     C'mon, let's keep moving!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 02/019_25754108_188f9fc.xml
+++ b/Day 02/019_25754108_188f9fc.xml
@@ -1,15 +1,15 @@
 <location>
-	<sjis>
+  <sjis>
 		森洞<end_line>
 	</sjis>
 </location>
 <location>
-	<sjis>
+  <sjis>
 		バジャンの森<end_line>
 	</sjis>
 </location>
 <location>
-	<sjis>
+  <sjis>
 		バジャンの森　エリア１<end_line>
 	</sjis>
 </location>
@@ -20,7 +20,7 @@
 		修行するなら他行ってやりな<end_line>
 		街道はあぶないからな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Go train elsewhere.<end_line>
 		The main road is dangerous.<end_line>
 	</ascii>
@@ -31,7 +31,7 @@
 	<sjis>
 		修行がんばれよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Work hard on your training.<end_line>
 	</ascii>
 </dialogue>
@@ -39,19 +39,23 @@
 	<info box="simple">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			今戻ったら見つかるぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今戻ると見つかっちゃうよお<end_line>
-		</sjis>
-	</female>
-		<ascii>
+    <ascii>
 			If we go back now,<end_line>
 			they'll find us.<end_line>
 		</ascii>
+  </male>
+  <female>
+    <sjis>
+			今戻ると見つかっちゃうよお<end_line>
+		</sjis>
+    <ascii>
+			If we go back now,<end_line>
+			they'll find us.<end_line>
+		</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="special">
@@ -59,7 +63,7 @@
 		転送装置は起動中の転送装置間を一瞬で<end_line>
 		移動することができます<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		While the transfer device is active,<end_line>
 		it is possible to move between<end_line>
 		transfer devices in an instant.<end_line>
@@ -72,7 +76,7 @@
 		上に立ってＡボタンを押すことで<end_line>
 		使用することができます<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Strike with the hammer to activate,<end_line>
 		and use it by standing on top of it<end_line>
 		and pressing the A button.<end_line>
@@ -84,7 +88,7 @@
 		今は別の転送装置が起動していないため<end_line>
 		使用することはできません<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		At this time, no other device<end_line>
 		is active, so it cannot be used.<end_line>
 	</ascii>

--- a/Day 02/020_25051628_17e41ec.xml
+++ b/Day 02/020_25051628_17e41ec.xml
@@ -2,38 +2,45 @@
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			やった！<end_line>
 			出たぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やった！<end_line>
-			外だ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     We made it out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やった！<end_line>
+			外だ！<end_line>
+		</sjis>
+    <ascii>
+    Alright!<end_line>
+    We made it out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			どうした？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			どうしたの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What's wrong?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			どうしたの？<end_line>
+		</sjis>
+    <ascii>
+    What's wrong?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -44,7 +51,7 @@
 		人間ノ　話シ声ヲ　確認<end_line>
 		コチラニ　向カッテキテイマス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Human Voices Confirmed.<end_line>
 		They Are Approaching.<end_line>
 	</ascii>
@@ -58,7 +65,7 @@
 		人の気配がする<three_dots><end_line>
 		近いぞ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I can sense someone<three_dots><end_line>
 		They're close!<end_line>
 	</ascii>
@@ -72,7 +79,7 @@
 		ニンゲンがいる<three_dots><end_line>
 		近いぞ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There are humans here<three_dots><end_line>
 		They're close!<end_line>
 	</ascii>
@@ -86,7 +93,7 @@
 		誰かいますわ<three_dots><end_line>
 		こっちにきます！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Someone's here<three_dots><end_line>
 		They're coming!<end_line>
 	</ascii>
@@ -99,7 +106,7 @@
 		ヤバい！<end_line>
 		かくれなきゃ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Crap!<end_line>
 		We gotta hide!<end_line>
 	</ascii>
@@ -111,7 +118,7 @@
 		<three_dots>でも大変だったでしょ？<end_line>
 		この間の地震で橋がおちてたし<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>That was tough wasn't it?<end_line>
     Who would've thought the<end_line>
     bridge would collapse?<end_line>
@@ -124,7 +131,7 @@
 		少しおどろいたが<end_line>
 		道なんかいくらでもあるからな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It was a bit surprising,<end_line>
 		but there are other ways around.<end_line>
 	</ascii>
@@ -136,7 +143,7 @@
 		ま、おかげで助かったよ<end_line>
 		ありがとうな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Well, you did save me.<end_line>
 		Thanks for that.<end_line>
 	</ascii>
@@ -149,7 +156,7 @@
 		あんなのは軽いもんですから！<end_line>
 		なぜなら、オレは<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You don't need to thank me.<end_line>
 		That much was nothing!<end_line>
 		And that's because<three_dots><end_line>
@@ -161,7 +168,7 @@
 	<sjis>
 		無敵で不死身っスから！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I am the strongest, the invincible!<end_line>
 	</ascii>
 </dialogue>
@@ -172,7 +179,7 @@
 	<sjis>
 		<three_dots>行ったかな？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Are they gone?<end_line>
 	</ascii>
 </dialogue>
@@ -184,7 +191,7 @@
 	<sjis>
 		ソノヨウデス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It Appears So.<end_line>
 	</ascii>
 </dialogue>
@@ -194,21 +201,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			さっきのセリフ<end_line>
 			なんか、アニキみたいだったな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			さっきのセリフ、なんだか<end_line>
-			アニキみたいだったけど<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     That guy<three_dots><end_line>
     He kind of sounded like Bro.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			さっきのセリフ、なんだか<end_line>
+			アニキみたいだったけど<three_dots><end_line>
+		</sjis>
+    <ascii>
+    That guy<three_dots><end_line>
+    He kind of sounded like Bro.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -219,7 +230,7 @@
 		あにき？<end_line>
 		アナタノ　オ兄サン　デスカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Bro?<end_line>
 		Is He Part Of Your Family?<end_line>
 	</ascii>
@@ -234,7 +245,7 @@
 		ロブ親方の友達だった人だよ<end_line>
 		鍛冶職人の男の人なんだ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh, no, that's just a nickname.<end_line>
 		He's a friend of Master Rob.<end_line>
     He's a blacksmith.<end_line>
@@ -250,7 +261,7 @@
 		プロスバンって町にすんでて<end_line>
 		昔はいっしょに修行もしたけど<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I trained with him once a<end_line>
     long time ago in Prosban<three_dots><end_line>
 	</ascii>
@@ -264,7 +275,7 @@
 		ロブ親方が死んでからは<end_line>
 		一度も会ってないなぁ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But I haven't seen him<end_line>
 		since Master Rob passed away<three_dots><end_line>
 	</ascii>
@@ -277,7 +288,7 @@
 	<sjis>
 		ソノ人ガ　ヤッテキタノデスカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Why Would He Be Here?<end_line>
 	</ascii>
 </dialogue>
@@ -289,7 +300,7 @@
 	<sjis>
 		そのようじゃ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Looks like it.<end_line>
 	</ascii>
 </dialogue>
@@ -299,21 +310,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			さっきのセリフ<end_line>
 			なんか、アニキみたいだったな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			さっきのセリフ、なんだか<end_line>
-			アニキみたいだったけど<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     That guy<three_dots><end_line>
     He kind of sounded like Bro.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			さっきのセリフ、なんだか<end_line>
+			アニキみたいだったけど<three_dots><end_line>
+		</sjis>
+    <ascii>
+    That guy<three_dots><end_line>
+    He kind of sounded like Bro.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -324,7 +339,7 @@
 		アニキ？<end_line>
 		おぬし、兄がいたのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Bro?<end_line>
 		You have a brother?<end_line>
 	</ascii>
@@ -339,7 +354,7 @@
 		ロブ親方の友達だった人だよ<end_line>
 		鍛冶職人の男の人なんだ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh, no, that's just a nickname.<end_line>
 		He's a friend of Master Rob.<end_line>
     He's a blacksmith.<end_line>
@@ -355,7 +370,7 @@
 		プロスバンって町にすんでて<end_line>
 		昔はいっしょに修行もしたけど<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I trained with him once a<end_line>
     long time ago in Prosban<three_dots><end_line>
 	</ascii>
@@ -369,7 +384,7 @@
 		ロブ親方が死んでからは<end_line>
 		一度も会ってないなぁ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But I haven't seen him<end_line>
 		since Master Rob passed away<three_dots><end_line>
 	</ascii>
@@ -382,7 +397,7 @@
 	<sjis>
 		そのアニキがやってきたのかの？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		And you think it's him?<end_line>
 	</ascii>
 </dialogue>
@@ -394,7 +409,7 @@
 	<sjis>
 		らしいな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Seems like it.<end_line>
 	</ascii>
 </dialogue>
@@ -404,21 +419,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			さっきのセリフ<end_line>
 			なんか、アニキみたいだったな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			さっきのセリフ、なんだか<end_line>
-			アニキみたいだったけど<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     That guy<three_dots><end_line>
     He kind of sounded like Bro.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			さっきのセリフ、なんだか<end_line>
+			アニキみたいだったけど<three_dots><end_line>
+		</sjis>
+    <ascii>
+    That guy<three_dots><end_line>
+    He kind of sounded like Bro.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -429,7 +448,7 @@
 		アニキ<three_dots>？<end_line>
 		キサマ、兄がいたのか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Bro<three_dots>？<end_line>
 		So you have a brother?<end_line>
 	</ascii>
@@ -444,7 +463,7 @@
 		ロブ親方の友達だった人だよ<end_line>
 		鍛冶職人の男の人なんだ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh, no, that's just a nickname.<end_line>
 		He's a friend of Master Rob.<end_line>
     He's a blacksmith.<end_line>
@@ -460,7 +479,7 @@
 		プロスバンって町にすんでて<end_line>
 		昔はいっしょに修行もしたけど<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I trained with him once a<end_line>
     long time ago in Prosban<three_dots><end_line>
 	</ascii>
@@ -474,7 +493,7 @@
 		ロブ親方が死んでからは<end_line>
 		一度も会ってないなぁ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But I haven't seen him<end_line>
 		since Master Rob passed away<three_dots><end_line>
 	</ascii>
@@ -509,21 +528,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			さっきのセリフ<end_line>
 			なんか、アニキみたいだったな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			さっきのセリフ、なんだか<end_line>
-			アニキみたいだったけど<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     That guy<three_dots><end_line>
     He kind of sounded like Bro.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			さっきのセリフ、なんだか<end_line>
+			アニキみたいだったけど<three_dots><end_line>
+		</sjis>
+    <ascii>
+    That guy<three_dots><end_line>
+    He kind of sounded like Bro.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -550,7 +573,7 @@
 		ロブ親方の友達だった人だよ<end_line>
 		鍛冶職人の男の人なんだ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh, no, that's just a nickname.<end_line>
 		He's a friend of Master Rob.<end_line>
     He's a blacksmith.<end_line>
@@ -566,7 +589,7 @@
 		プロスバンって町にすんでて<end_line>
 		昔はいっしょに修行もしたけど<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I trained with him once a<end_line>
     long time ago in Prosban<three_dots><end_line>
 	</ascii>
@@ -580,7 +603,7 @@
 		ロブ親方が死んでからは<end_line>
 		一度も会ってないなぁ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But I haven't seen him<end_line>
 		since Master Rob passed away<three_dots><end_line>
 	</ascii>
@@ -594,7 +617,7 @@
 		そのアニキさんが<end_line>
 		やってきたんですか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		And you think he is here?<end_line>
 	</ascii>
 </dialogue>
@@ -607,7 +630,7 @@
 		今はとにかく<end_line>
 		はぐれ退治に行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I don't know<three_dots><end_line>
 		Anyway, right now we need<end_line>
     to take care of that Stray!<end_line>
@@ -616,21 +639,25 @@
 <dialogue>
 	<info box="nobox">
 	<male>
-		<sjis>
+    <sjis>
 			さっきのセリフ<end_line>
 			なんか、アニキみたいだったな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			さっきのセリフ、なんだか<end_line>
-			アニキみたいだったけど<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     That guy<three_dots><end_line>
     He kind of sounded like Bro.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			さっきのセリフ、なんだか<end_line>
+			アニキみたいだったけど<three_dots><end_line>
+		</sjis>
+    <ascii>
+    That guy<three_dots><end_line>
+    He kind of sounded like Bro.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="nobox">
@@ -639,7 +666,7 @@
 		ロブ親方の友達だった人だよ<end_line>
 		鍛冶職人の男の人なんだ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh, no, that's just a nickname.<end_line>
 		He's a friend of Master Rob.<end_line>
     He's a blacksmith.<end_line>
@@ -652,7 +679,7 @@
 		プロスバンって町にすんでて<end_line>
 		昔はいっしょに修行もしたけど<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I trained with him once a<end_line>
     long time ago in Prosban<three_dots><end_line>
 	</ascii>
@@ -663,7 +690,7 @@
 		ロブ親方が死んでからは<end_line>
 		一度も会ってないなぁ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But I haven't seen him<end_line>
 		since Master Rob passed away<three_dots><end_line>
 	</ascii>

--- a/Day 02/021_25053660_17e49dc.xml
+++ b/Day 02/021_25053660_17e49dc.xml
@@ -240,7 +240,7 @@
   </sjis>
   <ascii>
     The Invincible Jade!<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <player gender="male">
@@ -430,15 +430,18 @@
     <sjis>
       どうしてそうなるんだよ？<end_line>
     </sjis>
+    <ascii>
+    Why would you think that?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしてそうなるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Why would you think that?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -563,6 +566,10 @@
       こいつは<partner><end_line>
       オレの相方<three_dots>パートナーだよ<end_line>
     </sjis>
+    <ascii>
+    Yeah.<end_line>
+    This is <partner>, my partner.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -570,11 +577,11 @@
       この子は<partner><end_line>
       わたしの相方<three_dots>パートナーだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah.<end_line>
     This is <partner>, my partner.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -942,15 +949,18 @@
     <sjis>
       なんだってー！<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なんですとー！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
   </ascii>
+  </female>
 </bigtext>
 <dialogue>
   <info box="right">

--- a/Day 02/022_25092748_17ee28c.xml
+++ b/Day 02/022_25092748_17ee28c.xml
@@ -7,7 +7,7 @@
 		はぐれ召喚獣退治なんてしようと<end_line>
 		してたんだよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Anyways, why did you two<end_line>
 		want to fight the Stray?<end_line>
 	</ascii>
@@ -17,24 +17,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="jade" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			それは<three_dots>、パートナーができて<end_line>
 			オレも強くなったと思うし<three_dots><end_line>
 			それに<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			それは<three_dots>、パートナーができて<end_line>
-			わたしも強くなったと思うし<three_dots><end_line>
-			それに<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Because<three_dots> I've gotten stronger<end_line>
     since I got a partner.<end_line>
     And I<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			それは<three_dots>、パートナーができて<end_line>
+			わたしも強くなったと思うし<three_dots><end_line>
+			それに<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Because<three_dots> I've gotten stronger<end_line>
+    since I got a partner.<end_line>
+    And I<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -44,7 +49,7 @@
 		<three_dots>？<end_line>
 		なに？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -57,7 +62,7 @@
 		そういうことか<end_line>
 		気持ちはわからんでもないな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ahh<three_dots><end_line>
 		I see how it is.<end_line>
 		I understand how you feel.<end_line>
@@ -72,7 +77,7 @@
 		悪いことじゃないと<end_line>
 		オレは思うからな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Well, I guess it's not<end_line>
 		like hating to lose<end_line>
 		to others is a bad thing.<end_line>
@@ -83,18 +88,21 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="jade" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、それ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What are you trying to say?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ<end_line>
+		</sjis>
+    <ascii>
+    What are you trying to say?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -105,7 +113,7 @@
 		勝負するところが<end_line>
 		ちょっとちがうんじゃないのか？<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		You guys are Craftknights, right?<end_line>
 		The area you're suppose to challenge<end_line>
 		others in is a bit different, yeah?<end_line>
@@ -120,7 +128,7 @@
 		ロブの様な一流の鍛冶師には<end_line>
 		なれないぜ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		If you keep doing that,<end_line>
 		you might never become<end_line>
 		a top-class Craftknight like Rob.<end_line>
@@ -136,7 +144,7 @@
 		オレだって毎日修行してるんだ<end_line>
 		今だったらアニキと勝負したって<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Wha!<end_line>
 		I train everyday!<end_line>
     I'm sure if we had a match<three_dots><end_line>
@@ -151,7 +159,7 @@
 		互角に戦えるくらい<end_line>
 		強くなってるさ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I'm strong enough to beat you!<end_line>
 	</ascii>
 </dialogue>
@@ -165,7 +173,7 @@
 		わたしだって毎日修行してるんだよ<end_line>
 		今だったらアニキと勝負したって<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Wha!<end_line>
 		I train everyday!<end_line>
     I'm sure if we had a match<three_dots><end_line>
@@ -180,7 +188,7 @@
 		互角に戦えるくらい<end_line>
 		強くなってるよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I'm strong enough to beat you!<end_line>
 	</ascii>
 </dialogue>
@@ -193,7 +201,7 @@
 		いつまでたってもお前は<end_line>
 		半人前なんだよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     You're so childish<three_dots><end_line>
     This is why you'll<end_line>
     always be an amateur.<end_line>
@@ -204,18 +212,21 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="jade" eye="sad" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			半人前って言うな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			半人前って言わないで！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm not an amateur!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			半人前って言わないで！<end_line>
+		</sjis>
+    <ascii>
+    I'm not an amateur!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -226,7 +237,7 @@
 		いられませんよ<end_line>
 		僕、もう戻っていいですか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I don't have time for this.<end_line>
 		May I leave now?<end_line>
 	</ascii>
@@ -240,7 +251,7 @@
 		オレもこんなことしてる場合じゃ<end_line>
 		なかったんだ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah, that's right.<end_line>
 		This isn't the time for<end_line>
 		kid's stuff like this.<end_line>
@@ -253,7 +264,7 @@
 	<sjis>
 		こ、こんなこと！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		K-Kid's stuff!?<end_line>
 	</ascii>
 </dialogue>
@@ -265,7 +276,7 @@
 		ちょっとヴィーねえさんに<end_line>
 		話があるんでな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I have some business with Vee.<end_line>
 	</ascii>
 </dialogue>
@@ -277,7 +288,7 @@
 		村長の家から出て行ったな<end_line>
 		家に戻ったみたいだぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Vee was just at the Chief's house.<end_line>
 		She might be back back home by now.<end_line>
 	</ascii>
@@ -289,7 +300,7 @@
 		そっスか<end_line>
 		ありがとっス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I see.<end_line>
 		Thanks.<end_line>
 	</ascii>
@@ -298,21 +309,25 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="stressed">
 	<male>
-		<sjis>
+    <sjis>
 			ちょっと待てよ！<end_line>
 			こっちの話がまだ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ちょっと待ってよ！<end_line>
-			こっちの話がまだ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Wait a minute!<end_line>
     I'm not done yet<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ちょっと待ってよ！<end_line>
+			こっちの話がまだ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Wait a minute!<end_line>
+    I'm not done yet<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -322,7 +337,7 @@
 	<sjis>
 		行ッテシマイマシタ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		They Have Already Left.<end_line>
 	</ascii>
 </dialogue>
@@ -334,7 +349,7 @@
 	<sjis>
 		行ってしまったぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		They're gone.<end_line>
 	</ascii>
 </dialogue>
@@ -346,7 +361,7 @@
 	<sjis>
 		ヤツはもう行ったぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		They're already gone.<end_line>
 	</ascii>
 </dialogue>
@@ -358,7 +373,7 @@
 	<sjis>
 		行っちゃいましたよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		They already left<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -372,7 +387,7 @@
 		そういえば親方に何の用なんだろう<end_line>
 		ちょっと気になるなぁ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
     What does he want with Vee?<end_line>
     I'm kind of curious<three_dots><end_line>
@@ -386,7 +401,7 @@
 	<sjis>
 		よし、オレたちも戻ろう<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Alright, let's head back too.<end_line>
 	</ascii>
 </dialogue>
@@ -400,7 +415,7 @@
 		そういえば親方に何の用かな？<end_line>
 		ちょっと気になるなぁ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
     What does he want with V.E?<end_line>
     I'm kind of curious<three_dots><end_line>
@@ -414,7 +429,7 @@
 	<sjis>
 		よし、わたしたちも戻ろう<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Alright, let's head back too.<end_line>
 	</ascii>
 </dialogue>

--- a/Day 02/023_25057292_17e580c.xml
+++ b/Day 02/023_25057292_17e580c.xml
@@ -3,24 +3,29 @@
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<portrait_r entry="weido_1" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			またお前たちかよ<three_dots><end_line>
 			なんか用？<end_line>
 			急いでるんだけど<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			またあんたたち<three_dots><end_line>
-			なんか用？<end_line>
-			急いでるんだけど<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You guys again<three_dots><end_line>
     What is it?<end_line>
     We're busy.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			またあんたたち<three_dots><end_line>
+			なんか用？<end_line>
+			急いでるんだけど<end_line>
+		</sjis>
+    <ascii>
+    You guys again<three_dots><end_line>
+    What is it?<end_line>
+    We're busy.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -31,7 +36,7 @@
 		はぐれ退治しようとしてた<end_line>
 		みたいじゃねぇか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It looks like the<end_line>
     Stray's apprentice is<end_line>
 		going around hunting Strays.<end_line>
@@ -45,7 +50,7 @@
 		なんだそれ<end_line>
 		ワケわかんねえ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     How could you do that<end_line>
     to your own kind?<end_line>
 		It just makes no sense.<end_line>
@@ -56,18 +61,21 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="weido_1" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだと、お前<three_dots>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What was that!? You<three_dots>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ！<end_line>
+		</sjis>
+    <ascii>
+    What was that!? You<three_dots>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -76,7 +84,7 @@
 	<sjis>
 		やンのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You wanna fight?<end_line>
 	</ascii>
 </dialogue>
@@ -90,7 +98,7 @@
 		ナイノデスカ？<end_line>
 		あにきサンハ　イイノデスカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Were We Not In A Hurry?<end_line>
 	</ascii>
 </dialogue>
@@ -103,7 +111,7 @@
 		ほう<three_dots><end_line>
 		アニキの件はもう良いのかの？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ho<three_dots><end_line>
 		Weren't we in a hurry?<end_line>
 	</ascii>
@@ -117,7 +125,7 @@
 		ふっ<three_dots><end_line>
 		アニキの話はいいんだな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Fu<three_dots><end_line>
 		You change your mind quick.<end_line>
 	</ascii>
@@ -132,7 +140,7 @@
 		アニキさんのお話は<end_line>
 		もういいんですか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		My<three_dots><end_line>
 		You were in a hurry<end_line>
 		just a moment ago.<end_line>
@@ -145,7 +153,7 @@
 	<sjis>
 		あ、そうだった<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Right.<end_line>
 	</ascii>
 </dialogue>
@@ -154,23 +162,27 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="weido_1" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			悪いけど<end_line>
 			お前たちみたいなヤツらに<end_line>
 			かまってるヒマ、ないんだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Sorry, but I don't have time<end_line>
+    to play with guys like you.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			悪いけど<end_line>
 			あんたたちみたいな人に<end_line>
 			かまってるヒマ、ないのよ<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Sorry, but I don't have time<end_line>
     to play with guys like you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -179,7 +191,7 @@
 	<sjis>
 		<three_dots>なんだと<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>What was that?<end_line>
 	</ascii>
 </dialogue>
@@ -188,23 +200,28 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="weido_1" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			それに、弱い者イジメなんかすると<end_line>
 			また半人前あつかいされちまう<end_line>
 			からな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			それに、弱い者イジメなんかすると<end_line>
-			また半人前あつかいされちゃうもん<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Besides, preying on the weak<end_line>
     is what the bad guys do.<end_line>
     I'd just get scolded again.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			それに、弱い者イジメなんかすると<end_line>
+			また半人前あつかいされちゃうもん<end_line>
+		</sjis>
+    <ascii>
+    Besides, preying on the weak<end_line>
+    is what the bad guys do.<end_line>
+    I'd just get scolded again.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -215,7 +232,7 @@
 		弱い者イジメって、はぐれの弟子が<end_line>
 		イキがってんじゃねぇよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huhh!?<end_line>
 		You're just a Stray's apprentice,<end_line>
 		don't get so full of yourself!<end_line>
@@ -226,24 +243,29 @@
 	<portrait_l entry="player" eye="sad" mouth="neutral">
 	<portrait_r entry="weido_1" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			ほら<end_line>
 			こんなことでさわいでると<end_line>
 			レミィのヤツがくるぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ほら<end_line>
-			こんなことでさわいでると<end_line>
-			またレミィがくるんじゃない？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Come on now.<end_line>
     Keep that up and Lemmy<end_line>
     will tell you off again.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ほら<end_line>
+			こんなことでさわいでると<end_line>
+			またレミィがくるんじゃない？<end_line>
+		</sjis>
+    <ascii>
+    Come on now.<end_line>
+    Keep that up and Lemmy<end_line>
+    will tell you off again.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -252,7 +274,7 @@
 	<sjis>
 		<three_dots>くそっ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Dammit!<end_line>
 	</ascii>
 </dialogue>
@@ -263,7 +285,7 @@
 	<sjis>
 		じゃ、行こうか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Well, let's get going then.<end_line>
 	</ascii>
 </dialogue>
@@ -275,7 +297,7 @@
 	<sjis>
 		オー！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Affirmative.<end_line>
 	</ascii>
 </dialogue>
@@ -287,7 +309,7 @@
 	<sjis>
 		承知<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Acknowledged.<end_line>
 	</ascii>
 </dialogue>
@@ -299,7 +321,7 @@
 	<sjis>
 		好きにしろ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah, yeah<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -311,7 +333,7 @@
 	<sjis>
 		そうですね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Agreed.<end_line>
 	</ascii>
 </dialogue>

--- a/Day 02/024_25058908_17e5e5c.xml
+++ b/Day 02/024_25058908_17e5e5c.xml
@@ -2,21 +2,25 @@
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			あれ<three_dots>？<end_line>
 			ミューノ、なに見てんだ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あれ<three_dots>？<end_line>
-			ミューノ、なに見てんだろ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Huh<three_dots>?<end_line>
     Murno, what are you looking at?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あれ<three_dots>？<end_line>
+			ミューノ、なに見てんだろ？<end_line>
+		</sjis>
+    <ascii>
+    Huh<three_dots>?<end_line>
+    Murno, what are you looking at?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -27,7 +31,7 @@
 		おかえりなさい<end_line>
 		私もさっき村長さんの家から戻ったの<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah, <player_nickname>!<end_line>
 		Welcome back.<end_line>
 		We just got home.<end_line>
@@ -42,7 +46,7 @@
 		ヴィーさんの大かつやくのおかげで<end_line>
 		大成功だったわ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The whole 'Forbidden Love'<end_line>
     story was a huge success!<end_line>
 		It's all thanks to Miss Vee<three_dots><end_line>
@@ -56,7 +60,7 @@
 		村長さん感動しちゃって<end_line>
 		なんだか少し悪いくらい<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The village head was moved to tears.<end_line>
 		I kinda felt bad lying to him<three_dots><end_line>
 	</ascii>
@@ -66,71 +70,79 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="murno" eye="sad" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			へぇ<three_dots>、そりゃよかった<end_line>
 			正直上手くいったのは<end_line>
 			ビックリだけど<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Oh<three_dots> That's great!<end_line>
 			Honestly though, I'm surprised<end_line>
       it went over so well.<end_line>
 		</ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			ホント！？　よかったね！<end_line>
 			正直上手くいったのは<end_line>
 			ビックリだけど<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Really!? That's awesome!<end_line>
 			Honestly though, I'm surprised<end_line>
       it went over so well.<end_line>
 		</ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="murno" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			（ミューノも楽しかったみたいで<end_line>
 			　ホントによかったな<three_dots>）<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			（ミューノも楽しかったみたいだね<end_line>
-			　ホントによかった<three_dots>）<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     (Murno looks like she had fun.<end_line>
      I'm glad it worked out<three_dots>)<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			（ミューノも楽しかったみたいだね<end_line>
+			　ホントによかった<three_dots>）<end_line>
+		</sjis>
+    <ascii>
+    (Murno looks like she had fun.<end_line>
+     I'm glad it worked out<three_dots>)<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="murno" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			ところでなにしてんの？<end_line>
 			こんなとこで<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ところでどうしたの？<end_line>
-			こんなとこで<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     By the way, what are you up to?<end_line>
     Why are you just standing here?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ところでどうしたの？<end_line>
+			こんなとこで<three_dots><end_line>
+		</sjis>
+    <ascii>
+    By the way, what are you up to?<end_line>
+    Why are you just standing here?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -141,7 +153,7 @@
 		さっき、こわい人が来て<end_line>
 		私には用のない話だって<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Um<three_dots><end_line>
 		A scary man came by earlier,<end_line>
 		and told me I wasn't needed.<end_line>
@@ -152,18 +164,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<portrait_r entry="murno" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			追い出したのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			追い出したの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     He kicked you out!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			追い出したの？<end_line>
+		</sjis>
+    <ascii>
+    He kicked you out!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -173,7 +188,7 @@
 		そうじゃないけど<end_line>
 		居づらくて<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Not exactly,<end_line>
 		but it was difficult<end_line>
     to stay inside, so<three_dots>.<end_line>
@@ -186,7 +201,7 @@
 	<sjis>
 		まったくアニキは<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		*sigh* Bro<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -200,7 +215,7 @@
 		敵ニ設定シマス<end_line>
 		イイデスカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Setting Identification<end_line>
     Code To Enemy.<end_line>
 		Requesting Verbal Confirmation.<end_line>
@@ -214,7 +229,7 @@
 	<sjis>
 		だからアニキは敵じゃないって！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I told you he's not a bad guy!<end_line>
 	</ascii>
 </dialogue>
@@ -227,7 +242,7 @@
 		<three_dots><end_line>
 		了解デス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 		Roger<three_dots><end_line>
 	</ascii>
@@ -241,7 +256,7 @@
 		やはり面がまえのとおり<end_line>
 		あやつは敵じゃったか！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I knew he was up to no good.<end_line>
 		I'll have his head for this<three_dots><end_line>
 	</ascii>
@@ -254,7 +269,7 @@
 	<sjis>
 		だからアニキは敵じゃないって！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I told you he's not a bad guy!<end_line>
 	</ascii>
 </dialogue>
@@ -266,7 +281,7 @@
 	<sjis>
 		むむ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Grr<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -279,7 +294,7 @@
 		やはり見た目のとおり<end_line>
 		あいつは敵か<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So he is an enemy after all.<end_line>
 		I'll be sure to erase him.<end_line>
 	</ascii>
@@ -292,7 +307,7 @@
 	<sjis>
 		だからアニキは敵じゃないって！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I told you he's not a bad guy!<end_line>
 	</ascii>
 </dialogue>
@@ -304,7 +319,7 @@
 	<sjis>
 		ちっ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Tch<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -317,7 +332,7 @@
 		やっぱりコワイ顔の人は<end_line>
 		敵にちがいありませんわ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So that scary-faced man<end_line>
 		really is an enemy then!<end_line>
 	</ascii>
@@ -330,7 +345,7 @@
 	<sjis>
 		だからアニキは敵じゃないって！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I told you he's not a bad guy!<end_line>
 	</ascii>
 </dialogue>
@@ -342,7 +357,7 @@
 	<sjis>
 		<three_dots>ホントですか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Are you sure?<end_line>
 	</ascii>
 </dialogue>
@@ -354,7 +369,7 @@
 	<sjis>
 		なんか<three_dots>不満なのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What<three_dots><end_line>
 		You still don't believe me?<end_line>
 	</ascii>
@@ -369,7 +384,7 @@
 		ミューノを追い出したこと<end_line>
 		注意してやるよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Alright, well,<end_line>
 		let's go ask him about it then.<end_line>
 	</ascii>
@@ -382,7 +397,7 @@
 	<sjis>
 		なんか<three_dots>不満なの？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What<three_dots><end_line>
 		You still don't believe me?<end_line>
 	</ascii>
@@ -397,7 +412,7 @@
 		ミューノを追い出したこと<end_line>
 		注意してあげる<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Alright, well,<end_line>
 		let's go ask him about it then.<end_line>
 	</ascii>

--- a/Day 02/025_25060668_17e653c.xml
+++ b/Day 02/025_25060668_17e653c.xml
@@ -5,7 +5,7 @@
 		ちょっとアニキ<end_line>
 		さっきミューノにヒドイこと<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey Bro,<end_line>
 		Murno said you<three_dots><end_line>
 	</ascii>
@@ -16,7 +16,7 @@
 	<sjis>
 		はぐれ召喚獣狩り、だって！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hunting Strays, you said!?<end_line>
 	</ascii>
 </dialogue>
@@ -26,7 +26,7 @@
 	<sjis>
 		え<three_dots>！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh<three_dots>!?<end_line>
 	</ascii>
 </dialogue>
@@ -39,7 +39,7 @@
 		ガラの悪い連中まで雇ってな<end_line>
 		さがし回ってるみたいだ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Yeah.<end_line>
 		They've even hired thugs,<end_line>
 		and seem to be searching everywhere.<end_line>
@@ -53,7 +53,7 @@
 		この間、地震があっただろ？<end_line>
 		あの時も出かけてたみたいだぜ<three_dots><end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		There was an earthquake just now,<end_line>
 		wasn't there?<end_line>
 		Seems like Strays appeared then.<end_line>
@@ -68,7 +68,7 @@
 		まだ動けるようになったばっか<end_line>
 		なんだろう？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Does he not remember anything?<end_line>
 		They just recently managed<end_line>
 		to be able to move again, right?<end_line>
@@ -82,7 +82,7 @@
 		それなのにまた<end_line>
 		ロブの仇討ちだなんて<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Even so, talking about<end_line>
 		avenging Rob again<three_dots><end_line>
 	</ascii>
@@ -91,20 +91,23 @@
 	<info box="left">
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			ロブ親方の<end_line>
 			仇討ちだって！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Avenging Master Rob!?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			ロブ親方の<end_line>
 			仇討ち！？<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Avenging Master Rob!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -115,7 +118,7 @@
 		ボスタフさんはロブの<end_line>
 		親友だったし<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There's no helping it.<end_line>
 		Bostaph was Rob's<end_line>
 		best friend, after all.<end_line>
@@ -128,7 +131,7 @@
 	<sjis>
 		親友、か<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Best friends, huh<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -141,7 +144,7 @@
 		多くなってるから<end_line>
 		止める理由もない<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Lately, Strays have been causing<end_line>
 		even more injuries in town,<end_line>
 		so we can't just stop him.<end_line>
@@ -156,7 +159,7 @@
 		あんたには知らせておいた方が<end_line>
 		いいと思ってよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But since it involves Bostaph,<end_line>
 		I thought it'd be better<end_line>
 		if you knew anyway.<end_line>
@@ -171,7 +174,7 @@
 		すまなかったね<end_line>
 		気をつかわせちまって<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Is that so<three_dots><end_line>
 		Sorry for the bother.<end_line>
 	</ascii>
@@ -185,7 +188,7 @@
 		ねえさんにあやまられるの<end_line>
 		はじめてかもしれないな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh<three_dots><end_line>
 		This might be the first time<end_line>
 		I've heard an apology from you.<end_line>
@@ -199,7 +202,7 @@
 		いつもはアンタが<end_line>
 		あやまってたからね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's because it's usually you<end_line>
 		who does the apologizing.<end_line>
 	</ascii>
@@ -213,7 +216,7 @@
 		かわってねぇな<three_dots><end_line>
 		安心したぜ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hah, yeah I guess so<three_dots><end_line>
 		You haven't changed a bit<three_dots><end_line>
 	</ascii>
@@ -226,7 +229,7 @@
 		で<end_line>
 		どうするつもりだい？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So, what are you going to do?<end_line>
 	</ascii>
 </dialogue>
@@ -239,7 +242,7 @@
 		ボスタフに会いに行った方がいいね<end_line>
 		町に行くよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I think<three_dots><end_line>
 		It'd be better if I talked to him.<end_line>
 		So I'll be going to town.<end_line>
@@ -249,18 +252,21 @@
 	<info box="right" effect="big">
 	<portrait_r entry="player" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			オレも行く！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしも行く！<end_line>
-		</sjis>
-	</female>
-  <ascii>	
+    <ascii>	
     I'm coming too!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしも行く！<end_line>
+		</sjis>
+    <ascii>	
+    I'm coming too!<end_line>
+  </ascii>
+  </female>
 </bigtext>
 <dialogue>
 	<info box="left">
@@ -269,7 +275,7 @@
 	<sjis>
 		なんだって？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What!?<end_line>
 	</ascii>
 </dialogue>
@@ -278,24 +284,29 @@
 	<portrait_l entry="vee" eye="surprised" mouth="stressed">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			オレも手伝いたいんだ<end_line>
 			はぐれ召喚獣狩り！<end_line>
 			ロブ親方の仇が討ちたいんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしも手伝いたいの<end_line>
-			はぐれ召喚獣狩り！<end_line>
-			ロブ親方の仇を討ちたいの！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I wanna help too!<end_line>
     Stray hunting!<end_line>
     I want to avenge Master Rob!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしも手伝いたいの<end_line>
+			はぐれ召喚獣狩り！<end_line>
+			ロブ親方の仇を討ちたいの！<end_line>
+		</sjis>
+    <ascii>
+    I wanna help too!<end_line>
+    Stray hunting!<end_line>
+    I want to avenge Master Rob!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -305,7 +316,7 @@
 		ロブの仇討ちだと<three_dots><end_line>
 		なに言ってるんだよ、お前は<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		Avenge Rob<three_dots>?<end_line>
     You're an idiot.<end_line>
 	</ascii>
@@ -315,24 +326,29 @@
 	<portrait_l entry="jade" eye="decided" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			言っただろ<end_line>
 			修行して強くなったって！<end_line>
 			今なら親方の仇だって<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			言ったでしょ<end_line>
-			修行して強くなったって！<end_line>
-			今なら親方の仇だって<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I told you,<end_line>
     I've trained and become strong!<end_line>
     Now, even Master's enemies will-<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			言ったでしょ<end_line>
+			修行して強くなったって！<end_line>
+			今なら親方の仇だって<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I told you,<end_line>
+    I've trained and become strong!<end_line>
+    Now, even Master's enemies will-<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -343,7 +359,7 @@
 		お前は何にもわかっちゃいねぇな<end_line>
 		ホントにロブの弟子だったのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You've become strong!?<end_line>
 		You really don't get it, do you?<end_line>
     Rob would never want this.<end_line>
@@ -354,24 +370,29 @@
 	<portrait_l entry="jade" eye="decided" mouth="tense">
 	<portrait_r entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			わかってないのはアニキだ<end_line>
 			オレの強さを見せてやるから<end_line>
 			勝負しろ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わかってないのはアニキだよ<end_line>
-			わたしの強さを見せてあげるから<end_line>
-			勝負してよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You're the one who doesn't get it!<end_line>
     I'll show you my strength!<end_line>
     Let's have a match!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わかってないのはアニキだよ<end_line>
+			わたしの強さを見せてあげるから<end_line>
+			勝負してよ！<end_line>
+		</sjis>
+    <ascii>
+    You're the one who doesn't get it!<end_line>
+    I'll show you my strength!<end_line>
+    Let's have a match!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -382,7 +403,7 @@
 		テメェの強さをジマンしたいだけの<end_line>
 		ヤツなんざ、鍛冶師失格だ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Well aren't you confident!<end_line>
     This is why you're an amateur!<end_line>
     Strength isn't everything!<end_line>
@@ -396,7 +417,7 @@
 		まったく<three_dots><end_line>
 		ロブが生きてたら何て言うか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		If only Rob were still here<three_dots><end_line>
 		Maybe he could talk <end_line>
     some sense into you<three_dots><end_line>
@@ -409,7 +430,7 @@
 	<sjis>
 		ちょっと待ちな！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hold it right there, Jade!<end_line>
 	</ascii>
 </dialogue>
@@ -420,7 +441,7 @@
 	<sjis>
 		なんだよ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What now<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -432,7 +453,7 @@
 		うちの<player_nickname>をバカにすると<end_line>
 		このアタシが承知しないよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No one treats <player_nickname><end_line>
 		like an idiot without my consent!<end_line>
 	</ascii>
@@ -445,7 +466,7 @@
 		おいおい<end_line>
 		悪いのはオレかよ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey, I'm not the bad guy here<three_dots>!<end_line>
 	</ascii>
 </dialogue>
@@ -455,7 +476,7 @@
 	<sjis>
 		へっへ～ん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hehe~<end_line>
 	</ascii>
 </dialogue>
@@ -466,7 +487,7 @@
 	<sjis>
 		アンタも笑ってンじゃないっ！<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		And what are you laughing about!?<end_line>
 	</ascii>
 </dialogue>
@@ -474,18 +495,21 @@
 	<info box="left">
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<male>
-		<sjis>
+    <sjis>
 			いって～っ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いった～<three_dots>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Owww!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いった～<three_dots>！<end_line>
+		</sjis>
+    <ascii>
+    Owww!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -496,7 +520,7 @@
 		仇討ちだなんてくだらないこと<end_line>
 		言うんじゃないって言っただろ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You're part of the problem too!<end_line>
 		I told you not to talk about<end_line>
 		dumb stuff like revenge.<end_line>
@@ -509,7 +533,7 @@
 	<sjis>
 		だから半人前って言われるんだ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's why you're<end_line>
     treated like a kid!<end_line>
 	</ascii>
@@ -521,7 +545,7 @@
 	<sjis>
 		でも<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -534,7 +558,7 @@
 		ちゃんと修行するんだよ！<end_line>
 		わかったね！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You're to stay here<end_line>
 		and practice, got it?<end_line>
 	</ascii>
@@ -546,7 +570,7 @@
 	<sjis>
 		そんな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -556,7 +580,7 @@
 	<sjis>
 		きゃあっ！！！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Kyaa!!<end_line>
 	</ascii>
 </bigtext>
@@ -568,7 +592,7 @@
 		今ノ声ハ<three_dots>！<end_line>
 		みゅーの様！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     That Voice<three_dots>!<end_line>
 		Lady Murno!<end_line>
 	</ascii>
@@ -580,7 +604,7 @@
 	<sjis>
 		ミューノの悲鳴！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That sounded like Murno!<end_line>
 	</ascii>
 </dialogue>
@@ -591,7 +615,7 @@
 	<sjis>
 		ミューノの声か！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Murno!<end_line>
 	</ascii>
 </dialogue>
@@ -602,7 +626,7 @@
 	<sjis>
 		ミューノ様！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Lady Murno!?<end_line>
 	</ascii>
 </dialogue>
@@ -612,7 +636,7 @@
 	<sjis>
 		なにごとだい！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What's going on!?<end_line>
 	</ascii>
 </dialogue>

--- a/Day 02/026_25063612_17e70bc.xml
+++ b/Day 02/026_25063612_17e70bc.xml
@@ -5,7 +5,7 @@
 	<sjis>
 		おねがい、返して！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Please, give it back!<end_line>
 	</ascii>
 </dialogue>
@@ -17,7 +17,7 @@
 		そんなに大事なものなのか<end_line>
 		コレ？<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		Is this thing really<end_line>
 		that important?<end_line>
 	</ascii>
@@ -29,7 +29,7 @@
 		あれは<three_dots><end_line>
 		ミューノの！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's<three_dots><end_line>
 		The thing Murno was holding!<end_line>
 	</ascii>
@@ -43,7 +43,7 @@
 		とても大事なものなの<end_line>
 		だから<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yes, it's incredibly important.<end_line>
 		So please<three_dots><end_line>
 	</ascii>
@@ -57,7 +57,7 @@
 		じゃあ、今度こそ<end_line>
 		オレたちとつきあってくれよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Is that so<three_dots><end_line>
     Come hang with us then.<end_line>
     We'll have lotsa fun together<three_dots><end_line>
@@ -71,7 +71,7 @@
 		そしたらこの間のことも<end_line>
 		忘れてやってもいいかもな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We might even forget<end_line>
 		about last time too,<end_line>
 		if you're lucky.<end_line>
@@ -84,7 +84,7 @@
 	<sjis>
 		そんな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -94,7 +94,7 @@
 	<sjis>
 		この間？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Last time?<end_line>
 	</ascii>
 </dialogue>
@@ -108,7 +108,7 @@
 		まだそんなこと言ってんのか！<end_line>
 		しつこいンだよ！<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		I can't believe you guys<end_line>
 		are still doing this crap!<end_line>
 		Just leave her alone!<end_line>
@@ -123,7 +123,7 @@
 		もういっぺん<end_line>
 		ぶっとばされたいか！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'll beat the crap outta you if<end_line>
 		you even lay a finger on Murno.<end_line>
 	</ascii>
@@ -138,7 +138,7 @@
 		まだそんなこと言ってるの！<end_line>
 		しつこすぎ！<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		I can't believe you guys<end_line>
 		are still doing this crap!<end_line>
 		Just leave her alone!<end_line>
@@ -153,7 +153,7 @@
 		ミューノにちょっかい出すと<end_line>
 		ゆるさないんだから！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I won't forgive you if you<end_line>
 		 even lay a finger on Murno.<end_line>
 	</ascii>
@@ -166,7 +166,7 @@
 	<sjis>
 		攻撃もーどニ移行シマス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Initiating Combat Mode.<end_line>
 	</ascii>
 </dialogue>
@@ -179,7 +179,7 @@
 		おぬしら<three_dots><end_line>
 		仕置きが足りなかったようじゃの<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You two<three_dots><end_line>
 		Seems we didn't punish you enough<three_dots><end_line>
 	</ascii>
@@ -194,7 +194,7 @@
 		もう２度と目に入れたくもない<three_dots><end_line>
 		今度こそ、消してやる<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I never want to see your<end_line>
     stupid faces again<three_dots><end_line>
 		This time, I will erase you.<end_line>
@@ -208,7 +208,7 @@
 	<sjis>
 		手かげんなしですわ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I won't hold back!<end_line>
 	</ascii>
 </dialogue>
@@ -221,7 +221,7 @@
 		弱い者イジメはしないんじゃ<end_line>
 		なかったのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh, scary<three_dots><end_line>
 		Didn't you say you weren't<end_line>
 		going to bully the weak?<end_line>
@@ -232,23 +232,27 @@
 	<portrait_l entry="weido_1" eye="sad" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			なに言ってんだよ！<end_line>
 			イタイ目にあいたくなかったら<end_line>
 			はやく返せ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Quit messing around!<end_line>
+    Just give it back you loser!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			なに言ってるのよ！<end_line>
 			イタイ目にあいたくなかったら<end_line>
 			はやく返して！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Quit messing around!<end_line>
     Just give it back you loser!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -259,7 +263,7 @@
 		お前に返すくらいなら<end_line>
 		ぶっこわした方がましだ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No way!<end_line>
 		I'd rather destroy it<end_line>
 		than give it back to you!<end_line>
@@ -273,7 +277,7 @@
 		そんな！？<end_line>
 		やめて！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What!?<end_line>
 		No! Stop!<end_line>
 	</ascii>
@@ -285,7 +289,7 @@
 		返して<three_dots>！<end_line>
 		返せ<three_dots>っ！！！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Give it back<three_dots>!<end_line>
 		Give it<three_dots>!!!<end_line>
 	</ascii>
@@ -298,7 +302,7 @@
 		なんだよ、こいつっ！<end_line>
 		はなせっ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What's with you!?<end_line>
 		Lemme go<three_dots>!<end_line>
 	</ascii>
@@ -309,7 +313,7 @@
 	<sjis>
 		ミューノっ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Murno!<end_line>
 	</ascii>
 </dialogue>
@@ -320,7 +324,7 @@
 	<sjis>
 		返せっ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Give it back!<end_line>
 	</ascii>
 </bigtext>
@@ -332,7 +336,7 @@
 		うるせえっ！<end_line>
 		今すぐぶっこわすぞ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Shut up already!<end_line>
 		I'm gonna break it right now!<end_line>
 	</ascii>
@@ -344,7 +348,7 @@
 	<sjis>
 		<three_dots>っ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>!<end_line>
 	</ascii>
 </dialogue>
@@ -353,18 +357,21 @@
 	<portrait_l entry="weido_1" eye="decided" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			きっさま<three_dots>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あんたねぇ<three_dots>！<end_line>
-		</sjis>
-	</female>
-  <ascii>	
+    <ascii>	
     Why you<three_dots>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あんたねぇ<three_dots>！<end_line>
+		</sjis>
+    <ascii>	
+    Why you<three_dots>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -374,7 +381,7 @@
 		お前が頭を下げるんなら<end_line>
 		返してやってもいいぜ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		If you bow your head to us,<end_line>
 		I'll return it.<end_line>
 	</ascii>
@@ -388,7 +395,7 @@
 		ごめんなさい<end_line>
 		返して下さい<three_dots>ってな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		"Sorry for all that arrogant crap.<end_line>
 		Please forgive me."<end_line>
 		Say that.<end_line>
@@ -399,18 +406,21 @@
 	<portrait_l entry="weido_1" eye="sad" mouth="talk">
 	<portrait_r entry="player" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なに<three_dots>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			えっ<three_dots>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Wha<three_dots>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			えっ<three_dots>！<end_line>
+		</sjis>
+    <ascii>
+    Wha<three_dots>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -419,7 +429,7 @@
 		ちっ<three_dots><end_line>
 		カスヤローが<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Tch<three_dots><end_line>
 		You scumbags<three_dots><end_line>
 	</ascii>
@@ -431,7 +441,7 @@
 	<sjis>
 		待ちなよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Wait.<end_line>
 	</ascii>
 </dialogue>
@@ -442,7 +452,7 @@
 	<sjis>
 		なんで！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Why!?<end_line>
 	</ascii>
 </dialogue>
@@ -454,7 +464,7 @@
 		いいから<end_line>
 		だまって見てな！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Enough,<end_line>
 		just watch quietly!<end_line>
 	</ascii>
@@ -464,18 +474,21 @@
 	<portrait_l entry="weido_1" eye="decided" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			だれがお前たちなんかに！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			だれがあんたたちなんかに！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     In your dreams!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			だれがあんたたちなんかに！<end_line>
+		</sjis>
+    <ascii>
+    In your dreams!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -484,7 +497,7 @@
 	<sjis>
 		だったら、ぶっこわすだけだ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Well then, I'll just break it!<end_line>
 	</ascii>
 </dialogue>
@@ -495,7 +508,7 @@
 	<sjis>
 		く<three_dots>っ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Urgh<three_dots>!<end_line>
 	</ascii>
 </dialogue>
@@ -507,7 +520,7 @@
 		じゃあ、頭下げる気になったら<end_line>
 		教えてくれ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Well, you should let us know<end_line>
     if you change your mind.<end_line>
 	</ascii>
@@ -521,7 +534,7 @@
 		早くしないと武器の材料にでも<end_line>
 		しちまうぜ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		If you don't hurry it up,<end_line>
 		it'll become weapon material.<end_line>
 	</ascii>
@@ -534,7 +547,7 @@
 		ゴヴァンの魔石を持っていると<end_line>
 		あなたたちにも不幸が<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Just<three_dots> Please!<end_line>
     If you don't, misfortune will<three_dots>!<end_line>
 	</ascii>
@@ -545,7 +558,7 @@
 	<sjis>
 		いた！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ow!<end_line>
 	</ascii>
 </dialogue>
@@ -557,7 +570,7 @@
 		大丈夫か、ミューノ！？<end_line>
 		ケガしてるのか！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are you okay, Murno!?<end_line>
 		Are you hurt!?<end_line>
 	</ascii>
@@ -571,7 +584,7 @@
 		あいつら<three_dots>！<end_line>
 		ぶっとばしてやる！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Damn it all!<end_line>
 		Those guys<three_dots>!<end_line>
 	</ascii>
@@ -584,7 +597,7 @@
 		大丈夫、ミューノ！？<end_line>
 		ケガしたの！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are you okay, Murno!?<end_line>
 		Are you hurt!?<end_line>
 	</ascii>
@@ -598,7 +611,7 @@
 		本気で怒ったからね<three_dots><end_line>
 		ぶっとばしてやる！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		How could they!<end_line>
     Now I'm really mad<three_dots><end_line>
 		They're gonna get it<three_dots>!<end_line>
@@ -610,7 +623,7 @@
 	<sjis>
 		待ちな！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Wait!<end_line>
 	</ascii>
 </dialogue>
@@ -619,22 +632,26 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="vee" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんでだよ！<end_line>
 			ミューノがやられたんだぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Why!?<end_line>
+    I can't forgive them for this!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			どうして！<end_line>
 			ミューノをこんな目にあわせるなんて<end_line>
 			ゆるせない！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Why!?<end_line>
     I can't forgive them for this!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -644,7 +661,7 @@
 		また仇討ち、かい<three_dots><end_line>
 		まったく<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		After revenge again<three_dots>?<end_line>
 		Jeez<three_dots><end_line>
 	</ascii>
@@ -658,7 +675,7 @@
 		どうしてこんなことに<end_line>
 		なってるのか、だよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     First off,<end_line>
     why do they hate you so much?<end_line>
 		How did it even come to this?<end_line>
@@ -671,7 +688,7 @@
 	<sjis>
 		どうしてって<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What do mean how<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -684,7 +701,7 @@
 		好かれちゃいないけど<end_line>
 		今日のはフンイキがちがったからさ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'm not fond of those guys either,<end_line>
 		but they seemed different today.<end_line>
 		Far more aggressive.<end_line>
@@ -698,7 +715,7 @@
 		アンタ<end_line>
 		なんか心当たりはないのかい？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Do you have any idea why?<end_line>
 	</ascii>
 </dialogue>
@@ -709,7 +726,7 @@
 	<sjis>
 		それは<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Uhh<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -723,7 +740,7 @@
 		しつこくからんでたから<end_line>
 		オレ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The other day,<end_line>
 		they just kept pestering Murno,<end_line>
 		so I<three_dots><end_line>
@@ -739,7 +756,7 @@
 		しつこくからんでたから<end_line>
 		わたし<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The other day,<end_line>
 		they just kept pestering Murno,<end_line>
 		so I<three_dots><end_line>
@@ -752,7 +769,7 @@
 	<sjis>
 		ぶっとばしたのかい？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Beat them up?<end_line>
 	</ascii>
 </dialogue>
@@ -763,7 +780,7 @@
 	<sjis>
 		<three_dots>うん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Sorta<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -775,7 +792,7 @@
 		ま、あんなカス<end_line>
 		なぐられてもしかたないだろうな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Well, there's no helping<end_line>
 		punching out scum like them.<end_line>
 	</ascii>
@@ -787,7 +804,7 @@
 	<sjis>
 		そうだよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's right!<end_line>
 	</ascii>
 </dialogue>
@@ -800,7 +817,7 @@
 		そのせいで今<end_line>
 		こんな目にあってるんだろ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What're you saying!<end_line>
 		Isn't that why this<end_line>
 		happened to begin with?<end_line>
@@ -813,7 +830,7 @@
 	<sjis>
 		そんな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -826,7 +843,7 @@
 		そんな下らないこと<end_line>
 		いつまでも続けるつもりかい？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Stop getting into fights.<end_line>
 		Just how long are you gonna keep <end_line>
 		doing stupid stuff like that?<end_line>
@@ -839,7 +856,7 @@
 	<sjis>
 		でも<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -848,21 +865,25 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="vee" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			だったらどうすればいいんだよ<end_line>
 			ミューノがケガしてんだぜ！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			だったらどうすればいいの<end_line>
-			ミューノがケガしたんだよ！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What should I have done then?<end_line>
     They were going to hurt Murno!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			だったらどうすればいいの<end_line>
+			ミューノがケガしたんだよ！？<end_line>
+		</sjis>
+    <ascii>
+    What should I have done then?<end_line>
+    They were going to hurt Murno!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -873,7 +894,7 @@
 		子供のケンカにつきあうほど<end_line>
 		アタシはヒマじゃないんだ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Think about that yourself!<end_line>
 		I have more important things to<end_line>
 		do than get involved in this.<end_line>
@@ -888,7 +909,7 @@
 		そりゃちょっと<end_line>
 		冷たいんじゃないのか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey<three_dots><end_line>
 		That's pretty cold, isn't it?<end_line>
 	</ascii>
@@ -902,7 +923,7 @@
 		ウチのやり方に口挟むのは<end_line>
 		やめてもらいたいね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I don't need your advice.<end_line>
     I have my ways.<end_line>
 	</ascii>
@@ -916,7 +937,7 @@
 		あんたの身内がやられてるんだぜ？<end_line>
 		何もしないつもりなのかよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Are you kidding me!?<end_line>
 		You're not gonna do anything!?<end_line>
 	</ascii>
@@ -930,7 +951,7 @@
 		だからあの子自身で<end_line>
 		ケリをつけさせたいんだ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Exactly<three_dots><end_line>
 		I want to let that kid<end_line>
 		settle things themselves<three_dots><end_line>
@@ -943,7 +964,7 @@
 	<sjis>
 		<three_dots>っ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>!<end_line>
 	</ascii>
 </dialogue>
@@ -954,7 +975,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -962,18 +983,21 @@
 	<info box="left">
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			オレは、どうしたら<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたし、どうしたら<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I<three_dots> What should I<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わたし、どうしたら<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I<three_dots> What should I<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -984,7 +1008,7 @@
 		ご※ぁんノ魔石ヲ　取リ返シ<end_line>
 		みゅーの様ヲ守ル<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Retrieve Govan's Demon Stone.<end_line>
 		Protect Lady Murno<three_dots><end_line>
 	</ascii>
@@ -997,7 +1021,7 @@
 	<sjis>
 		<partner><three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<partner><three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1010,7 +1034,7 @@
 		<three_dots>悪いが、ヤツらをたおして<end_line>
 		ゴヴァンの魔石を取り戻すだけじゃ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>All we can do is fight<end_line>
 		and retrieve that stone.<end_line>
 	</ascii>
@@ -1024,7 +1048,7 @@
 		でも、そうしたら<end_line>
 		またあいつらが<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But if we do that,<end_line>
     the next time we see them<three_dots><end_line>
 	</ascii>
@@ -1039,7 +1063,7 @@
 		村から出て行けばすむこと<three_dots><end_line>
 		全ては元のさやに収まるだけじゃ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That'll be settled<end_line>
 		if we leave the village<three_dots><end_line>
 		Just return everything to normal.<end_line>
@@ -1053,7 +1077,7 @@
 	<sjis>
 		そんな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<partner><three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1066,7 +1090,7 @@
 		ヤツらを消して<end_line>
 		ゴヴァンの魔石を取り戻すだけだ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		All we have to do is get rid<end_line>
 		of them and take back the stone.<end_line>
 	</ascii>
@@ -1080,7 +1104,7 @@
 		でも、そうしたら<end_line>
 		またあいつらが<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But if we do that,<end_line>
     the next time we see them<three_dots><end_line>
 	</ascii>
@@ -1095,7 +1119,7 @@
 		魔石を取り戻したら<end_line>
 		こんな村、出て行けばいい<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Doesn't matter.<end_line>
 		Once we have the stone,<end_line>
 		we can just leave this town.<end_line>
@@ -1109,7 +1133,7 @@
 	<sjis>
 		そんな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<partner><three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1122,7 +1146,7 @@
 		あの人たちをやっつけて<end_line>
 		ゴヴァンの魔石を取り戻します<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Beat them up,<end_line>
 		and take back the stone!<end_line>
 	</ascii>
@@ -1136,7 +1160,7 @@
 		でも、そうしたら<end_line>
 		またあいつらが<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But if we do that,<end_line>
     the next time we see them<three_dots><end_line>
 	</ascii>
@@ -1151,7 +1175,7 @@
 		この村から出て行けば<end_line>
 		関係ありませんわ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		If we just leave the village<end_line>
 		afterwards, there's no problem.<end_line>
 	</ascii>
@@ -1164,7 +1188,7 @@
 	<sjis>
 		そんな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<partner><three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1174,7 +1198,7 @@
 	<sjis>
 		私、返してもらいに<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'm<three_dots> Going to get it back<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1186,7 +1210,7 @@
 		ちょっと待ちな<end_line>
 		ケガしてるんだろ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Hold on a second.<end_line>
 		Aren't you hurt?!<end_line>
 	</ascii>
@@ -1200,7 +1224,7 @@
 		ダメなんです<three_dots>！<end_line>
 		アレは私が守らないと<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     But<three_dots><end_line>
 		I have to<three_dots><end_line>
 		If I don't guard it<three_dots>!<end_line>
@@ -1214,7 +1238,7 @@
 		一体なんなんだい<three_dots><end_line>
 		そのゴヴァンの魔石ってのは<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Just what is it<three_dots>?<end_line>
 		This "Govan's Demon Stone"<three_dots>?<end_line>
 	</ascii>
@@ -1227,7 +1251,7 @@
 		それは<three_dots><end_line>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's<three_dots><end_line>
 		<three_dots><end_line>
 	</ascii>
@@ -1241,7 +1265,7 @@
 		わかったよ<end_line>
 		とにかく今はムリしなくていい<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So you can't say<three_dots><end_line>
 		Alright then.<end_line>
 		Anyway, don't push yourself.<end_line>
@@ -1256,7 +1280,7 @@
 		あいつらは返しちゃくれないし<end_line>
 		大丈夫、こわされやしないよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Even if you went, those guys<end_line>
 		aren't the kind of folk to just<end_line>
 		give it back to you.<end_line>
@@ -1271,7 +1295,7 @@
 		あいつらの手にあるかぎり<end_line>
 		こっちは手を出しづらいからな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's true, as long as they<end_line>
 		have the stone, it'll be hard<end_line>
 		to make a move at all.<end_line>
@@ -1285,7 +1309,7 @@
 		さあ、ウチに戻りな<end_line>
 		ケガの手当だよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's go home, then.<end_line>
 		We have to treat your injuries.<end_line>
 	</ascii>
@@ -1297,7 +1321,7 @@
 		くっそ<three_dots>！<end_line>
 		ガマンできねぇ<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Dammit<three_dots><end_line>
 		I can't take this!<end_line>
 	</ascii>
@@ -1309,7 +1333,7 @@
 		ちょっと、どこ行くんだい？<end_line>
 		勝手なことするんじゃないよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey, where're you going!?<end_line>
 		Don't do anything stupid!<end_line>
 	</ascii>
@@ -1323,7 +1347,7 @@
 		ただジッとしてると<end_line>
 		何もできない自分にむかつくんだよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I know!<end_line>
 		It just pisses me off<end_line>
 		that I can't do anything!<end_line>
@@ -1333,18 +1357,21 @@
 	<info box="left">
 	<portrait_l entry="player" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			オレのせい、なのか<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしのせい、なの<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     This is my fault<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしのせい、なの<three_dots><end_line>
+		</sjis>
+    <ascii>
+    This is my fault<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -1353,7 +1380,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1362,21 +1389,25 @@
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ごめん<three_dots><end_line>
 			ごめんな、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ごめん<three_dots><end_line>
-			ごめんね、<partner><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Sorry<three_dots><end_line>
     I'm sorry, <partner>.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ごめん<three_dots><end_line>
+			ごめんね、<partner><end_line>
+		</sjis>
+    <ascii>
+    Sorry<three_dots><end_line>
+    I'm sorry, <partner>.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1387,7 +1418,7 @@
 		みゅーの様ヲ　守ル<end_line>
 		魔石ヲ　守ル<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We Must Protect Lady Murno.<end_line>
 		We Must Acquire The Demon Stone.<end_line>
 	</ascii>
@@ -1401,7 +1432,7 @@
 		もうよい、行くぞ<end_line>
 		ヤツらのところへ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Enough, let's get going.<end_line>
 		To where they are.<end_line>
 	</ascii>
@@ -1415,7 +1446,7 @@
 		もう私には関係ないことだ<three_dots><end_line>
 		行くぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Don't drag me into this<three_dots><end_line>
 		Let's just go.<end_line>
 	</ascii>
@@ -1430,7 +1461,7 @@
 		それより早く<end_line>
 		あの人たちのところへ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Don't worry about it<three_dots><end_line>
 		Anyway, let's hurry<end_line>
 		to where they're waiting for us.<end_line>
@@ -1444,7 +1475,7 @@
 		<three_dots>うん<end_line>
 		とにかくアイツらをさがそう<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Okay.<end_line>
 		Let's start looking.<end_line>
 	</ascii>

--- a/Day 02/027_25071948_17e914c.xml
+++ b/Day 02/027_25071948_17e914c.xml
@@ -4,7 +4,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -13,21 +13,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ちょっと、<partner><end_line>
 			どうしたんだ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ちょっと、<partner><end_line>
-			どうしたの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey <partner>,<end_line>
     what's wrong?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ちょっと、<partner><end_line>
+			どうしたの？<end_line>
+		</sjis>
+    <ascii>
+    Hey <partner>,<end_line>
+    what's wrong?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -39,7 +43,7 @@
 		動キヲスル　人物ヲ<end_line>
 		せんさーニ　トラエタノデスガ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     My Sensors Have Detected<end_line>
     Movement Behind Us.<end_line>
     Someone Must Be Following Us.<end_line>
@@ -55,7 +59,7 @@
 		気配を感じたのじゃが<three_dots><end_line>
 		できる<three_dots>、気配を消しおった<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I felt a presence that<end_line>
 		seems to be following us<three_dots><end_line>
 	</ascii>
@@ -70,7 +74,7 @@
 		ちっ<three_dots>！<end_line>
 		ムカムカする<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It feels like we're being watched.<end_line>
     Tch<three_dots>!<end_line>
 		It's pissing me off<three_dots><end_line>
@@ -86,7 +90,7 @@
 		すっごくイヤ～な感じがしたんです<end_line>
 		絶対あの人たちの仲間ですわ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I think someone is following us<three_dots><end_line>
 		I have a very unpleasant feeling<three_dots><end_line>
     I'm certain it may be one of them!<end_line>
@@ -97,23 +101,27 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、それ<three_dots><end_line>
 			そんなヤツ<end_line>
 			ダレもいないぞ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    What are talking about<three_dots><end_line>
+    I don't see anyone else here.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			なによ、それ<three_dots><end_line>
 			そんな人<end_line>
 			ダレもいないよ<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What are talking about<three_dots><end_line>
     I don't see anyone else here.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -123,7 +131,7 @@
 		とにかく、今は<end_line>
 		急がなくちゃ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Anyway, for now,<end_line>
 		we just have to hurry<three_dots><end_line>
 	</ascii>

--- a/Day 02/029_25073276_17e967c.xml
+++ b/Day 02/029_25073276_17e967c.xml
@@ -5,7 +5,7 @@
 	<sjis>
 		誰カイマス！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Someone Is Here!<end_line>
 	</ascii>
 </dialogue>
@@ -16,7 +16,7 @@
 	<sjis>
 		誰じゃ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Who's there!?<end_line>
 	</ascii>
 </dialogue>
@@ -27,7 +27,7 @@
 	<sjis>
 		誰だ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Who's there!?<end_line>
 	</ascii>
 </dialogue>
@@ -38,7 +38,7 @@
 	<sjis>
 		誰ですか！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Who's there!?<end_line>
 	</ascii>
 </dialogue>
@@ -50,7 +50,7 @@
 		やっぱムカついてると<end_line>
 		だめだな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh man~<three_dots><end_line>
 		Like I thought, getting<end_line>
 		pissed off was a bad idea<three_dots><end_line>
@@ -64,7 +64,7 @@
 		アニキ<three_dots><end_line>
 		どうして？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Bro<three_dots><end_line>
 		Why are you here<three_dots>?<end_line>
 	</ascii>
@@ -78,7 +78,7 @@
 		ほら、ここらでも最近<end_line>
 		はぐれが出たって話だし、それを<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Nothing to do with you.<end_line>
 		Look, there's talk on how strays<end_line>
 		were showing up here and stuff, so<three_dots><end_line>
@@ -91,7 +91,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -103,7 +103,7 @@
 		う<three_dots><end_line>
 		わかったよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ugh<three_dots><end_line>
 		Oh, fine!<end_line>
 	</ascii>
@@ -117,7 +117,7 @@
 		だまってろって言われたけど<end_line>
 		やっぱ気になってな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You see, Vee told me to<end_line>
 		not say anything,<end_line>
 		but it really bothers me<three_dots><end_line>
@@ -132,7 +132,7 @@
 		どんな手をつかってくるか<end_line>
 		わかったもんじゃないだろ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		After all, we don't know<end_line>
 		what kind of things those punks<end_line>
 		would do, right?<end_line>
@@ -147,7 +147,7 @@
 		オレのようなシッカリ者が<end_line>
 		ついてないとだな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So, I figured, just in case,<end_line>
 		a reliable guy like me should<end_line>
 		be around to protect you<three_dots><end_line>
@@ -160,7 +160,7 @@
 	<sjis>
 		ありがとう、アニキ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Thanks Bro. I appreciate it.<end_line>
 	</ascii>
 </dialogue>
@@ -171,7 +171,7 @@
 	<sjis>
 		<player_nickname><three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<player_nickname><three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -180,23 +180,27 @@
 	<portrait_l entry="jade" eye="serious" mouth="tense">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			でも、オレ<three_dots><end_line>
 			あいつらとの決着は<end_line>
 			自分でつけたいんだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    But this time<three_dots><end_line>
+    I want to settle things by myself.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			でも、わたし<three_dots><end_line>
 			あの人たちとの決着は<end_line>
 			自分でつけたいんだ<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     But this time<three_dots><end_line>
     I want to settle things by myself.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -205,7 +209,7 @@
 	<sjis>
 		だから<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -218,7 +222,7 @@
 		手はださない<end_line>
 		ギリギリまでな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I know, I know.<end_line>
 		I'll stay out of your way.<end_line>
 		I said 'just in case', you know.<end_line>
@@ -231,7 +235,7 @@
 	<sjis>
 		ありがとう、アニキ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Haha, yeah of course.<end_line>
 		Thanks again.<end_line>
 	</ascii>
@@ -245,7 +249,7 @@
 		だが<end_line>
 		アニキってのは止めろ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Don't mention it.<end_line>
 		But seriously,<end_line>
 		stop calling me 'Bro'!<end_line>
@@ -258,7 +262,7 @@
 	<sjis>
 		えへへ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hehehe~<end_line>
 	</ascii>
 </dialogue>

--- a/Day 02/031_25074812_17e9c7c.xml
+++ b/Day 02/031_25074812_17e9c7c.xml
@@ -6,7 +6,7 @@
 		お前ら<end_line>
 		よくここがわかったな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Oh, you found us.<end_line>
 	</ascii>
 </dialogue>
@@ -15,24 +15,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="weido_1" eye="surprised" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			たのむ<three_dots>！<end_line>
 			その魔石ってヤツを返してくれ<three_dots><end_line>
 			ミューノの大切なものみたいなんだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			おねがい<three_dots>！<end_line>
-			その魔石っていうのを返して<three_dots><end_line>
-			ミューノの大切なものみたいなの<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Please<three_dots>!<end_line>
     Give back that stone!<end_line>
     It's really important<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			おねがい<three_dots>！<end_line>
+			その魔石っていうのを返して<three_dots><end_line>
+			ミューノの大切なものみたいなの<end_line>
+		</sjis>
+    <ascii>
+    Please<three_dots>!<end_line>
+    Give back that stone!<end_line>
+    It's really important<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -43,7 +48,7 @@
 		たしかに光ってるし、フシギなもんだ<end_line>
 		そりゃ大切だろうよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		This rock, huh<three_dots><end_line>
 		It glows a lot. Pretty weird.<end_line>
 		Sure does look important.<end_line>
@@ -58,7 +63,7 @@
 		返してほしければちゃんと<end_line>
 		オレたちに頭を下げろってな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I might be willing to give it back.<end_line>
     You know what you have to do, right?<end_line>
 	</ascii>
@@ -68,18 +73,21 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="weido_1" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			く<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うっ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Urgh<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うっ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Urgh<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -88,7 +96,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -101,7 +109,7 @@
 		魔石ってのをぶっこわすぜ？<end_line>
 		いいのか？　大事なんだろ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey now! Don't surprise me,<end_line>
 		I might lose my grip and break it.<end_line>
 		Is that okay? Isn't it important?<end_line>
@@ -114,7 +122,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -126,7 +134,7 @@
 		で、どうだ？<end_line>
 		あやまる覚悟はできたか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So, what'll you do?<end_line>
 		Ready to apologize?<end_line>
 	</ascii>
@@ -138,7 +146,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -147,21 +155,21 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="weido_1" eye="decided" mouth="neutral">
 	<option>
-		<sjis>
+    <sjis>
 			あやまる覚悟はもうできた<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			I'm ready,<end_line>
 		</ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			実を言うと覚悟できてない<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			I can't do it<three_dots><end_line>
 		</ascii>
-	</option>
+  </option>
 </choice>
 <dialogue>
 	<info box="right">
@@ -170,7 +178,7 @@
 	<sjis>
 		覚悟してから来るんだな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Come back when you are, then.<end_line>
 	</ascii>
 </dialogue>
@@ -180,7 +188,7 @@
 		わかった<three_dots><end_line>
 		あやまるよ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Fine<three_dots><end_line>
 		I'll do it<three_dots><end_line>
 	</ascii>
@@ -192,7 +200,7 @@
 		ひひひ<three_dots><end_line>
 		いい子だ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Heyyyy!<end_line>
 		Now that's a good kid.<end_line>
 	</ascii>
@@ -205,7 +213,7 @@
 		そのゴヴァンの魔石を<end_line>
 		返して下さい<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'm sorry.<end_line>
 		Please return the stone.<end_line>
 	</ascii>
@@ -218,7 +226,7 @@
 		おいおい、それだけか？<end_line>
 		ちゃんとあやまってくれよ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey hey, is that it?<end_line>
     You don't sound very sorry.<end_line>
     Try it again.<end_line>
@@ -231,7 +239,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ugh<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -242,7 +250,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -255,7 +263,7 @@
 		すみませんでした<three_dots><end_line>
 		ごめんなさい<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'm sorry for saying such<end_line>
 		disrespectful things<three_dots><end_line>
 	</ascii>
@@ -269,7 +277,7 @@
 		本当に魔石を返して<end_line>
 		ほしいのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hoho~<end_line>
 		Do you really want it back?<end_line>
 	</ascii>
@@ -281,7 +289,7 @@
 	<sjis>
 		はい<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yes<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -293,7 +301,7 @@
 		その割には<end_line>
 		心がこもってない気がするな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     C'mon kid<three_dots><end_line>
     You really aren't trying are you<three_dots><end_line>
 	</ascii>
@@ -306,7 +314,7 @@
 	<sjis>
 		ナニヲ根拠ニ！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		On What Basis!?<end_line>
 	</ascii>
 </dialogue>
@@ -318,7 +326,7 @@
 	<sjis>
 		なんじゃと！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What was that!?<end_line>
 	</ascii>
 </dialogue>
@@ -330,7 +338,7 @@
 	<sjis>
 		キサマ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Bastard<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -342,7 +350,7 @@
 	<sjis>
 		えぇ<three_dots>！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huhh!?<end_line>
 	</ascii>
 </dialogue>
@@ -353,7 +361,7 @@
 	<sjis>
 		そんな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -366,7 +374,7 @@
 		お前<three_dots><end_line>
 		土下座って知ってるか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Hmm<three_dots><end_line>
     How about this<three_dots><end_line>
 		You know about dogeza?<end_line>
@@ -379,7 +387,7 @@
 	<sjis>
 		どげざ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Do<three_dots> geza<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -391,7 +399,7 @@
 	<sjis>
 		なっ、土下座じゃと<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No<three_dots>!<end_line>
 	</ascii>
 </dialogue>
@@ -404,7 +412,7 @@
 		ヒザついてから<end_line>
 		地面にアタマつけるんだってよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah, it's a Silturn specialty.<end_line>
 		It's where you get on your knees,<end_line>
 		and put your head to the ground.<end_line>
@@ -419,7 +427,7 @@
 		そりゃいい<end_line>
 		やってもらおうか！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Heh~<end_line>
 		That sounds good.<end_line>
 		I'll have you do that!<end_line>
@@ -432,7 +440,7 @@
 	<sjis>
 		！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		!?<end_line>
 	</ascii>
 </dialogue>
@@ -441,23 +449,27 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="weido_1" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			その土下座ってのをすれば<end_line>
 			ゴヴァンの魔石は<end_line>
 			返してもらえるのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    <three_dots>If I do this,<end_line>
+    you'll return the stone?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			その土下座ってのをすれば<end_line>
 			ゴヴァンの魔石は<end_line>
 			返してもらえるの？<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots>If I do this,<end_line>
     you'll return the stone?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -467,7 +479,7 @@
 		お前次第だな<end_line>
 		心をこめてやりゃいいんだよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Maybe. That all depends on<end_line>
 		how sincere you are.<end_line>
 	</ascii>
@@ -479,7 +491,7 @@
 	<sjis>
 		わかった<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Okay<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -491,7 +503,7 @@
 		ひゃははは！<end_line>
 		かっこわりい！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hyahahaha!<end_line>
 		That's so lame!<end_line>
 	</ascii>
@@ -504,7 +516,7 @@
 		ほら<end_line>
 		もっとシッカリやれよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Look,<end_line>
 		you gotta do it properly!<end_line>
 	</ascii>
@@ -515,7 +527,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -528,7 +540,7 @@
 		土下座ハ　シマシタ<end_line>
 		ダカラ　魔石ヲ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We Have Done It.<end_line>
 		Now Return The Stone.<end_line>
 	</ascii>
@@ -542,7 +554,7 @@
 		これで気が済んだはずじゃ<end_line>
 		魔石を<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Are you satisfied?<end_line>
     Now then, the stone<three_dots><end_line>
 	</ascii>
@@ -556,7 +568,7 @@
 		おい<end_line>
 		早く魔石を渡せ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are we done here?<end_line>
 		Give it back already<three_dots><end_line>
 	</ascii>
@@ -570,7 +582,7 @@
 		これでいいですよね？<end_line>
 		魔石を返して下さい！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's enough isn't it?<end_line>
 		Please give it back now!<end_line>
 	</ascii>
@@ -582,7 +594,7 @@
 	<sjis>
 		<partner><three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<partner><three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -593,7 +605,7 @@
 	<sjis>
 		どうしようかな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I wonder what I should do<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -605,7 +617,7 @@
 	<sjis>
 		要求ハ全テ　受ケイレマシタガ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Have We Not Fulfilled The Deal!?<end_line>
 	</ascii>
 </dialogue>
@@ -617,7 +629,7 @@
 	<sjis>
 		なんじゃと！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What do you mean 'wonder'?!<end_line>
 	</ascii>
 </dialogue>
@@ -629,7 +641,7 @@
 	<sjis>
 		<three_dots>なんだと<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>You<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -641,7 +653,7 @@
 	<sjis>
 		なんですって！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What's worth wondering about!?<end_line>
 	</ascii>
 </dialogue>
@@ -652,7 +664,7 @@
 	<sjis>
 		へへへ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hehehehe<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -664,7 +676,7 @@
 	<sjis>
 		約束ヲ　ヤブルノデスカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are You Going Back On Our Deal?<end_line>
 	</ascii>
 </dialogue>
@@ -677,7 +689,7 @@
 		おぬしたちの性根が<end_line>
 		ここまでクサっておるとはな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     You truly are rotten to the core<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -690,7 +702,7 @@
 		キサマら<three_dots><end_line>
 		覚悟はいいか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Bastards<three_dots><end_line>
 		Ready to die?<end_line>
 	</ascii>
@@ -705,7 +717,7 @@
 		約束を守らないような人たちに<end_line>
 		ヨウシャはしませんわよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I've had enough<three_dots><end_line>
 		I won't forgive anyone<end_line>
 		who breaks a promise!<end_line>
@@ -720,7 +732,7 @@
 		召喚獣のくせに<end_line>
 		生意気だな！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hah? What was that!?<end_line>
     A Summon Beast, talking back<end_line>
     to a human? You little<three_dots><end_line>
@@ -732,7 +744,7 @@
 	<sjis>
 		うっ！　うわあああ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		U-Uwaah!?<end_line>
 	</ascii>
 </dialogue>
@@ -742,7 +754,7 @@
 	<sjis>
 		アニキ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Bro!<end_line>
 	</ascii>
 </dialogue>
@@ -753,7 +765,7 @@
 		こいつはオレにまかせて<end_line>
 		お前たちも逃げろ！<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		Leave these guys to me.<end_line>
 		Get away from here!<end_line>
 	</ascii>
@@ -762,18 +774,21 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			あいつ、なにやってんだ！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あいつ、なにやってるの！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What's he doing!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あいつ、なにやってるの！？<end_line>
+		</sjis>
+    <ascii>
+    What's he doing!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -781,7 +796,7 @@
 	<sjis>
 		こ、こいつ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		T-This is<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -789,7 +804,7 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			くそっ！<end_line>
 			行くぞ、<partner>！<end_line>
 		</sjis>
@@ -797,9 +812,9 @@
       Dammit!<end_line>
       Let's fight, <partner>!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			あぶない！<end_line>
 			いくよ、<partner>！<end_line>
 		</sjis>
@@ -807,7 +822,7 @@
       Run!<end_line>
       Let's fight, <partner>!<end_line>
      </ascii>
-	</female>  
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -817,7 +832,7 @@
 	<sjis>
 		リ、了解デス！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		R-Roger!<end_line>
 	</ascii>
 </dialogue>
@@ -829,7 +844,7 @@
 	<sjis>
 		このお人好しが！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Alright!<end_line>
 	</ascii>
 </dialogue>
@@ -842,7 +857,7 @@
 		キサマ<three_dots>！<end_line>
 		ちっ<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Bastard<three_dots><end_line>
 		Wait<three_dots>!<end_line>
 	</ascii>
@@ -855,7 +870,7 @@
 	<sjis>
 		あ、はい！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah, yes!<end_line>
 	</ascii>
 </dialogue>

--- a/Day 02/032_25078716_17eabbc.xml
+++ b/Day 02/032_25078716_17eabbc.xml
@@ -5,7 +5,7 @@
 		大丈夫か？<end_line>
 		<player_nickname>、<partner>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are you okay?<end_line>
 		<player_nickname>! <partner>!<end_line>
 	</ascii>
@@ -15,24 +15,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="jade" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			平気、平気！<end_line>
 			言っただろ、強くなったって<end_line>
 			な、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			平気、平気！<end_line>
-			言ったでしょ、強くなったって<end_line>
-			ね、<partner><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm totally fine!<end_line>
     I told you I've gotten stronger!<end_line>
     Right, <partner>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			平気、平気！<end_line>
+			言ったでしょ、強くなったって<end_line>
+			ね、<partner><end_line>
+		</sjis>
+    <ascii>
+    I'm totally fine!<end_line>
+    I told you I've gotten stronger!<end_line>
+    Right, <partner>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -42,7 +47,7 @@
 	<sjis>
 		ハイ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yes.<end_line>
 	</ascii>
 </dialogue>
@@ -54,7 +59,7 @@
 	<sjis>
 		うむ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You're right there.<end_line>
 	</ascii>
 </dialogue>
@@ -66,7 +71,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -78,7 +83,7 @@
 	<sjis>
 		そうですわ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 	  You have!<end_line>
 	</ascii>
 </dialogue>
@@ -87,18 +92,21 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="jade" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			それより、ケガしたヤツらは？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			それより、ケガした人たちは？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What about the others?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			それより、ケガした人たちは？<end_line>
+		</sjis>
+    <ascii>
+    What about the others?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -108,7 +116,7 @@
 		大丈夫だ<end_line>
 		工房で手当を受けてる<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		They're fine.<end_line>
 		They're being treated<end_line>
     at the workshop.<end_line>
@@ -119,21 +127,25 @@
 	<portrait_l entry="player" eye="serious" mouth="serious">
 	<portrait_r entry="lemmy" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>で、お前<end_line>
 			何しにきたんだよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots>で、あんたは<end_line>
-			何しにきたのよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots><end_line>
     And why are you here?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots>で、あんたは<end_line>
+			何しにきたのよ<end_line>
+		</sjis>
+    <ascii>
+    <three_dots><end_line>
+    And why are you here?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -144,7 +156,7 @@
 		レミィさんはな！<end_line>
 		お前のことが<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey!<end_line>
 		Just so you know,<end_line>
 		Mr. Lemmy was<three_dots><end_line>
@@ -158,7 +170,7 @@
 		工房の人間が取り残されているって<end_line>
 		聞いたから、来ただけだよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I heard some of our<end_line>
     people were left behind.<end_line>
     So I came to get them.<end_line>
@@ -172,7 +184,7 @@
 		無事なようですね<end_line>
 		サージさん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Seems like you're fine too, Sarge.<end_line>
 	</ascii>
 </dialogue>
@@ -185,7 +197,7 @@
 		まさかあいつに助けられるとはな<end_line>
 		胸クソ悪ぃ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah<three_dots><end_line>
     Though without them I'd be<three_dots><end_line>
 		It's disgraceful<three_dots><end_line>
@@ -196,24 +208,29 @@
 	<portrait_l entry="weido_1" eye="serious" mouth="tense">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			じゃあ<end_line>
 			助けたお礼に返してくれよ<end_line>
 			ミューノの大事な魔石！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			じゃあ<end_line>
-			助けたお礼に返してよね<end_line>
-			ミューノの大事な魔石！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Then,<end_line>
     to thank me for saving you,<end_line>
     you can return the stone!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			じゃあ<end_line>
+			助けたお礼に返してよね<end_line>
+			ミューノの大事な魔石！<end_line>
+		</sjis>
+    <ascii>
+    Then,<end_line>
+    to thank me for saving you,<end_line>
+    you can return the stone!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -224,7 +241,7 @@
 		勝手にやったくせに<end_line>
 		何言ってやがる！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Thank you!?<end_line>
 		I never asked you to save me!<end_line>
 	</ascii>
@@ -234,22 +251,27 @@
 	<portrait_l entry="weido_1" eye="decided" mouth="serious">
 	<portrait_r entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			なんだと！？<end_line>
 			あんだけあやまったじゃねぇか！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ！？<end_line>
-			あれだけあやまったじゃない！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Don't be like that!<end_line>
     You're still saying that<end_line>
     after everything I've done?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ！？<end_line>
+			あれだけあやまったじゃない！<end_line>
+		</sjis>
+    <ascii>
+    Don't be like that!<end_line>
+    You're still saying that<end_line>
+    after everything I've done?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -260,7 +282,7 @@
 		確かに<three_dots><end_line>
 		借りはできちまったしな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Tch<three_dots><end_line>
 		It<three_dots>is true that<end_line>
 		I'm in your debt<three_dots><end_line>
@@ -274,7 +296,7 @@
 		わかった<end_line>
 		返してやろう<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Fine<three_dots><end_line>
 		I'll give it back<three_dots><end_line>
 	</ascii>
@@ -286,7 +308,7 @@
 	<sjis>
 		やった！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yes! Finally!<end_line>
 	</ascii>
 </dialogue>
@@ -297,7 +319,7 @@
 	<sjis>
 		ただし、条件がある<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But, on one condition.<end_line>
 	</ascii>
 </dialogue>
@@ -310,7 +332,7 @@
 		条件？<end_line>
 		なんだよ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What is it?<end_line>
 	</ascii>
 </dialogue>
@@ -323,7 +345,7 @@
 		オレがお前を助けたこと<end_line>
 		だまってろって？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What, me keeping quiet about<end_line>
 		saving you or something?<end_line>
 	</ascii>
@@ -337,7 +359,7 @@
 		条件？<end_line>
 		なによ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh?<end_line>
 		A condition?<end_line>
 	</ascii>
@@ -352,7 +374,7 @@
 		わたしがあんたを助けたこと<end_line>
 		内緒にしてくださいってコト？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What, me keeping quiet about<end_line>
 		saving you or something?<end_line>
 	</ascii>
@@ -364,7 +386,7 @@
 	<sjis>
 		そんなことじゃない！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Not that!<end_line>
 	</ascii>
 </dialogue>
@@ -373,18 +395,21 @@
 	<portrait_l entry="weido_1" eye="serious" mouth="yell">
 	<portrait_r entry="player" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			じゃあ、なんだよ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			じゃ、なんなのよ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Then what?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			じゃ、なんなのよ？<end_line>
+		</sjis>
+    <ascii>
+    Then what?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -395,7 +420,7 @@
 		お前たちがオレに勝ったら<end_line>
 		魔石は返してやる<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's have a match!<end_line>
 		If you two beat me, fair and square,<end_line>
 		I'll give it back.<end_line>
@@ -410,7 +435,7 @@
 		アナタトノ　勝負ナラ<end_line>
 		先日　勝利シマシタガ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     We Have Already Beat<end_line>
     You Before.<end_line>
 	</ascii>
@@ -424,7 +449,7 @@
 		はて、またいつぞやと<end_line>
 		同じ目にあいたいのかの？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What's this?<end_line>
 		You want a repeat of last time?<end_line>
 	</ascii>
@@ -437,7 +462,7 @@
 	<sjis>
 		<three_dots>無駄な事を<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>That's pointless.<end_line>
 		We've already crushed you before.<end_line>
 	</ascii>
@@ -450,7 +475,7 @@
 	<sjis>
 		あらあら、こりない方ですわね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh dear, how persistent.<end_line>
 	</ascii>
 </dialogue>
@@ -463,7 +488,7 @@
 		オレだって、ボスタフ工房丙部屋の<end_line>
 		組頭なんだ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Shut up!<end_line>
     I still have my pride as<end_line>
     a senior at the atelier.<end_line>
@@ -478,7 +503,7 @@
 		他の部屋に示しがつかねぇんだよ<end_line>
 		だから、もう一度勝負してくれ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I'll set a bad example<end_line>
     if I just keep losing.<end_line>
 		So fight against me, one last time!<end_line>
@@ -493,7 +518,7 @@
 		でも<three_dots><end_line>
 		勝負、か<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 		A match, huh<three_dots><end_line>
 	</ascii>
@@ -505,7 +530,7 @@
 	<sjis>
 		たのむ<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Please!<end_line>
 	</ascii>
 </dialogue>
@@ -516,7 +541,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -525,59 +550,62 @@
 	<portrait_l entry="weido_1" eye="decided" mouth="serious">
 	<portrait_r entry="player" eye="decided" mouth="serious">
 	<male>
-		<option>
-			<sjis>
+    <option>
+      <sjis>
 				わかった！　勝負しよう<end_line>
 			</sjis>
-			<ascii>
+      <ascii>
 				Alright! Let's do this!<end_line>
 			</ascii>
-		</option>
-		<option>
-			<sjis>
+    </option>
+    <option>
+      <sjis>
 				だめだ<three_dots>　勝負なんかできない<end_line>
 			</sjis>
-			<ascii>
+      <ascii>
 				No<three_dots> I can't accept that.<end_line>
 			</ascii>
-		</option>
-	</male>
-	<female>
-		<option>
-			<sjis>
+    </option>
+  </male>
+  <female>
+    <option>
+      <sjis>
 				わかったわ！　勝負しよう<end_line>
 			</sjis>
-			<ascii>
+      <ascii>
 				Alright! Let's do this!<end_line>
 			</ascii>
-		</option>
-		<option>
-			<sjis>
+    </option>
+    <option>
+      <sjis>
 				だめだよ<three_dots>　勝負なんかできない<end_line>
 			</sjis>
-			<ascii>
+      <ascii>
 				No<three_dots> I can't accept that.<end_line>
 			</ascii>
-		</option>
-	</female>
+    </option>
+  </female>
 </choice>
 <dialogue>
 	<info box="right">
 	<portrait_l entry="weido_1" eye="decided" mouth="serious">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			わかった<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わかったわ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わかったわ<end_line>
+		</sjis>
+    <ascii>
+    Alright.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -588,7 +616,7 @@
 		お前をたおすためにあみだした必殺技<end_line>
 		見せてやるぜ！<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		Let's do it!<end_line>
     I'm not the same as before!<end_line>
     Time to show off my new moves!<end_line>
@@ -599,45 +627,54 @@
 	<portrait_l entry="weido_1" eye="decided" mouth="talk">
 	<portrait_r entry="player" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			へえ！<end_line>
 			おもしろそうだぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ふーん<end_line>
-			おもしろそうね！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Oh?<end_line>
     Bring it on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ふーん<end_line>
+			おもしろそうね！<end_line>
+		</sjis>
+    <ascii>
+    Oh?<end_line>
+    Bring it on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
 	<portrait_l entry="weido_1" eye="decided" mouth="talk">
 	<portrait_r entry="player" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			だめだ<end_line>
 			ケンカで解決ってのは<end_line>
 			ダメなんだ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			だめだよ<end_line>
-			ケンカで解決するのは<end_line>
-			ダメなんだよ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I can't.<end_line>
     Settling things through fighting<end_line>
     is just meaningless<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			だめだよ<end_line>
+			ケンカで解決するのは<end_line>
+			ダメなんだよ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I can't.<end_line>
+    Settling things through fighting<end_line>
+    is just meaningless<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -648,7 +685,7 @@
 		それに魔石を返して欲しければ<end_line>
 		勝負を受けるしかねぇんだ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's not just a fight! It's a match!<end_line>
 		And if you want that stone back,<end_line>
 		this is the only way you'll get it!<end_line>
@@ -659,21 +696,25 @@
 	<portrait_l entry="weido_1" eye="decided" mouth="yell">
 	<portrait_r entry="player" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そんな<three_dots><end_line>
 			じゃ、勝負するしかないのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そんな<three_dots><end_line>
-			じゃ、勝負するしかないの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ugh<three_dots><end_line>
     Do I have to<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そんな<three_dots><end_line>
+			じゃ、勝負するしかないの？<end_line>
+		</sjis>
+    <ascii>
+    Ugh<three_dots><end_line>
+    Do I have to<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -684,7 +725,7 @@
 		お前をたおすためにあみだした必殺技<end_line>
 		見せてやるぜ！<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		Let's do it!<end_line>
     I'm not the same as before!<end_line>
     Time to show off my new moves!<end_line>
@@ -695,21 +736,25 @@
 	<portrait_l entry="weido_1" eye="decided" mouth="neutral">
 	<portrait_r entry="player" eye="happy" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			ああ<three_dots>！<end_line>
 			もう、仕方ないか！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ああ<three_dots>！<end_line>
-			もう、仕方ないわ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ugh<three_dots>!<end_line>
     Well alright, let's do it then!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ああ<three_dots>！<end_line>
+			もう、仕方ないわ！<end_line>
+		</sjis>
+    <ascii>
+    Ugh<three_dots>!<end_line>
+    Well alright, let's do it then!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -719,7 +764,7 @@
 		意外に面白いことに<end_line>
 		なってきたじゃねぇか！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now this is getting exciting!<end_line>
 	</ascii>
 </dialogue>
@@ -729,7 +774,7 @@
 	<sjis>
 		バカらしい<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		How idiotic.<end_line>
 	</ascii>
 </dialogue>
@@ -740,7 +785,7 @@
 		あ！？<end_line>
 		レミィさん？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah!?<end_line>
 		Lemmy?<end_line>
 	</ascii>
@@ -754,7 +799,7 @@
 		さっきの戦いで消耗してたとか<end_line>
 		言われちゃたまんねぇ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     This time,<end_line>
     I won't make any excuses.<end_line>
     We'll have a fair fight.<end_line>
@@ -768,7 +813,7 @@
 		オレはここで待ってるから<end_line>
 		準備してきな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'll be waiting here<end_line>
     whenever you're ready.<end_line>
 	</ascii>

--- a/Day 02/033_25081580_17eb6ec.xml
+++ b/Day 02/033_25081580_17eb6ec.xml
@@ -5,7 +5,7 @@
 	<sjis>
 		勝負の準備はできたのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You ready for the match?<end_line>
 	</ascii>
 </dialogue>
@@ -14,42 +14,46 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="weido_1" eye="serious" mouth="neutral">
 	<option>
-		<sjis>
+    <sjis>
 			準備はバッチリ！<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Bring it on!<end_line>
 		</ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			そういえば忘れ物が<three_dots><end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Ehh, wait a bit<three_dots><end_line>
 		</ascii>
-	</option>
+  </option>
 </choice>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			よし！<end_line>
 			行くぞ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よし！<end_line>
-			行くよ、<partner>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Let's do this, <partner>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よし！<end_line>
+			行くよ、<partner>！<end_line>
+		</sjis>
+    <ascii>
+    Alright!<end_line>
+    Let's do this, <partner>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -59,7 +63,7 @@
 	<sjis>
 		オー！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yes!<end_line>
 	</ascii>
 </dialogue>
@@ -71,7 +75,7 @@
 	<sjis>
 		承知！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Understood!<end_line>
 	</ascii>
 </dialogue>
@@ -83,7 +87,7 @@
 	<sjis>
 		好きにしろ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yep.<end_line>
 	</ascii>
 </dialogue>
@@ -95,7 +99,7 @@
 	<sjis>
 		はい！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Okay!<end_line>
 	</ascii>
 </dialogue>

--- a/Day 02/034_25082540_17ebaac.xml
+++ b/Day 02/034_25082540_17ebaac.xml
@@ -3,21 +3,25 @@
 	<portrait_l entry="weido_1" eye="sad" mouth="tense">
 	<portrait_r entry="player" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			よしっ！<end_line>
 			勝ったぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やったぁ！<end_line>
-			勝ったよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
     I won!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やったぁ！<end_line>
+			勝ったよ！<end_line>
+		</sjis>
+    <ascii>
+    Yeah!<end_line>
+    I won!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -26,7 +30,7 @@
 	<sjis>
 		負けちまったか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ugh<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -37,7 +41,7 @@
 	<sjis>
 		さあ、早くゴヴァンの魔石を<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now, about that stone<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -46,18 +50,21 @@
 	<portrait_l entry="weido_1" eye="sad" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			返してもらおうか！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			返して！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'll be taking it back!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			返して！<end_line>
+		</sjis>
+    <ascii>
+    I'll be taking it back!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -66,7 +73,7 @@
 	<sjis>
 		誰がお前に返すって言った？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Who said anything about<end_line>
 		giving it to you?<end_line>
 	</ascii>
@@ -76,18 +83,21 @@
 	<portrait_l entry="weido_1" eye="serious" mouth="talk">
 	<portrait_r entry="player" eye="surprised" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			なんだと！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     But you did!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ！？<end_line>
+		</sjis>
+    <ascii>
+    But you did!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -97,7 +107,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -110,7 +120,7 @@
 		おぬし<three_dots><end_line>
 		仏の顔も三度までじゃぞ<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 		I've gotten truly sick of you.<end_line>
 	</ascii>
@@ -125,7 +135,7 @@
 		この私がこれ以上<end_line>
 		ガマンするとでも思ったのか<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
     I'm done putting up with your crap.<end_line>
 	</ascii>
@@ -138,7 +148,7 @@
 		あなた<three_dots><end_line>
 		私、もう本気で<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
     I'm seriously going to<three_dots><end_line>
 	</ascii>
@@ -151,7 +161,7 @@
 		誰も返さないとは言ってないだろ<end_line>
 		コレは直接あの子に返す<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Didn't say I wouldn't give it back.<end_line>
 		I'll give it to the girl myself.<end_line>
 	</ascii>
@@ -164,7 +174,7 @@
 		え<three_dots>？<end_line>
 		直接<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Really?<end_line>
 	</ascii>
 </dialogue>
@@ -175,7 +185,7 @@
 	<sjis>
 		ありがとう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Thanks!<end_line>
 	</ascii>
 </dialogue>
@@ -186,7 +196,7 @@
 	<sjis>
 		え？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Eh?<end_line>
 	</ascii>
 </dialogue>
@@ -198,7 +208,7 @@
 		あ、ああ<three_dots><end_line>
 		<three_dots>悪かった、な<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Uhhh<three_dots> yeah<three_dots><end_line>
 		<three_dots>Sorry<three_dots><end_line>
 	</ascii>
@@ -210,7 +220,7 @@
 	<sjis>
 		なに？<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		Hm?<end_line>
 	</ascii>
 </dialogue>
@@ -222,7 +232,7 @@
 		なんでもねぇよ<end_line>
 		じゃあ行くぜ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Nothing.<end_line>
 		I'll be going.<end_line>
 	</ascii>
@@ -235,7 +245,7 @@
 		よかったな<end_line>
 		<player_nickname><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     And all is well.<end_line>
 	</ascii>
 </dialogue>
@@ -246,7 +256,7 @@
 	<sjis>
 		うん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah!<end_line>
 	</ascii>
 </dialogue>
@@ -255,20 +265,23 @@
 	<portrait_l entry="player" eye="happy" mouth="neutral">
 	<portrait_r entry="jade" eye="happy" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			よし！<end_line>
 			オレたちも戻ろう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Alright, let's head back too!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			さて！<end_line>
 			わたしたちも戻ろう！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright, let's head back too!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -278,7 +291,7 @@
 	<sjis>
 		オー！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yes!<end_line>
 	</ascii>
 </dialogue>
@@ -290,7 +303,7 @@
 	<sjis>
 		承知！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Understood!<end_line>
 	</ascii>
 </dialogue>
@@ -302,7 +315,7 @@
 	<sjis>
 		好きにしろ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Alright.<end_line>
 	</ascii>
 </dialogue>
@@ -314,7 +327,7 @@
 	<sjis>
 		はい！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Okay!<end_line>
 	</ascii>
 </dialogue>

--- a/Day 02/035_25084012_17ec06c.xml
+++ b/Day 02/035_25084012_17ec06c.xml
@@ -5,7 +5,7 @@
 		お<end_line>
 		きたきた<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh,<end_line>
 		there you are.<end_line>
 	</ascii>
@@ -17,7 +17,7 @@
 		何やってンだ？<end_line>
 		遅いぞ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What were you doing?<end_line>
 		You're late!<end_line>
 	</ascii>
@@ -27,18 +27,21 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="weido_1" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			なんだと！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Huh!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ！<end_line>
+		</sjis>
+    <ascii>
+    Huh!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -48,7 +51,7 @@
 		うるせぇ<end_line>
 		行くぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You're annoying.<end_line>
 		Let's get this over with.<end_line>
 	</ascii>
@@ -59,7 +62,7 @@
 	<sjis>
 		うるさいのはどっちだ！<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		Who's annoying!?<end_line>
 	</ascii>
 </dialogue>
@@ -70,7 +73,7 @@
 	<sjis>
 		うわあ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Woah!<end_line>
 	</ascii>
 </dialogue>
@@ -83,7 +86,7 @@
 		<three_dots>って<player_nickname><end_line>
 		またアンタ、ケンカ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     What's all the commotion?<end_line>
 		<three_dots>Oh, it's just <player_nickname>.<end_line>
     Causing trouble again<three_dots>?<end_line>
@@ -94,21 +97,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="yell">
 	<portrait_r entry="vee" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			ちがうって！<end_line>
 			こいつが魔石を返しに来たんだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ちがうって！<end_line>
-			この人が魔石を返しに来たの<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     No!<end_line>
     This guy came to return the stone.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ちがうって！<end_line>
+			この人が魔石を返しに来たの<end_line>
+		</sjis>
+    <ascii>
+    No!<end_line>
+    This guy came to return the stone.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -119,7 +126,7 @@
 		そっか<end_line>
 		なるほどね<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh~<three_dots><end_line>
 		Is that all?<end_line>
 		I see<three_dots><end_line>
@@ -132,7 +139,7 @@
 		おーい！<end_line>
 		ミューノ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Heeeeeey!<end_line>
 		Murnooo!<end_line>
 	</ascii>
@@ -143,7 +150,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -152,24 +159,29 @@
 	<portrait_l entry="murno" eye="decided" mouth="serious">
 	<portrait_r entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			大丈夫だよ<end_line>
 			こいつがミューノに直接<end_line>
 			魔石を返したいってさ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			大丈夫<end_line>
-			この人、ミューノに直接<end_line>
-			魔石を返したいんだって<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     It's okay.<end_line>
     This guy just wants to<end_line>
     give the stone back to you.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			大丈夫<end_line>
+			この人、ミューノに直接<end_line>
+			魔石を返したいんだって<end_line>
+		</sjis>
+    <ascii>
+    It's okay.<end_line>
+    This guy just wants to<end_line>
+    give the stone back to you.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -178,7 +190,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -190,7 +202,7 @@
 		これ<three_dots><end_line>
 		返す<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		Here<three_dots><end_line>
 		You can have it back.<end_line>
 	</ascii>
@@ -203,7 +215,7 @@
 		<three_dots><end_line>
 		ありがとう<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 		Thank you.<end_line>
 	</ascii>
@@ -217,7 +229,7 @@
 		すまなかったな<three_dots><end_line>
 		それから、ケガは大丈夫か？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No<three_dots><end_line>
 		I'm sorry<three_dots><end_line>
 		Is your wound okay?<end_line>
@@ -231,7 +243,7 @@
 		え<three_dots><end_line>
 		はい、もう<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hm<three_dots>?<end_line>
 		Y-Yes, I'm fine<three_dots><end_line>
 	</ascii>
@@ -244,7 +256,7 @@
 		そうか、よかった<three_dots><end_line>
 		じゃ、オレはこれで<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I see. Good for you.<end_line>
 		Alright, I guess I'll go now.<end_line>
 	</ascii>
@@ -254,20 +266,23 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="weido_1" eye="neutral_blush" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			あ！<end_line>
 			ありがとな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Hey, thanks.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			うん<end_line>
 			ありがとね！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey, thanks.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -277,7 +292,7 @@
 		お前に礼を言われる<end_line>
 		筋合いはない！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I didn't want any thanks from you!<end_line>
 	</ascii>
 </dialogue>
@@ -288,7 +303,7 @@
 	<sjis>
 		よかった<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Thank goodness<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -297,21 +312,25 @@
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<portrait_r entry="murno" eye="sad_blush" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			ごめんな、ミューノ<end_line>
 			オレのせいでこんな目に<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ごめんね、ミューノ<end_line>
-			わたしのせいでこんな目に<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm sorry, Murno.<end_line>
     It's all my fault.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ごめんね、ミューノ<end_line>
+			わたしのせいでこんな目に<end_line>
+		</sjis>
+    <ascii>
+    I'm sorry, Murno.<end_line>
+    It's all my fault.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -322,7 +341,7 @@
 		それより、私の方こそ<end_line>
 		あやまらなくっちゃ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No, it's okay.<end_line>
 		In fact, I should be the<end_line>
 		one apologizing to you<three_dots><end_line>
@@ -337,7 +356,7 @@
 		<player_nickname>たちには<end_line>
 		メイワクかけっぱなしで<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Since I came here, all I've<end_line>
 		done is stir up trouble<three_dots><end_line>
     I must be a burden to you<three_dots><end_line>
@@ -350,7 +369,7 @@
 	<sjis>
 		そんな、メイワクだなんて！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No, it's not a problem!<end_line>
 	</ascii>
 </dialogue>
@@ -362,7 +381,7 @@
 	<sjis>
 		当然ノ事ヲ　シタマデデス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We Only Did What Was Natural.<end_line>
 	</ascii>
 </dialogue>
@@ -375,7 +394,7 @@
 		当然の事じゃ<end_line>
 		ミューノを守るのじゃからな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		This was natural.<end_line>
 		We're sworn to protect you,<end_line>
 		after all.<end_line>
@@ -390,7 +409,7 @@
 		そうだ<end_line>
 		お前が気にすることなど無い<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's right.<end_line>
 		Don't worry about it.<end_line>
 	</ascii>
@@ -404,7 +423,7 @@
 		そうですわ<end_line>
 		当然の事をしたまでです<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's right.<end_line>
 		We're sworn to protect Lady Murno.<end_line>
 	</ascii>
@@ -417,7 +436,7 @@
 		<partner><three_dots><end_line>
 		あなた<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<partner><three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -429,7 +448,7 @@
 		ありがとう<end_line>
 		ふたりとも<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Thank you.<end_line>
 		Both of you.<end_line>
 	</ascii>
@@ -441,7 +460,7 @@
 	<sjis>
 		えへへ<three_dots><end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		Hehe~<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -453,7 +472,7 @@
 		ちったぁマシな顔に<end_line>
 		なってきたってとこかな？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Your face has gotten<end_line>
 		quite a bit more mature, hasn't it?<end_line>
 	</ascii>
@@ -465,7 +484,7 @@
 	<sjis>
 		<player_nickname><three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -479,7 +498,7 @@
 		ごめんなさい<three_dots><end_line>
 		結局、勝負になっちまった<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Master<three_dots><end_line>
 		I'm sorry<three_dots><end_line>
 		It turned into a fight after all<three_dots><end_line>
@@ -493,7 +512,7 @@
 	<sjis>
 		これじゃ、何もかわんないよな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I guess nothing's really changed<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -507,7 +526,7 @@
 		ごめんなさい<three_dots><end_line>
 		結局、勝負になっちゃった<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Master<three_dots><end_line>
 		I'm sorry<three_dots><end_line>
 		It turned into a fight after all<three_dots><end_line>
@@ -521,7 +540,7 @@
 	<sjis>
 		これじゃ、何もかわんないよね<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I guess nothing's really changed<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -533,7 +552,7 @@
 		何言ってるんだい<end_line>
 		ちゃんと変わってるだろ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are you blind?<end_line>
 		Of course things have changed.<end_line>
 	</ascii>
@@ -545,7 +564,7 @@
 	<sjis>
 		えっ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh?<end_line>
 	</ascii>
 </dialogue>
@@ -556,7 +575,7 @@
 	<sjis>
 		アイツの顔さ<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		The other guy's expression.<end_line>
 	</ascii>
 </dialogue>
@@ -568,7 +587,7 @@
 		アイツ、また仕返しみたいなこと<end_line>
 		するような顔、してたかい？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Did he seem like he<end_line>
 		still wanted revenge on you?<end_line>
 	</ascii>
@@ -580,7 +599,7 @@
 	<sjis>
 		ううん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -592,7 +611,7 @@
 		じゃ、そういうことさ<end_line>
 		アンタはよくやったよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     See, there's a difference.<end_line>
 		Good job.<end_line>
 	</ascii>
@@ -605,7 +624,7 @@
 		え～っと<three_dots>？<end_line>
 		つまり、どういうこと？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huuuh?<end_line>
     What?<end_line>
 	</ascii>
@@ -619,7 +638,7 @@
 		力で物事は解決できないこともある<end_line>
 		<three_dots>っていうのはちょっとちがうか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		In short<three_dots><end_line>
 		There are times where you<end_line>
 		can't solve everything by force.<end_line>
@@ -634,7 +653,7 @@
 		やり返そうとか思わないような<end_line>
 		フンイキ作りが大切っていうか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Hm, how do I put this<three_dots>?<end_line>
 		When you beat someone, its important<end_line>
 		to still have some goodwill left?<end_line>
@@ -648,7 +667,7 @@
 		ああ！　もう、やめだ！<end_line>
 		そんなこと、自分で考えな！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Arghhh! I don't know! I quit!<end_line>
 		You can think of it yourself!<end_line>
 	</ascii>
@@ -660,7 +679,7 @@
 	<sjis>
 		え～っ！<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		Ehhh!?<end_line>
 	</ascii>
 </dialogue>
@@ -673,7 +692,7 @@
 		モットモ重要ナ情報ガ<end_line>
 		抜ケテイマス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You Omitted An Important<end_line>
 		Piece Of Information.<end_line>
 	</ascii>
@@ -687,7 +706,7 @@
 		やれやれ<end_line>
 		無責任じゃの<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		My goodness,<end_line>
     how irresponsible.<end_line>
 	</ascii>
@@ -700,7 +719,7 @@
 	<sjis>
 		<three_dots>はぁ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>*sigh*<end_line>
 	</ascii>
 </dialogue>
@@ -713,7 +732,7 @@
 		あの<three_dots><end_line>
 		よくわからなかったんですけど<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Um<three_dots><end_line>
 		I don't really get it.<end_line>
 	</ascii>
@@ -726,7 +745,7 @@
 		ああそうだ！<end_line>
 		昔、ロブが言ってたよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ahh, that's right!<end_line>
     Rob told me this before.<end_line>
 	</ascii>
@@ -740,7 +759,7 @@
 		目的じゃなくて手段の１つとなる<end_line>
 		武器を作るんだってね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We Craftknights work so that<end_line>
 		we may fulfill our goals easier, not<end_line>
 		because crafting itself is our goal.<end_line>
@@ -754,7 +773,7 @@
 		ま、そういうことだよ<end_line>
 		な！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Well, something like that.<end_line>
 	</ascii>
 </dialogue>
@@ -765,7 +784,7 @@
 	<sjis>
 		う～ん<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Uh<three_dots>huh<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -776,7 +795,7 @@
 	<sjis>
 		な！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		WHAT?<end_line>
 	</ascii>
 </bigtext>
@@ -787,7 +806,7 @@
 	<sjis>
 		わかったよ～<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		N-Nothing<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -800,7 +819,7 @@
 		じゃあアタシは<end_line>
 		町へ行く準備でもするかね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Good.<end_line>
 		Now, I guess I'll get ready<end_line>
 		to head to town.<end_line>
@@ -816,7 +835,7 @@
 		もう仇討ちだなんて言わないからさ<end_line>
 		オレも行ってもいいかな？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Master<three_dots><end_line>
     Can I come this time?<end_line>
     I won't say anything stupid.<end_line>
@@ -832,7 +851,7 @@
 		るすばんなんて、ヤだよ<end_line>
 		ちゃんと修行はするからさ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I don't want to stay at home<end_line>
 		when something's happening in town.<end_line>
 		And I promise I'll keep training.<end_line>
@@ -848,7 +867,7 @@
 		もう仇討ちだなんて言わないから<end_line>
 		わたしも行ってもいいかな？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Master<three_dots><end_line>
     Can I come this time?<end_line>
     I won't say anything stupid.<end_line>
@@ -864,7 +883,7 @@
 		るすばんなんて、イヤだよ<end_line>
 		ちゃんと修行はするから<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I don't want to stay at home<end_line>
 		when something's happening in town.<end_line>
 		And I promise I'll keep training.<end_line>
@@ -879,7 +898,7 @@
 		だめだよ<end_line>
 		アンタはるすばん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Of course not.<end_line>
 		You have to watch the house.<end_line>
 	</ascii>
@@ -893,7 +912,7 @@
 		それはないんじゃないか？<end_line>
 		<player_nickname>、よくやったじゃねえか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Heyy.<end_line>
 		You don't have to be like that.<end_line>
 		<player_nickname> did well, right?<end_line>
@@ -908,7 +927,7 @@
 		ウチにミューノひとり<end_line>
 		残しておくワケにはいかないだろ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You again.<end_line>
 		You know we can't leave<end_line>
 		Murno here alone.<end_line>
@@ -923,7 +942,7 @@
 		ごめん、ミューノ<end_line>
 		勝手なこと言っちゃって<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ohh, right.<end_line>
 		Sorry, Murno.<end_line>
 		I was being selfish there.<end_line>
@@ -936,7 +955,7 @@
 	<sjis>
 		<player_nickname><three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<player_nickname><three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -949,7 +968,7 @@
 		<player_nickname>のこと<end_line>
 		よろしくたのむよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     And Murno,<end_line>
     you need to watch out<end_line>
     for <player_nickname> too.<end_line>
@@ -964,7 +983,7 @@
 		私もついていっちゃ<end_line>
 		ダメ、ですか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Um, Miss Vee<three_dots><end_line>
 		Would it be possible<end_line>
 		for me to go with you?<end_line>
@@ -978,7 +997,7 @@
 		ちょっと<three_dots><end_line>
 		なんだい、突然<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey<three_dots><end_line>
 		What's this all of a sudden?<end_line>
 	</ascii>
@@ -992,7 +1011,7 @@
 		身の回りのお世話は<end_line>
 		私の仕事だし<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Until your injuries heal,<end_line>
 		it's my job to help you with<end_line>
 		the daily necessities.<end_line>
@@ -1007,7 +1026,7 @@
 		町へ行くのはこっちの都合だし<end_line>
 		アンタがそこまでする必要はないよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No, it's okay.<end_line>
 		I'm going there on my own accord.<end_line>
 		There's no need to help!<end_line>
@@ -1021,7 +1040,7 @@
 		でも<three_dots>、行きたいんです<end_line>
 		お願いします<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But<three_dots> I want to go.<end_line>
 		Please<three_dots><end_line>
 	</ascii>
@@ -1035,7 +1054,7 @@
 		荷物持ちでも雑用でも<end_line>
 		なんでもしますから<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'll do anything!<end_line>
     Chores, errands, whatever you want!<end_line>
 	</ascii>
@@ -1048,7 +1067,7 @@
 	<sjis>
 		みゅーの様<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Lady Murno<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1060,7 +1079,7 @@
 	<sjis>
 		ミューノ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Murno<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1072,7 +1091,7 @@
 	<sjis>
 		正気か？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Murno<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -1084,7 +1103,7 @@
 	<sjis>
 		ミューノ様<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Lady Murno<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1097,7 +1116,7 @@
 		目立つようなことはできるだけ<end_line>
 		さけた方がいいんじゃ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Why are you<three_dots><end_line>
 		Wouldn't it be better to avoid<end_line>
 		standing out as much as pos-<end_line>
@@ -1110,7 +1129,7 @@
 	<sjis>
 		でも<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1121,7 +1140,7 @@
 	<sjis>
 		え？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hm?<end_line>
 	</ascii>
 </dialogue>
@@ -1133,7 +1152,7 @@
 		ふう～ん<three_dots><end_line>
 		アンタがそこまで考えてるとはねぇ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hmmmm<three_dots><end_line>
 		So you've thought it out that far<three_dots><end_line>
 	</ascii>
@@ -1147,7 +1166,7 @@
 		はぐれもふえて危ないんだよねぇ<three_dots><end_line>
 		アタシひとりだと正直心細いんだよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But there are more strays out now,<end_line>
 		so it's far more dangerous.<end_line>
 		Even I couldn't handle all of them.<end_line>
@@ -1158,41 +1177,41 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="vee" eye="sad" mouth="neutral">
 	<male>
-		<option>
-			<sjis>
+    <option>
+      <sjis>
 				こういう時こそオレの出番だ！<end_line>
 			</sjis>
-			<ascii>
+      <ascii>
 				That's where I come in!<end_line>
 			</ascii>
-		</option>
-		<option>
-			<sjis>
+    </option>
+    <option>
+      <sjis>
 				親方の言うとおり、キケンだな<three_dots><end_line>
 			</sjis>
-			<ascii>
+      <ascii>
 				It is pretty dangerous<three_dots><end_line>
 			</ascii>
-		</option>
-	</male>
-	<female>
-		<option>
-			<sjis>
+    </option>
+  </male>
+  <female>
+    <option>
+      <sjis>
 				こういう時こそわたしの出番！<end_line>
 			</sjis>
-			<ascii>
+      <ascii>
 				That's where I come in!<end_line>
 			</ascii>
-		</option>
-		<option>
-			<sjis>
+    </option>
+    <option>
+      <sjis>
 				親方の言うとおり、キケンだよ<three_dots><end_line>
 			</sjis>
-			<ascii>
+      <ascii>
 				It is pretty dangerous<three_dots><end_line>
 			</ascii>
-		</option>
-	</female>
+    </option>
+  </female>
 </choice>
 <dialogue>
 	<info box="left">
@@ -1201,7 +1220,7 @@
 	<sjis>
 		それなら<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		In that case,<end_line>
 	</ascii>
 </dialogue>
@@ -1210,18 +1229,21 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="vee" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			オレたちがついてるじゃないか！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしたちがついてるじゃない！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     why don't I come along too!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしたちがついてるじゃない！<end_line>
+		</sjis>
+    <ascii>
+    why don't I come along too!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -1231,7 +1253,7 @@
 		それができれば<end_line>
 		悩まないんだけどねぇ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I suppose you could,<end_line>
     if you can keep yourself<end_line>
     out of trouble<three_dots><end_line>
@@ -1244,7 +1266,7 @@
 	<sjis>
 		なっ！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey!<end_line>
 	</ascii>
 </dialogue>
@@ -1257,7 +1279,7 @@
 		ミューノが行くには<end_line>
 		あぶないよ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     It'll certainly be<end_line>
     more dangerous with<end_line>
     Murno tagging along<three_dots><end_line>
@@ -1272,7 +1294,7 @@
 		大丈夫デス<end_line>
 		みゅーの様ハ　私ガ守リマス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It Is Fine.<end_line>
 		I Will Protect Her.<end_line>
 	</ascii>
@@ -1286,7 +1308,7 @@
 		案ずるな<end_line>
 		ミューノはワガハイが守る<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Do not be concerned.<end_line>
 		I will protect her.<end_line>
 	</ascii>
@@ -1300,7 +1322,7 @@
 		だったらキサマがなんとかすれば<end_line>
 		いいだろう<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Why don't you do<end_line>
     something about it then<three_dots><end_line>
 	</ascii>
@@ -1315,7 +1337,7 @@
 		ミューノ様は私が絶対に<end_line>
 		お守りしますので<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     No need for concern!<end_line>
 		I will definitely protect her!<end_line>
 	</ascii>
@@ -1327,7 +1349,7 @@
 	<sjis>
 		あ、そうだ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Of course!<end_line>
 	</ascii>
 </dialogue>
@@ -1336,18 +1358,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			オレだって！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしだって！<end_line>
-		</sjis>
-	</female>	
-  <ascii>
+    <ascii>
     That goes for me too!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしだって！<end_line>
+		</sjis>
+    <ascii>
+    That goes for me too!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -1357,7 +1382,7 @@
 		それができれば<end_line>
 		悩まないんだけどねぇ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I suppose you could,<end_line>
     if you can keep yourself<end_line>
     out of trouble<three_dots><end_line>
@@ -1370,7 +1395,7 @@
 	<sjis>
 		なっ！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey!<end_line>
 	</ascii>
 </dialogue>
@@ -1383,7 +1408,7 @@
 		ねえさんが心配する気持ちも<end_line>
 		わかるな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Well, I can understand<end_line>
 		why Vee's worried.<end_line>
 	</ascii>
@@ -1397,7 +1422,7 @@
 		森にはさっきの男より<end_line>
 		手強いはぐれもいるんだぜ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		In the forest there are strays<end_line>
 		far stronger than that guy earlier.<end_line>
 	</ascii>
@@ -1409,7 +1434,7 @@
 	<sjis>
 		でも<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1422,7 +1447,7 @@
 		オレが直々にお前たちの<end_line>
 		実力をたしかめてやろうか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That said, how about<end_line>
 		I test your strength?<end_line>
 	</ascii>
@@ -1435,7 +1460,7 @@
 		え！？　本当！？<end_line>
 		勝負してくれるの？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Whoa!? Really!?<end_line>
 		You'll fight with me?<end_line>
 	</ascii>
@@ -1449,7 +1474,7 @@
 		鍛冶師としてオレと勝負することが<end_line>
 		できそうだからな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah<three_dots> Right now, you're<end_line>
 		fully capable of going up against<end_line>
 		me as a fellow Craftknight.<end_line>
@@ -1463,7 +1488,7 @@
 		やった！<end_line>
 		さっすがアニキ！　カッコイイ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Alright!<end_line>
 		Just I'd expect from you Bro!<end_line>
 		You're awesome!<end_line>
@@ -1478,7 +1503,7 @@
 		アンタのおすみつきがでればって<end_line>
 		話なんだろうが<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I wonder<three_dots><end_line>
 		If <player_nickname> can get your approval,<end_line>
 		they must've seriously improved.<end_line>
@@ -1493,7 +1518,7 @@
 		負けると思ってるのかい？<end_line>
 		なあ、<player_nickname><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But, do you think that my apprentice<end_line>
 		would lose to someone like you?<end_line>
 		Well, <player_nickname>?<end_line>
@@ -1504,42 +1529,46 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="jade" eye="serious" mouth="talk">
 	<option>
-		<sjis>
+    <sjis>
 			そりゃあ勝つ気マンマンです！<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Of course I'll win!<end_line>
 		</ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			実は勝てる自信がありません<three_dots><end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Actually I'm not that sure<three_dots><end_line>
 		</ascii>
-	</option>
+  </option>
 </choice>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="jade" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			おう！<end_line>
 			もちろん！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん！<end_line>
-			もちろん！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
     Of course!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん！<end_line>
+			もちろん！<end_line>
+		</sjis>
+    <ascii>
+    Yeah!<end_line>
+    Of course!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="nobox">
@@ -1548,7 +1577,7 @@
 	<sjis>
 		どうかなぁ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I wonder<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1561,7 +1590,7 @@
 		今ノ　私タチナラバ<end_line>
 		問題アリマセン<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		As We Are Now,<end_line>
 		We Are Fully Capable Of Victory.<end_line>
 	</ascii>
@@ -1576,7 +1605,7 @@
 		おぬしとワガハイならば<end_line>
 		勝てぬ相手ではないぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Believe in yourself!<end_line>
 		With you and I together,<end_line>
 		there is no opponent to fear.<end_line>
@@ -1591,7 +1620,7 @@
 		<three_dots>面倒だ<end_line>
 		さっさと片付けるぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 		Let's just beat him<end_line>
 		and get it over with.<end_line>
@@ -1607,7 +1636,7 @@
 		自信を持ってください！<end_line>
 		絶対に勝てますわ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     We can do it, <player_nickname>!<end_line>
     Believe in yourself!<end_line>
 		We will definitely win!<end_line>
@@ -1620,7 +1649,7 @@
 	<sjis>
 		<partner><three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<partner><three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1633,7 +1662,7 @@
 		じゃ、エンリョなく<end_line>
 		やらせてもらうぜ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Well said.<end_line>
 		Then, I'll be going at it<end_line>
 		with everything I've got!<end_line>
@@ -1647,7 +1676,7 @@
 		じゃ、こっちもエンリョはいらないよ<end_line>
 		わかったね、<player_nickname>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No holding back then.<end_line>
 		You got that, <player_nickname>?<end_line>
 	</ascii>
@@ -1657,18 +1686,21 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="vee" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			お、おお！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			は、はい！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Y-Yeah!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			は、はい！<end_line>
+		</sjis>
+    <ascii>
+    Y-Yeah!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -1678,7 +1710,7 @@
 		よっしゃ、<player_nickname><end_line>
 		勝負の準備ができたら教えな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Alright then.<end_line>
 		Let me know when you're ready.<end_line>
 	</ascii>

--- a/Day 02/036_25089516_17ed5ec.xml
+++ b/Day 02/036_25089516_17ed5ec.xml
@@ -5,7 +5,7 @@
 	<sjis>
 		勝負の準備はできたのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are you ready?<end_line>
 	</ascii>
 </dialogue>
@@ -14,21 +14,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="jade" eye="serious" mouth="neutral">
 	<option>
-		<sjis>
+    <sjis>
 			準備はカンペキだよ！<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Any time!<end_line>
 		</ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			まだ何か忘れてる気が<three_dots><end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			One more thing<three_dots><end_line>
 		</ascii>
-	</option>
+  </option>
 </choice>
 <dialogue>
 	<info box="right">
@@ -39,7 +39,7 @@
 		じゃあ、お前の実力<end_line>
 		たしかめてやるぜ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Alright!<end_line>
 		Show me what you've got!<end_line>
 	</ascii>
@@ -51,7 +51,7 @@
 	<sjis>
 		この、不死身のジェイドがなっ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I, the invincible Jade, am ready.<end_line>
 	</ascii>
 </dialogue>
@@ -60,21 +60,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いくぞ！<end_line>
 			<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いくよ！<end_line>
-			<partner>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's go!<end_line>
     <partner>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いくよ！<end_line>
+			<partner>！<end_line>
+		</sjis>
+    <ascii>
+    Let's go!<end_line>
+    <partner>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -84,7 +88,7 @@
 	<sjis>
 		オー！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Roger!<end_line>
 	</ascii>
 </dialogue>
@@ -96,7 +100,7 @@
 	<sjis>
 		承知！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yes!<end_line>
 	</ascii>
 </dialogue>
@@ -108,7 +112,7 @@
 	<sjis>
 		好きにしろ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah.<end_line>
 	</ascii>
 </dialogue>
@@ -120,7 +124,7 @@
 	<sjis>
 		はい！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah!<end_line>
 	</ascii>
 </dialogue>

--- a/Day 02/037_25090652_17eda5c.xml
+++ b/Day 02/037_25090652_17eda5c.xml
@@ -5,7 +5,7 @@
 	<sjis>
 		やった！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yes!<end_line>
 	</ascii>
 </dialogue>
@@ -17,7 +17,7 @@
 		つ～<three_dots><end_line>
 		本当に結構やりやがるな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ugh<three_dots><end_line>
 		You got me good<three_dots><end_line>
 	</ascii>
@@ -30,7 +30,7 @@
 		まさかオレの武器がこわされるとは<three_dots><end_line>
 		本当に結構やりやがるな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You broke my weapon<three_dots><end_line>
 		You got me good<three_dots><end_line>
 	</ascii>
@@ -40,20 +40,23 @@
 	<portrait_l entry="jade" eye="serious" mouth="stressed">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			どう？　アニキ<end_line>
 			オレたちの実力？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    So what do you think?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			どう？　アニキ<end_line>
 			わたしたちの実力？<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So what do you think?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -64,7 +67,7 @@
 		ロブの強さに追いつくには<end_line>
 		全然修行が足りてねぇ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You certainly gotten stronger,<end_line>
 		but compared to Rob,<end_line>
 		you've still got a long way to go.<end_line>
@@ -79,7 +82,7 @@
 		今のお前の実力でも<end_line>
 		十分たよりになると思うぜ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But, if it's just protecting<end_line>
 		the village, then your abilities<end_line>
 		are more than enough.<end_line>
@@ -90,21 +93,25 @@
 	<portrait_l entry="jade" eye="happy" mouth="talk">
 	<portrait_r entry="player" eye="happy" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			本当！？<end_line>
 			やったぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			本当！？<end_line>
-			やったあ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Really!?<end_line>
     That's awesome!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			本当！？<end_line>
+			やったあ！<end_line>
+		</sjis>
+    <ascii>
+    Really!?<end_line>
+    That's awesome!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -115,7 +122,7 @@
 		町につながる橋が落ちてるんだ<end_line>
 		ま、抜け道はあるんだが<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now, let's discuss your journey.<end_line>
     So you know the bridge collapsed.<end_line>
 		There is a way past, but<three_dots><end_line>
@@ -130,7 +137,7 @@
 		ちょっと大変だと思うからな<end_line>
 		しっかりお供してやりな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Vee has absolutely no sense<end_line>
     of directions, so you'll need<end_line>
     to stick together.<end_line>
@@ -145,7 +152,7 @@
 		アタシは心にロックっていう<end_line>
 		方位磁石を持つひとりなんだよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     What are you on about!?<end_line>
     All you need to guide you<end_line>
     is the spirit of rock!<end_line>
@@ -160,7 +167,7 @@
 		とにかく<player_nickname>を<end_line>
 		連れて行った方がいいって<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Uh, sure<three_dots><end_line>
 		Anyways, I recommend you take<end_line>
 		<player_nickname> with you.<end_line>
@@ -175,7 +182,7 @@
 		でも、アタシはまだ<end_line>
 		納得できないね！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I get your point,<end_line>
 		but I still can't approve!<end_line>
 	</ascii>
@@ -188,7 +195,7 @@
 		はぁ！？<end_line>
 		そりゃ、どういうことだ！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh!?<end_line>
 		Well why not?<end_line>
 	</ascii>
@@ -202,7 +209,7 @@
 		アタシの弟子がアンタに負けるわけ<end_line>
 		ないんだよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Like I said, there was no way my<end_line>
 		apprentice would lose to you.<end_line>
 	</ascii>
@@ -215,7 +222,7 @@
 		勝って当然！<end_line>
 		当たり前！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's obvious they'd win!<end_line>
 		Obvious!<end_line>
 	</ascii>
@@ -227,7 +234,7 @@
 	<sjis>
 		なんだ、えらそうに！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The hell's that supposed to mean!?<end_line>
 	</ascii>
 </dialogue>
@@ -236,20 +243,23 @@
 	<portrait_l entry="player" eye="surprised" mouth="stressed">
 	<portrait_r entry="vee" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			じゃあ<end_line>
 			どうすればいいんだよ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Then what should I do?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			じゃあ<end_line>
 			どうしたらいいの？<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Then what should I do?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -260,7 +270,7 @@
 		アタシがアンタのウデ<end_line>
 		たしかめてやるよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now then, I have no choice but<end_line>
 		to test your strength myself!<end_line>
 	</ascii>
@@ -270,24 +280,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="vee" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			ちょっと、親方<end_line>
 			それって勝負するってことだろ？<end_line>
 			でも親方はまだウデのケガが<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ちょっと、親方<end_line>
-			それって勝負するってことでしょ？<end_line>
-			でも親方はまだウデのケガが<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Wait, Master!<end_line>
     You mean have a match?<end_line>
     But your're still injured<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ちょっと、親方<end_line>
+			それって勝負するってことでしょ？<end_line>
+			でも親方はまだウデのケガが<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Wait, Master!<end_line>
+    You mean have a match?<end_line>
+    But your're still injured<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -298,7 +313,7 @@
 		アンタなんかにおくれをとる<end_line>
 		アタシだと思ってるのかい？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     And what?<end_line>
     I'm still going to win.<end_line>
 	</ascii>
@@ -312,7 +327,7 @@
 		オレのウデはケガしたあんた以下と<end_line>
 		でも言うつもりか！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Wait a sec!<end_line>
     Then you're saying that I'm<three_dots><end_line>
 	</ascii>
@@ -326,7 +341,7 @@
 		しっかり武器を準備して<end_line>
 		アタシのところへ来な<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Prepare yourself for tomorrow,<end_line>
 		and come find me when<end_line>
 		it's time to leave.<end_line>
@@ -341,7 +356,7 @@
 		ミューノといっしょに<end_line>
 		つれてってやるよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     If you really have grown,<end_line>
 		I'll take you with me.<end_line>
 	</ascii>
@@ -355,7 +370,7 @@
 		アンタたちみんな、るすばんだ！<end_line>
 		わかったね！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		And if not,<end_line>
 		then you're to stay here quietly!<end_line>
 		Understood?<end_line>
@@ -366,24 +381,29 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="vee" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			はい！<end_line>
 			よ～し！<end_line>
 			がんばろうな、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			はい！<end_line>
-			よ～し！<end_line>
-			がんばろうね、<partner>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yes!<end_line>
     Alright!<end_line>
     Let's do our best, <partner>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			はい！<end_line>
+			よ～し！<end_line>
+			がんばろうね、<partner>！<end_line>
+		</sjis>
+    <ascii>
+    Yes!<end_line>
+    Alright!<end_line>
+    Let's do our best, <partner>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -393,7 +413,7 @@
 	<sjis>
 		オー！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Roger!<end_line>
 	</ascii>
 </dialogue>
@@ -405,7 +425,7 @@
 	<sjis>
 		承知！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Of course!<end_line>
 	</ascii>
 </dialogue>
@@ -417,7 +437,7 @@
 	<sjis>
 		好きにしろ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah, yeah.<end_line>
 	</ascii>
 </dialogue>
@@ -429,7 +449,7 @@
 	<sjis>
 		はい！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yes!<end_line>
 	</ascii>
 </dialogue>
@@ -440,7 +460,7 @@
 		チクショウ！　無視すンな！！<end_line>
 		オレは不死身のジェイドだー！！！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Dammit! Don't ignore me!<end_line>
 		I am the invincible Jade!<end_line>
 	</ascii>

--- a/Day 02/038_25094636_17ee9ec.xml
+++ b/Day 02/038_25094636_17ee9ec.xml
@@ -7,7 +7,7 @@
 		ミューノも話したくないみたいだったし<end_line>
 		これ以上考えるのはやめよう<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's hopeless<three_dots><end_line>
     Murno doesn't want to talk.<end_line>
 		I'll just leave it be.<end_line>
@@ -22,7 +22,7 @@
 		それがミューノのためにもなる<end_line>
 		<three_dots>と思うし<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I have to concentrate on the match!<end_line>
 		That'll help Murno too<three_dots><end_line>
 		<three_dots>I think.<end_line>
@@ -37,7 +37,7 @@
 		ミューノも話したくないみたいだったし<end_line>
 		これ以上考えるのはやめよう<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's no good<three_dots><end_line>
     Murno doesn't want to talk,<end_line>
 		I'll just have to leave it be.<end_line>
@@ -52,7 +52,7 @@
 		それがミューノのためにもなる<end_line>
 		<three_dots>と思うし<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I have to concentrate on the match!<end_line>
 		That'll help Murno too<three_dots><end_line>
 		<three_dots>I think.<end_line>
@@ -62,64 +62,69 @@
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			ん？<end_line>
 			誰かいるのか？<end_line>
 			まさか<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あれ？<end_line>
-			誰かいるの？<end_line>
-			まさか<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Huh<three_dots>?<end_line>
     Is somebody there?<end_line>
     Is that<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あれ？<end_line>
+			誰かいるの？<end_line>
+			まさか<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Huh<three_dots>?<end_line>
+    Is somebody there?<end_line>
+    Is that<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <menu>
-	<option>
-		<sjis>
+  <option>
+    <sjis>
 			ミューノ<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Murno<end_line>
 		</ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			<partner><end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			<partner><end_line>
 		</ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			ヴィー<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			V.E<end_line>
 		</ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			レミィ<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Lemmy<end_line>
 		</ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			ジェイド<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Jade<end_line>
 		</ascii>
-	</option>
+  </option>
 </menu>

--- a/Day 02/039_25095532_17eed6c.xml
+++ b/Day 02/039_25095532_17eed6c.xml
@@ -4,7 +4,7 @@
 	<sjis>
 		ここだったのね、<player_nickname><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There you are, <player_nickname>.<end_line>
 	</ascii>
 </dialogue>
@@ -17,7 +17,7 @@
 		明日の準備はどう？<end_line>
 		上手くいってる？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Um<three_dots><end_line>
 		How are your preparations?<end_line>
 		Going well?<end_line>
@@ -32,7 +32,7 @@
 		相手が親方だからね<end_line>
 		今さらジタバタしても仕方ないよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I want to say they're going perfect,<end_line>
 		but I'm going against Master here.<end_line>
 		Though panicking now is pointless.<end_line>
@@ -47,7 +47,7 @@
 		助けてもらったのに<end_line>
 		私は何もできなくて<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<player_nickname><three_dots><end_line>
 		You saved me again today<three_dots><end_line>
 		But I didn't deserve it.<end_line>
@@ -62,7 +62,7 @@
 		何か手伝えることがあったら教えてね<end_line>
 		私、なんでもするから<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So, I want to do something for you.<end_line>
 		If there's anything I can help with,<end_line>
 		please let me know.<end_line>
@@ -78,7 +78,7 @@
 		オレは大丈夫だから<end_line>
 		それよりも<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No, you don't have to!<end_line>
 		I'm totally fine!<end_line>
     More importantly<three_dots><end_line>
@@ -94,7 +94,7 @@
 		ミューノにメイワクかけたから<end_line>
 		がんばらなくっちゃな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'm the one who caused you trouble<end_line>
 		today, and I'm sorry for that.<end_line>
 	</ascii>
@@ -109,7 +109,7 @@
 		わたしは大丈夫だから<end_line>
 		それよりも<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You don't have to do that<three_dots><end_line>
 		I'm totally fine.<end_line>
 		And, more importantly<three_dots><end_line>
@@ -125,7 +125,7 @@
 		ミューノにメイワクかけたから<end_line>
 		がんばらなくっちゃね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'm the one who caused you trouble<end_line>
 		today, and I'm sorry for that.<end_line>
 	</ascii>
@@ -139,7 +139,7 @@
 		いいの<three_dots><end_line>
 		アレは私がぼーっとしてたから<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's not your fault<three_dots><end_line>
 		I wasn't paying attention.<end_line>
 	</ascii>
@@ -153,7 +153,7 @@
 		ミューノを守るって言ったのに<end_line>
 		あんな目にあわせちゃったんだ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No<three_dots><end_line>
 		I said I'd protect you,<end_line>
 		and I failed<three_dots><end_line>
@@ -164,24 +164,29 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="murno" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			だから<three_dots><end_line>
 			明日の勝負は絶対に勝って<end_line>
 			ミューノを町に行かせてやるぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			だから<three_dots><end_line>
-			明日の勝負は絶対に勝って<end_line>
-			ミューノを町に連れてってみせる！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So<three_dots><end_line>
     I'm going to win tomorrow's match,<end_line>
     and we'll leave together!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			だから<three_dots><end_line>
+			明日の勝負は絶対に勝って<end_line>
+			ミューノを町に連れてってみせる！<end_line>
+		</sjis>
+    <ascii>
+    So<three_dots><end_line>
+    I'm going to win tomorrow's match,<end_line>
+    and we'll leave together!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -191,7 +196,7 @@
 		え？<end_line>
 		あ<three_dots>、ありがとう<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh<three_dots>?<end_line>
 		Oh<three_dots> Thank you<three_dots><end_line>
 	</ascii>
@@ -205,7 +210,7 @@
 		町に行きたがるなんて<three_dots><end_line>
 		一体なにが<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I'm curious though<three_dots><end_line>
     You wanted to go really badly.<end_line>
 		Just what are you looking for<three_dots>?<end_line>
@@ -219,7 +224,7 @@
 		そ、それは<three_dots><end_line>
 		その<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		T-That<three_dots><end_line>
 		Umm<three_dots><end_line>
 	</ascii>
@@ -231,7 +236,7 @@
 	<sjis>
 		やっぱりヒミツ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Still a secret?<end_line>
 	</ascii>
 </dialogue>
@@ -242,7 +247,7 @@
 	<sjis>
 		う、うん<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Y-Yeah, I guess<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -251,21 +256,25 @@
 	<portrait_l entry="player" eye="happy" mouth="talk">
 	<portrait_r entry="murno" eye="surprised_blush" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			あはは<three_dots><end_line>
 			ミューノはヒミツばっかだな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あはは<three_dots><end_line>
-			ミューノはヒミツばっかりだね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ahaha<three_dots><end_line>
     You're so mysterious.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あはは<three_dots><end_line>
+			ミューノはヒミツばっかりだね<end_line>
+		</sjis>
+    <ascii>
+    Ahaha<three_dots><end_line>
+    You're so mysterious.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -276,7 +285,7 @@
 		このヒミツは他のとは<end_line>
 		ちがうのに<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		N-No, that's not<three_dots>!<end_line>
 		This is different<three_dots><end_line>
 	</ascii>
@@ -289,7 +298,7 @@
 		え、あ<end_line>
 		あの？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hm?<end_line>
 	</ascii>
 </dialogue>
@@ -300,7 +309,7 @@
 	<sjis>
 		もう帰るね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>I'll be going now.<end_line>
 	</ascii>
 </dialogue>
@@ -308,20 +317,24 @@
 	<info box="left">
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			あ<three_dots><end_line>
 			オレ、何か悪いこと言ったのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Huh<three_dots><end_line>
+    Did I say something wrong?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			あ<three_dots><end_line>
 			わたし<end_line>
 			何か悪いこと言ったのかな？<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Huh<three_dots><end_line>
     Did I say something wrong?<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 02/040_25097260_17ef42c.xml
+++ b/Day 02/040_25097260_17ef42c.xml
@@ -5,7 +5,7 @@
 	<sjis>
 		ココデシタカ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There you are<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -16,7 +16,7 @@
 	<sjis>
 		ここにおったか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There you are<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -27,7 +27,7 @@
 	<sjis>
 		ここだったとは<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So this is where you were<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -37,7 +37,7 @@
 	<sjis>
 		ここでしたか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There you are<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -50,7 +50,7 @@
 		親方トノ　勝負ニソナエテ<end_line>
 		何カスルコトハ　ナイノデスカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are There Still Preperations<end_line>
 		Required For The Match?<end_line>
 	</ascii>
@@ -61,24 +61,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			今日はもういいよ<end_line>
 			ゆっくり休んで<end_line>
 			明日にそなえようぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今日はもういいよ<end_line>
-			ゆっくり休んで<end_line>
-			明日にそなえよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I've done enough today.<end_line>
     I'll rest well tonight,<end_line>
     and be ready for tomorrow!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今日はもういいよ<end_line>
+			ゆっくり休んで<end_line>
+			明日にそなえよう！<end_line>
+		</sjis>
+    <ascii>
+    I've done enough today.<end_line>
+    I'll rest well tonight,<end_line>
+    and be ready for tomorrow!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -89,7 +94,7 @@
 		ナルホド<end_line>
 		了解デス<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		I See.<end_line>
 		Understood.<end_line>
 	</ascii>
@@ -100,23 +105,27 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そう言えば、<partner><end_line>
 			今日はガマンしてくれて<end_line>
 			ありがとな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Speaking of which,<end_line>
+    thanks for being holding back today.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そう言えば、<partner><end_line>
 			今日はガマンしてくれて<end_line>
 			ありがとね<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Speaking of which,<end_line>
     thanks for being holding back today.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -127,7 +136,7 @@
 		ガマン？<end_line>
 		ソレハ　ドウイウコトデスカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Holding Back?<end_line>
     When Did I Do That?<end_line>
 	</ascii>
@@ -141,7 +150,7 @@
 	<sjis>
 		魔石を取り返す時のことさ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		When we went to get the stone back.<end_line>
 	</ascii>
 </dialogue>
@@ -155,7 +164,7 @@
 		本当はさっさとやっつけて<end_line>
 		魔石を取り戻したかったんだろ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You just wanted to beat them up,<end_line>
 		and take it back, didn't you?<end_line>
 	</ascii>
@@ -171,7 +180,7 @@
 		ガマンしてくれて<three_dots><end_line>
 		ありがとな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But, for my sake, you didn't<three_dots><end_line>
 		I appreciate that.<end_line>
 	</ascii>
@@ -185,7 +194,7 @@
 	<sjis>
 		魔石を取り返す時のことだよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		When we went to get the stone back.<end_line>
 	</ascii>
 </dialogue>
@@ -199,7 +208,7 @@
 		本当はさっさとやっつけて<end_line>
 		魔石を取り戻したかったんでしょ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You just wanted to beat them up,<end_line>
 		and take it back, didn't you?<end_line>
 	</ascii>
@@ -215,7 +224,7 @@
 		ガマンしてくれて<three_dots><end_line>
 		ありがとう<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But, for my sake, you didn't<three_dots><end_line>
 		I appreciate that.<end_line>
 	</ascii>
@@ -230,7 +239,7 @@
 		私ハ　アナタノ指示ヲ　守ッタダケ<end_line>
 		ガマンヲシテイタノハ　アナタデス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		'Tolerance' Is Defined As Enduring.<end_line>
 		I Only Followed Your Orders.<end_line>
 		The One Enduring Was You.<end_line>
@@ -244,7 +253,7 @@
 	<sjis>
 		<partner><three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<partner><three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -258,7 +267,7 @@
 		シタクモナイ　土下座トイウモノマデ<end_line>
 		シテイマシタ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You Even Bowed Down<end_line>
 		Despite Having No Need To,<end_line>
 		Only For Murno's sake.<end_line>
@@ -270,21 +279,25 @@
 	<portrait_l entry="player" eye="sad" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			あれか<three_dots><end_line>
 			あれはかなりカッコわるかったな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あれかぁ<three_dots><end_line>
-			あれはかなりカッコわるかったね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Don't remind me<three_dots><end_line>
     That was totally lame, huh?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あれかぁ<three_dots><end_line>
+			あれはかなりカッコわるかったね<end_line>
+		</sjis>
+    <ascii>
+    Don't remind me<three_dots><end_line>
+    That was totally lame, huh?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -296,7 +309,7 @@
 		アナタハ　自分ヲコロシテマデ<end_line>
 		約束ヲ守ロウトシテイマシタ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No.<end_line>
 		You Kept Your Promise, Even If<end_line>
 		It Required Repressing Emotions.<end_line>
@@ -311,7 +324,7 @@
 		ソレハ　アナタノ言ウ<end_line>
 		カッコイイ行動デアルト　思ワレマス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That Is What I Would Define As<end_line>
 		A 'Cool' Action To Take.<end_line>
 	</ascii>
@@ -324,7 +337,7 @@
 	<sjis>
 		<partner><three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     <partner><three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -338,7 +351,7 @@
 		人ノ気持チトイウモノヲ<end_line>
 		動カシテイルト　判断シマス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		And, As A Result,<end_line>
 		You Were Successful In Not<end_line>
 		Creating Any Further Problems.<end_line>
@@ -350,24 +363,29 @@
 	<portrait_l entry="player" eye="happy_blush" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんか<three_dots><end_line>
 			<partner>にほめられるなんて<end_line>
 			すっげぇうれしいよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なんか<three_dots><end_line>
-			<partner>にほめられるなんて<end_line>
-			すっごくうれしいよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Haha<three_dots><end_line>
     I'm really happy<end_line>
     to hear that from you!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なんか<three_dots><end_line>
+			<partner>にほめられるなんて<end_line>
+			すっごくうれしいよ！<end_line>
+		</sjis>
+    <ascii>
+    Haha<three_dots><end_line>
+    I'm really happy<end_line>
+    to hear that from you!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -377,7 +395,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -387,23 +405,27 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			あ、まあ<end_line>
 			明日はいっしょに<end_line>
 			がんばろうぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Alright, well,<end_line>
+    let's do our best tomorrow!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			あ、まあ<end_line>
 			明日はいっしょに<end_line>
 			がんばろうね！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright, well,<end_line>
     let's do our best tomorrow!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -413,7 +435,7 @@
 	<sjis>
 		オー！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Roger!<end_line>
 	</ascii>
 </dialogue>
@@ -426,7 +448,7 @@
 		親方との勝負の前なのに<end_line>
 		ずいぶんと余裕のようじゃの<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You seem quite relaxed,<end_line>
 		despite your match approaching.<end_line>
 	</ascii>
@@ -441,7 +463,7 @@
 		相手が親方だから<end_line>
 		今さらジタバタしたって仕方ないよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Well, yeah.<end_line>
 		I'm going up against Master,<end_line>
 		so getting worked up now is useless.<end_line>
@@ -456,7 +478,7 @@
 		まあ、たしかに<end_line>
 		そのようじゃな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's certainly true.<end_line>
 	</ascii>
 </dialogue>
@@ -466,23 +488,27 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そう言えば、<partner><end_line>
 			今日はガマンしてくれて<end_line>
 			ありがとな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Speaking of which,<end_line>
+    thanks for being holding back today.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そう言えば、<partner><end_line>
 			今日はガマンしてくれて<end_line>
 			ありがとね<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Speaking of which,<end_line>
     thanks for being holding back today.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -492,7 +518,7 @@
 	<sjis>
 		ガマン？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Holding back?<end_line>
 	</ascii>
 </dialogue>
@@ -506,7 +532,7 @@
 		なった時から<end_line>
 		ずっとしておるが？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You realize I've been doing that the<end_line>
 		whole time I've been your partner?<end_line>
 	</ascii>
@@ -521,7 +547,7 @@
 		そうじゃなくて！<end_line>
 		魔石を取り返す時のことさ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No, not that!<end_line>
 		I'm talking about when<end_line>
 		we went to get the stone back.<end_line>
@@ -537,7 +563,7 @@
 		本当はさっさとやっつけて<end_line>
 		魔石を取り戻したかったんだろ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You actually wanted to beat them up,<end_line>
 		and take the stone back, didn't you?<end_line>
 	</ascii>
@@ -553,7 +579,7 @@
 		ガマンしてくれて<three_dots><end_line>
 		ありがとな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But, for my sake, you didn't.<end_line>
 		I appreciate that.<end_line>
 	</ascii>
@@ -568,7 +594,7 @@
 		そうじゃなくて！<end_line>
 		魔石を取り返す時のことだよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No, not that!<end_line>
 		I'm talking about when<end_line>
 		we went to get the stone back.<end_line>
@@ -584,7 +610,7 @@
 		本当はさっさとやっつけて<end_line>
 		魔石を取り戻したかったんでしょ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You actually wanted to beat them up,<end_line>
 		and take the stone back, didn't you?<end_line>
 	</ascii>
@@ -600,7 +626,7 @@
 		ガマンしてくれて<three_dots><end_line>
 		ありがとう<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But, for my sake, you didn't.<end_line>
 		I appreciate that.<end_line>
 	</ascii>
@@ -615,7 +641,7 @@
 		あんな連中<end_line>
 		いつでもたおせたからの<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No thanks needed.<end_line>
     I could have taken them out<end_line>
     whenever I wanted.<end_line>
@@ -631,7 +657,7 @@
 		ミューノのためにどこまでやるか<end_line>
 		見てみたかったのじゃ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I only wanted to see<end_line>
 		how far you were willing to go<end_line>
 		simply for Murno's sake.<end_line>
@@ -645,7 +671,7 @@
 	<sjis>
 		<partner><three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -658,7 +684,7 @@
 		おぬしはミューノのために<end_line>
 		土下座までしてくれて<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     And you were even willing<end_line>
     to bow down to them<three_dots><end_line>
 	</ascii>
@@ -669,21 +695,25 @@
 	<portrait_l entry="player" eye="sad" mouth="neutral">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			あれか<three_dots><end_line>
 			あれはかなりカッコわるかったな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あれかぁ<three_dots><end_line>
-			あれはかなりカッコわるかったね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Don't remind me<three_dots><end_line>
     That was pretty lame, huh?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あれかぁ<three_dots><end_line>
+			あれはかなりカッコわるかったね<end_line>
+		</sjis>
+    <ascii>
+    Don't remind me<three_dots><end_line>
+    That was pretty lame, huh?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -695,7 +725,7 @@
 		おぬしの心意気に<end_line>
 		ワガハイはうたれたぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Not at all.<end_line>
 		I was quite impressed<end_line>
     by your conviction.<end_line>
@@ -709,7 +739,7 @@
 	<sjis>
 		格好良かったぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It was very cool, actually.<end_line>
 	</ascii>
 </dialogue>
@@ -721,7 +751,7 @@
 	<sjis>
 		<partner><three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<partner><three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -731,22 +761,27 @@
 	<portrait_l entry="player" eye="neutral_blush" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			おぬしがそこまでできる男じゃから<end_line>
 			ミューノの心も動いたのかもしれん<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			おぬしがそこまでできる者じゃから<end_line>
-			ミューノの心も動いたのかもしれん<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     It may be because you're capable<end_line>
     of such, that you managed to move<end_line>
     Murno's heart like so.<end_line>
-  </ascii>	
+  </ascii>
+  </male>
+  <female>
+    <sjis>
+			おぬしがそこまでできる者じゃから<end_line>
+			ミューノの心も動いたのかもしれん<end_line>
+		</sjis>
+    <ascii>
+    It may be because you're capable<end_line>
+    of such, that you managed to move<end_line>
+    Murno's heart like so.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -757,7 +792,7 @@
 		え？<end_line>
 		ミューノの心？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh?<end_line>
 		Murno's heart?<end_line>
 	</ascii>
@@ -771,7 +806,7 @@
 		ん<three_dots>？<end_line>
 		まったく、ニブいヤツじゃのう<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Mm<three_dots>?<end_line>
 		Truly, how dense you are<three_dots><end_line>
 	</ascii>
@@ -782,18 +817,21 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			な、なんだよ、それ！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			な、なによ、それ！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     W-What's that supposed to mean?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			な、なによ、それ！？<end_line>
+		</sjis>
+    <ascii>
+    W-What's that supposed to mean?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -805,7 +843,7 @@
 		こんなところにいるとは<end_line>
 		勝負をあきらめたのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Does your being here mean<end_line>
 		you've given up on the match?<end_line>
 	</ascii>
@@ -820,7 +858,7 @@
 		相手が親方だから<end_line>
 		今さらジタバタしたって仕方ないよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Of course not.<end_line>
 		I'm going up against Master so,<end_line>
 		it's useless to get worked up now.<end_line>
@@ -832,21 +870,25 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			それより明日にそなえて<end_line>
 			休んでおかないとな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			それより明日にそなえて<end_line>
-			休んでおかないとね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     More importantly, I have to<end_line>
     get some rest for tomorrow.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			それより明日にそなえて<end_line>
+			休んでおかないとね<end_line>
+		</sjis>
+    <ascii>
+    More importantly, I have to<end_line>
+    get some rest for tomorrow.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -857,7 +899,7 @@
 		キサマにしては<end_line>
 		けんめいな判断だな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's a wise decision,<end_line>
 		coming from you.<end_line>
 	</ascii>
@@ -868,24 +910,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そう言えば、<partner><end_line>
 			今日はガマンしてくれて<end_line>
 			ありがとな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そう言えば、<partner><end_line>
-			今日はガマンしてくれて<end_line>
-			ありがとね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah, yeah.<end_line>
     Anyway, thanks for<end_line>
     holding back today.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そう言えば、<partner><end_line>
+			今日はガマンしてくれて<end_line>
+			ありがとね<end_line>
+		</sjis>
+    <ascii>
+    Yeah, yeah.<end_line>
+    Anyway, thanks for<end_line>
+    holding back today.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -895,7 +942,7 @@
 	<sjis>
 		ガマン？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Holding back?<end_line>
 	</ascii>
 </dialogue>
@@ -909,7 +956,7 @@
 		なった時から<end_line>
 		ずっとしている<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I've been doing that ever since<end_line>
 		I was forced to be your partner.<end_line>
 	</ascii>
@@ -920,24 +967,29 @@
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ヒドイこと言うなぁ！<end_line>
 			そういうことじゃなくて<end_line>
 			魔石を取り返す時のことさ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ヒドイこと言うなぁ！<end_line>
-			そういうことじゃなくて<end_line>
-			魔石を取り返す時のことだよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     That's not what I meant!<end_line>
     I'm talking about when<end_line>
     we went to get the stone back.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ヒドイこと言うなぁ！<end_line>
+			そういうことじゃなくて<end_line>
+			魔石を取り返す時のことだよ！<end_line>
+		</sjis>
+    <ascii>
+    That's not what I meant!<end_line>
+    I'm talking about when<end_line>
+    we went to get the stone back.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -947,7 +999,7 @@
 	<sjis>
 		？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hm?<end_line>
 	</ascii>
 </dialogue>
@@ -961,7 +1013,7 @@
 		本当はさっさとあいつらをやっつけて<end_line>
 		魔石を取り戻したかったんだろ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You really wanted to beat<end_line>
     those guys up and just take<end_line>
 		the stone back, right?<end_line>
@@ -978,7 +1030,7 @@
 		ガマンしてくれて<three_dots><end_line>
 		ありがとな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But, for my sake, you didn't.<end_line>
 		I appreciate that.<end_line>
 	</ascii>
@@ -993,7 +1045,7 @@
 		本当はさっさとあいつらをやっつけて<end_line>
 		魔石を取り戻したかったんでしょ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You really wanted to beat<end_line>
     those guys up and just take<end_line>
 		the stone back, right?<end_line>
@@ -1010,7 +1062,7 @@
 		ガマンしてくれて<three_dots><end_line>
 		ありがとう<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But, for my sake, you didn't.<end_line>
 		I appreciate that.<end_line>
 	</ascii>
@@ -1024,7 +1076,7 @@
 		キサマのためにガマンだと<three_dots><end_line>
 		ふざけたことを言うな！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     As if I'd do that for you.<end_line>
 		Don't be ridiculous.<end_line>
 	</ascii>
@@ -1038,7 +1090,7 @@
 		私はキサマがどんな目にあうか<end_line>
 		見てみたかっただけだ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I only wanted to see<end_line>
 		how far you were going to go.<end_line>
 	</ascii>
@@ -1052,7 +1104,7 @@
 		まさか、土下座とやらまで<end_line>
 		することになるとはな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But I didn't think you'd take it<end_line>
 		so far as to bow your head<three_dots><end_line>
 	</ascii>
@@ -1063,21 +1115,25 @@
 	<portrait_l entry="player" eye="sad" mouth="neutral">
 	<portrait_r entry="partner" eye="special" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			あれか<three_dots><end_line>
 			あれはかなりカッコわるかったな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あれかぁ<three_dots><end_line>
-			あれはかなりカッコわるかったね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Don't remind me<three_dots><end_line>
     That was pretty lame, huh?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あれかぁ<three_dots><end_line>
+			あれはかなりカッコわるかったね<end_line>
+		</sjis>
+    <ascii>
+    Don't remind me<three_dots><end_line>
+    That was pretty lame, huh?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1089,7 +1145,7 @@
 		あんな情けないこと<end_line>
 		私には絶対にできんことだ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah.<end_line>
 		There's no way I could do<end_line>
 		something so degrading.<end_line>
@@ -1103,7 +1159,7 @@
 	<sjis>
 		ハッキリ言うなぁ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You sure say it straight<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1116,7 +1172,7 @@
 		くやしいがそこが<end_line>
 		私とキサマの決定的な差だろうな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Though I hate to admit it,<end_line>
 		that's the decisive difference<end_line>
 		between us<three_dots><end_line>
@@ -1130,7 +1186,7 @@
 	<sjis>
 		そして、ミューノは<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		And also the reason Murno<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1143,7 +1199,7 @@
 		え<three_dots>？<end_line>
 		何？　<partner><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -1167,18 +1223,21 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			な、なんだよ、それ！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			な、なによ、それ！？<end_line>
-		</sjis>
-	</female>
-  <ascii>	
+    <ascii>	
     Hey, what's that supposed to mean!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			な、なによ、それ！？<end_line>
+		</sjis>
+    <ascii>	
+    Hey, what's that supposed to mean!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1189,7 +1248,7 @@
 		もっと準備とかしなくて<end_line>
 		いいんですか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You're up against Master,<end_line>
 		so shouldn't you still be preparing?<end_line>
 	</ascii>
@@ -1203,7 +1262,7 @@
 		相手が親方だから<end_line>
 		今さらジタバタしたって仕方ないよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Nah.<end_line>
     There's no point in<end_line>
     freaking out out now.<end_line>
@@ -1214,20 +1273,23 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			それより、キンチョーしすぎると<end_line>
 			実力をだせないぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    It'd make me too nervous, you know?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			それより、キンチョーしすぎると<end_line>
 			実力をだせないよ<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     It'd make me too nervous, you know?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1237,7 +1299,7 @@
 		たしかにそうかもしれませんわ<three_dots><end_line>
 		落ち着かないと<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That may be true<three_dots><end_line>
 		We must be calm<three_dots><end_line>
 	</ascii>
@@ -1247,23 +1309,27 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そう言えば、<partner><end_line>
 			今日はガマンしてくれて<end_line>
 			ありがとな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Speaking of which,<end_line>
+    thanks for being holding back today.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そう言えば、<partner><end_line>
 			今日はガマンしてくれて<end_line>
 			ありがとね<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Speaking of which,<end_line>
     thanks for being holding back today.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1272,7 +1338,7 @@
 	<sjis>
 		ガマン？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Holding back?<end_line>
 	</ascii>
 </dialogue>
@@ -1285,7 +1351,7 @@
 		なった時から<end_line>
 		ずっとしていますわ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I've been doing that<end_line>
 		since I became your partner.<end_line>
 	</ascii>
@@ -1295,24 +1361,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ヒドイこと言うなぁ！<end_line>
 			そういうことじゃなくてさ<end_line>
 			魔石を取り返す時のことさ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ヒドイこと言うなぁ！<end_line>
-			そういうことじゃなくて<end_line>
-			魔石を取り返す時のことだよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Uh<three_dots>Right<three_dots><end_line>
     But I'm talking about when<end_line>
     we went to get the stone back.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ヒドイこと言うなぁ！<end_line>
+			そういうことじゃなくて<end_line>
+			魔石を取り返す時のことだよ！<end_line>
+		</sjis>
+    <ascii>
+    Uh<three_dots>Right<three_dots><end_line>
+    But I'm talking about when<end_line>
+    we went to get the stone back.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1321,7 +1392,7 @@
 	<sjis>
 		はあ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ohh~<end_line>
 	</ascii>
 </dialogue>
@@ -1334,7 +1405,7 @@
 		本当はさっさとあいつらをやっつけて<end_line>
 		魔石を取り戻したかったんだろ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You really wanted to beat<end_line>
     those guys up and just take<end_line>
 		the stone back, right?<end_line>
@@ -1350,7 +1421,7 @@
 		ガマンしてくれて<three_dots><end_line>
 		ありがとな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But, for my sake, you didn't.<end_line>
 		I appreciate that.<end_line>
 	</ascii>
@@ -1364,7 +1435,7 @@
 		本当はさっさとあいつらをやっつけて<end_line>
 		魔石を取り戻したかったんでしょ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You really wanted to beat<end_line>
     those guys up and just take<end_line>
 		the stone back, right?<end_line>
@@ -1380,7 +1451,7 @@
 		ガマンしてくれて<three_dots><end_line>
 		ありがとう<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But, for my sake, you didn't.<end_line>
 		I appreciate that.<end_line>
 	</ascii>
@@ -1394,7 +1465,7 @@
 		もうあなたのためにあんなガマンを<end_line>
 		するなんて、まっぴらですわ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's right!<end_line>
 		But don't ever put me through<end_line>
 		anything like that again!<end_line>
@@ -1407,7 +1478,7 @@
 	<sjis>
 		そ、そんな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		H-Hey<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1420,7 +1491,7 @@
 		戦いをさけるためには<end_line>
 		助けることすら許されないなんて<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     You tried so hard to avoid<end_line>
     unnecessary conflict<three_dots><end_line>
 	</ascii>
@@ -1432,7 +1503,7 @@
 	<sjis>
 		<partner><three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<partner><three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1445,7 +1516,7 @@
 		土下座とかいう格好まで<end_line>
 		させられていたと言うのに<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You even went so far as to<end_line>
 		bow your head for Lady Murno<three_dots><end_line>
 		And all I could do was watch<three_dots><end_line>
@@ -1460,7 +1531,7 @@
 		あんなガマンなんて、もう絶対に<end_line>
 		したくないですわ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I don't want to feel<end_line>
     so useless ever again<three_dots><end_line>
 	</ascii>
@@ -1470,21 +1541,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			あれか<three_dots><end_line>
 			あれはかなりカッコわるかったな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あれかぁ<three_dots><end_line>
-			あれはかなりカッコわるかったね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Don't remind me<three_dots><end_line>
     That was pretty lame, huh?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あれかぁ<three_dots><end_line>
+			あれはかなりカッコわるかったね<end_line>
+		</sjis>
+    <ascii>
+    Don't remind me<three_dots><end_line>
+    That was pretty lame, huh?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1495,7 +1570,7 @@
 		大切なものを守るために<end_line>
 		けんめいに耐えている姿<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's not true!<end_line>
 		Seeing you so earnestly enduring<end_line>
 		it to protect someone<three_dots><end_line>
@@ -1509,7 +1584,7 @@
 		とてもムネをうたれましたわ<end_line>
 		格好良かったです<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It was really moving.<end_line>
 		You were very cool.<end_line>
 	</ascii>
@@ -1521,7 +1596,7 @@
 	<sjis>
 		<partner><three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<partner><three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1534,7 +1609,7 @@
 		ミューノ様の心も動いたのかも<end_line>
 		しれません<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     That may be the reason<end_line>
 		you have managed to stir<end_line>
 		Lady Murno's heart.<end_line>
@@ -1548,7 +1623,7 @@
 		え<three_dots>？<end_line>
 		それってどういうこと？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -1560,7 +1635,7 @@
 		はぁ<three_dots><end_line>
 		とんだニブチンさんですわ<three_dots><end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		*Sigh*<three_dots><end_line>
 		How can you be so incredibly dense<three_dots>?<end_line>
 	</ascii>
@@ -1570,16 +1645,19 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			な、なんだよ、それ！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			な、なによ、それ！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     W-What!?!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			な、なによ、それ！？<end_line>
+		</sjis>
+    <ascii>
+    W-What!?!<end_line>
+  </ascii>
+  </female>
 </dialogue>

--- a/Day 02/041_25101132_17f034c.xml
+++ b/Day 02/041_25101132_17f034c.xml
@@ -4,7 +4,7 @@
 	<sjis>
 		ここだと思ったよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I figured you were here.<end_line>
 	</ascii>
 </dialogue>
@@ -15,7 +15,7 @@
 	<sjis>
 		親方<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Master<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -27,7 +27,7 @@
 		勝負の前だってのに<end_line>
 		ずいぶん余裕じゃないか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You seem pretty relaxed.<end_line>
  		You know we have a match tomorrow?<end_line>
 	</ascii>
@@ -37,24 +37,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="vee" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そんなことないけど<end_line>
 			いまさらジタバタしたって<end_line>
 			仕方ないだろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そんなことないけど<end_line>
-			いまさらジタバタしたって<end_line>
-			仕方ないでしょ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Of course I do.<end_line>
     It's more that there's no point<end_line>
     in getting worked up this late.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そんなことないけど<end_line>
+			いまさらジタバタしたって<end_line>
+			仕方ないでしょ？<end_line>
+		</sjis>
+    <ascii>
+    Of course I do.<end_line>
+    It's more that there's no point<end_line>
+    in getting worked up this late.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -65,7 +70,7 @@
 		ジェイドをたおしたからって<end_line>
 		調子に乗ってると、痛い目見るよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So you say<three_dots><end_line>
     Don't get overconfident.<end_line>
     Jade is nothing compared to me.<end_line>
@@ -80,7 +85,7 @@
 		今までの修行の成果を<end_line>
 		全部ぶつけるつもりでがんばるから<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'm taking this seriously!<end_line>
 		I'm gonna try my best to show you<end_line>
 		the results of my training.<end_line>
@@ -93,7 +98,7 @@
 	<sjis>
 		みててよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So just watch me!<end_line>
 	</ascii>
 </dialogue>
@@ -106,7 +111,7 @@
 		本当の強さってものが<end_line>
 		わかってきたみたいだね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Looks like you're slowly coming<end_line>
 		to understand what true strength is.<end_line>
 	</ascii>
@@ -120,7 +125,7 @@
 		そんなむずかしいこと<end_line>
 		よくわからないよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		True strength<three_dots>?<end_line>
 		I don't think I'd know about<end_line>
 		something like that yet.<end_line>
@@ -135,7 +140,7 @@
 		なんて言うか、そうだね<end_line>
 		魂の強さも大切なんだよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Strength isn't just 'physical'<three_dots><end_line>
 		Like, how should I put this<three_dots>?<end_line>
     Your conviction is important too.<end_line>
@@ -150,7 +155,7 @@
 		武器を通して自分の魂を伝え<end_line>
 		相手の魂を感じ取るんだ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		A strong Craftknight can feel their<end_line>
 		spirit through their weapons.<end_line>
 	</ascii>
@@ -164,7 +169,7 @@
 		それは、なんとなくだけど<end_line>
 		わかる気がするよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Feel their spirit<three_dots><end_line>
 		I think I kind of get it.<end_line>
 	</ascii>
@@ -178,7 +183,7 @@
 		いっちょまえのこと言うように<end_line>
 		なったもんだ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Heh.<end_line>
     I can tell you're<end_line>
     growing by the day.<end_line>
@@ -192,7 +197,7 @@
 		じゃあ明日は<end_line>
 		その実力をみせてもらうよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Tomorrow I'll have you show me<end_line>
 		your true abilities in combat.<end_line>
 	</ascii>
@@ -205,7 +210,7 @@
 		うん<end_line>
 		がんばるよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah!<end_line>
 		I'll do my best!<end_line>
 	</ascii>

--- a/Day 02/042_25104156_17f0f1c.xml
+++ b/Day 02/042_25104156_17f0f1c.xml
@@ -4,7 +4,7 @@
 	<sjis>
 		お、<player_nickname>じゃないか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey <player_nickname>.<end_line>
 	</ascii>
 </dialogue>
@@ -17,7 +17,7 @@
 		大丈夫なのか？<end_line>
 		こんなとこでボーっとしててよ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's right before your match.<end_line>
     Sure you've got time to waste?<end_line>
 	</ascii>
@@ -31,7 +31,7 @@
 		いまさらジタバタしても仕方ないよ<end_line>
 		相手は親方なんだから<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No, but<three_dots><end_line>
 		Freaking out about it this late<end_line>
 		isn't going to change anything.<end_line>
@@ -45,7 +45,7 @@
 		アニキこそ<end_line>
 		どうしたの？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     And why are you here, Bro?<end_line>
 	</ascii>
 </dialogue>
@@ -58,7 +58,7 @@
 		やかましいヤツがいてさ<end_line>
 		ちょっと席を外して<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There's this noisy guy staying at<end_line>
 		Chief's place that was bothering me,<end_line>
 		so I came out to get some air.<end_line>
@@ -72,7 +72,7 @@
 		<three_dots>って<end_line>
 		アニキって呼ぶなって<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Hey!<end_line>
 		I told you not to call me Bro!<end_line>
 	</ascii>
@@ -85,7 +85,7 @@
 		村長んとこってお金かかるんでしょ？<end_line>
 		ウチに泊まればいいのに<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Staying there costs money, right?<end_line>
 		You should just stay with us.<end_line>
 	</ascii>
@@ -99,7 +99,7 @@
 		ミューノに<partner>もふえて<end_line>
 		いろいろ大変なんじゃないのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You say it like it's no big deal,<end_line>
 		but you already have two guests.<end_line>
 		It's tough in a lot ways, right?<end_line>
@@ -114,7 +114,7 @@
 		くわしくは知らないけど<end_line>
 		親方もケガしてるし<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Well yeah.<end_line>
 		And Master's injured too<three_dots><end_line>
 	</ascii>
@@ -128,7 +128,7 @@
 		手伝わねぇとダメだぞ<end_line>
 		ロブのためにもな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You better make sure<end_line>
 		to help out V.E out.<end_line>
 		For Rob's sake and hers.<end_line>
@@ -141,7 +141,7 @@
 	<sjis>
 		ロブ親方の<three_dots><end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		For Master Rob<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -154,7 +154,7 @@
 		なんせオレとの勝負に勝てるくらいの<end_line>
 		修行をつんでるんだからな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Don't worry! You can handle it!<end_line>
 		I mean, you're strong enough<end_line>
 		to beat me, after all.<end_line>
@@ -165,21 +165,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="jade" eye="happy" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			アニキにとって今日の勝負は<end_line>
 			オレのウデ試しだろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニキにとって今日の勝負は<end_line>
-			わたしのウデ試しでしょ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Our match today<three_dots><end_line>
     You were just testing me, right?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニキにとって今日の勝負は<end_line>
+			わたしのウデ試しでしょ？<end_line>
+		</sjis>
+    <ascii>
+    Our match today<three_dots><end_line>
+    You were just testing me, right?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -190,7 +194,7 @@
 		<partner>がいても<end_line>
 		勝てるかどうかわからないよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		If you were serious,<end_line>
 		I honestly don't know if I could<end_line>
 		beat you even with <partner>.<end_line>
@@ -204,7 +208,7 @@
 		おお<end_line>
 		めずらしくケンキョな意見だな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     That's suprisingly modest<end_line>
     coming from you.<end_line>
 	</ascii>
@@ -214,24 +218,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="jade" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			本気で怒った時のアニキは<end_line>
 			おっそろしくコワイもんな<end_line>
 			まさにその顔にピッタリだよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			本気で怒った時のアニキは<end_line>
-			おっそろしくコワイもんね<end_line>
-			まさにその顔にピッタリだよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     When you're serious,<end_line>
     you get really terrifying.<end_line>
     And your face becomes a perfect fit.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			本気で怒った時のアニキは<end_line>
+			おっそろしくコワイもんね<end_line>
+			まさにその顔にピッタリだよ<end_line>
+		</sjis>
+    <ascii>
+    When you're serious,<end_line>
+    you get really terrifying.<end_line>
+    And your face becomes a perfect fit.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -240,7 +249,7 @@
 	<sjis>
 		ンだとこらぁ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What'd you say!?<end_line>
 	</ascii>
 </dialogue>
@@ -251,7 +260,7 @@
 	<sjis>
 		ほら、コワイ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		See, like that.<end_line>
 	</ascii>
 </dialogue>
@@ -264,7 +273,7 @@
 		明日の勝負にゃガッチリ勝って<end_line>
 		ねえさんを安心させてやれ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Anyways, make sure to<end_line>
 		deliver a solid victory<end_line>
 		in the match tomorrow.<end_line>
@@ -279,7 +288,7 @@
 		そのお前がねえさんとの試合に<end_line>
 		負けるなんて、許さねぇぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You beat me, so if Vee beats you,<end_line>
 		that would mean I'm<three_dots><end_line>
 		<three_dots>I won't let you lose.<end_line>
@@ -292,7 +301,7 @@
 	<sjis>
 		そ、そんなこと<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		W-Well<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -303,7 +312,7 @@
 	<sjis>
 		わかったな！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Got it!?<end_line>
 	</ascii>
 </dialogue>
@@ -314,7 +323,7 @@
 	<sjis>
 		はい！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah!<end_line>
 	</ascii>
 </dialogue>

--- a/Day 02/043_25102572_17f08ec.xml
+++ b/Day 02/043_25102572_17f08ec.xml
@@ -4,7 +4,7 @@
 	<sjis>
 		誰かと思えば<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I was wondering who it was<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -15,7 +15,7 @@
 	<sjis>
 		やっぱり君か<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Of course it's you<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -24,18 +24,21 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="lemmy" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりってなんだよ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりってなによ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     'Of course'?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりってなによ？<end_line>
+		</sjis>
+    <ascii>
+    'Of course'?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -45,7 +48,7 @@
 		あやしい人影が見えたから<end_line>
 		調べに来ただけだよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I saw someone suspicious,<end_line>
 		so I came to investigate.<end_line>
 	</ascii>
@@ -55,20 +58,23 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="lemmy" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			あやしいって、オレのことかよ<end_line>
 			オレのどこがあやしいんだ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Suspicious? How am I suspicious?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			あやしいって、わたしのこと？<end_line>
 			わたしのどこがあやしいのよ<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Suspicious? How am I suspicious?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -78,7 +84,7 @@
 		気がついてなかったのか<three_dots><end_line>
 		君は十分あやしいよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     You seriously haven't noticed<three_dots>?<end_line>
     Think about it for a second.<end_line>
 	</ascii>
@@ -88,18 +94,21 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="lemmy" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			なんだと！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なんですって！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What are you talking about<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なんですって！<end_line>
+		</sjis>
+    <ascii>
+    What are you talking about<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -109,7 +118,7 @@
 		さわぎのあるところには必ず<end_line>
 		君がいるじゃないか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Whenever there's trouble,<end_line>
 		you're there, without fail.<end_line>
 	</ascii>
@@ -122,7 +131,7 @@
 		う<three_dots><end_line>
 		反論できないところが<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh<three_dots><end_line>
 		I guess that true<three_dots><end_line>
 	</ascii>
@@ -132,22 +141,26 @@
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<portrait_r entry="lemmy" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そういえば<end_line>
 			あの、ケガした連中はどうなった？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    But anyway, what happened<end_line>
+    to those injured people?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そういえば<end_line>
 			あの、ケガした人たちは<end_line>
 			どうなったの？<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     But anyway, what happened<end_line>
     to those injured people?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -158,7 +171,7 @@
 		もう元気にしてる<three_dots><end_line>
 		いや、元気じゃないか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Their injuries weren't severe,<end_line>
     so physically, they're fine.<end_line>
 		<three_dots>Mentally, maybe not<three_dots><end_line>
@@ -169,21 +182,25 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="lemmy" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ？<end_line>
 			どこか悪いのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ？<end_line>
-			どこか悪いの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What?<end_line>
     Did something happen?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ？<end_line>
+			どこか悪いの？<end_line>
+		</sjis>
+    <ascii>
+    What?<end_line>
+    Did something happen?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -194,7 +211,7 @@
 		おとなしくなってる<end_line>
 		反省している<three_dots>といいけど<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		They've quieted down.<end_line>
 		It's as if they're truly<end_line>
     reflecting on their actions.<end_line>
@@ -205,24 +222,29 @@
 	<portrait_l entry="player" eye="happy" mouth="neutral">
 	<portrait_r entry="lemmy" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そっか<end_line>
 			大丈夫だろ<end_line>
 			とくにサージってヤツは<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そっか<end_line>
-			大丈夫でしょ<end_line>
-			とくにサージって人は<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I see.<end_line>
     But I mean, isn't that fine?<end_line>
     Especially for that 'Sarge'.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そっか<end_line>
+			大丈夫でしょ<end_line>
+			とくにサージって人は<end_line>
+		</sjis>
+    <ascii>
+    I see.<end_line>
+    But I mean, isn't that fine?<end_line>
+    Especially for that 'Sarge'.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -232,7 +254,7 @@
 		また君がケンカで<end_line>
 		やっつけたからかい？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Because you beat them up again?<end_line>
 	</ascii>
 </dialogue>
@@ -241,22 +263,27 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="lemmy" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			ケンカじゃない！<end_line>
 			勝負だ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ケンカじゃない！<end_line>
-			勝負よ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I didn't!<end_line>
     It was a match,<end_line>
     and he asked me for it!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ケンカじゃない！<end_line>
+			勝負よ！<end_line>
+		</sjis>
+    <ascii>
+    I didn't!<end_line>
+    It was a match,<end_line>
+    and he asked me for it!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -265,7 +292,7 @@
 	<sjis>
 		それって、何かちがうの？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What's the difference?<end_line>
 	</ascii>
 </dialogue>
@@ -274,24 +301,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="lemmy" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			全然ちがうだろ！<end_line>
 			なんていうかさ<three_dots><end_line>
 			心とか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			全然ちがうでしょ！<end_line>
-			なんていうかさ<three_dots><end_line>
-			心とか？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     They're completely different!<end_line>
     <three_dots>How do I put this<three_dots><end_line>
     They're different at heart!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			全然ちがうでしょ！<end_line>
+			なんていうかさ<three_dots><end_line>
+			心とか？<end_line>
+		</sjis>
+    <ascii>
+    They're completely different!<end_line>
+    <three_dots>How do I put this<three_dots><end_line>
+    They're different at heart!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -302,7 +334,7 @@
 		心、か<three_dots><end_line>
 		君がたまにうらやましくなるよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hah<three_dots><end_line>
 		At heart, huh<three_dots>?<end_line>
 		I envy you sometimes.<end_line>
@@ -313,23 +345,27 @@
 	<portrait_l entry="player" eye="decided" mouth="stressed">
 	<portrait_r entry="lemmy" eye="sad" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			な<three_dots><end_line>
 			今オレのこと<end_line>
 			バカにしなかったか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Wha<three_dots><end_line>
+    Are you making fun of me?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			な<three_dots><end_line>
 			今わたしのこと<end_line>
 			バカにしなかった？<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Wha<three_dots><end_line>
     Are you making fun of me?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -338,7 +374,7 @@
 	<sjis>
 		さあね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Maybe.<end_line>
 	</ascii>
 </dialogue>

--- a/Day 02/24348364_17386cc.xml
+++ b/Day 02/24348364_17386cc.xml
@@ -32,20 +32,23 @@
 	<portrait_l entry="player" eye="surprised" mouth="yell">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			今さらっとヒドイこと<end_line>
 			言っただろ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Well, excuse me for caring!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			今さらっとヒドイこと<end_line>
 			言ったでしょ！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, excuse me for caring!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -81,20 +84,23 @@
 	<portrait_l entry="player" eye="surprised" mouth="yell">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			今さらっとヒドイこと<end_line>
 			言っただろ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Well, excuse me for caring!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			今さらっとヒドイこと<end_line>
 			言ったでしょ！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, excuse me for caring!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -128,21 +134,25 @@
 	<portrait_l entry="player" eye="happy" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			ま、そういうことに<end_line>
 			しといてやるよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ま、そういうことに<end_line>
-			しといてあげる<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Uh, sure.<end_line>
     We'll leave it at that.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ま、そういうことに<end_line>
+			しといてあげる<end_line>
+		</sjis>
+    <ascii>
+    Uh, sure.<end_line>
+    We'll leave it at that.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -172,20 +182,23 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			今さらっとヒドイこと<end_line>
 			言っただろ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Well, excuse me for caring!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			今さらっとヒドイこと<end_line>
 			言ったでしょ！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, excuse me for caring!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -223,24 +236,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			まあ、大丈夫だろ<end_line>
 			親方もついてるんだしな<end_line>
 			とりあえず修行しようぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			まあ、大丈夫でしょ<end_line>
-			親方もついてるんだし<end_line>
-			とりあえず修行しよう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm sure they'll be fine.<end_line>
     She'll make something up<end_line>
     if there are any issues.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			まあ、大丈夫でしょ<end_line>
+			親方もついてるんだし<end_line>
+			とりあえず修行しよう<end_line>
+		</sjis>
+    <ascii>
+    I'm sure they'll be fine.<end_line>
+    She'll make something up<end_line>
+    if there are any issues.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -293,24 +311,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			まあ、大丈夫だろ<end_line>
 			村長って結構、いいかげんだし<end_line>
 			いざとなれば親方がなんとかするさ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			まあ、大丈夫でしょ<end_line>
-			村長って結構、いいかげんだし<end_line>
-			いざとなれば親方がなんとかするよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm sure they'll be fine.<end_line>
     She'll make something up<end_line>
     if there are any issues.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			まあ、大丈夫でしょ<end_line>
+			村長って結構、いいかげんだし<end_line>
+			いざとなれば親方がなんとかするよ<end_line>
+		</sjis>
+    <ascii>
+    I'm sure they'll be fine.<end_line>
+    She'll make something up<end_line>
+    if there are any issues.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -377,23 +400,27 @@
 	<portrait_l entry="player" eye="serious" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			あのさ<three_dots><end_line>
 			実はオレ<end_line>
 			本当はよくわかってないんだけど<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Actually<three_dots><end_line>
+    I don't really understand<three_dots><end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			あのさ<three_dots><end_line>
 			実はわたし<end_line>
 			本当はよくわかってないんだけど<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Actually<three_dots><end_line>
     I don't really understand<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -441,23 +468,27 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>って、なんだか<partner><end_line>
 			さびしそうだけど<end_line>
 			どうしたんだ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    <three_dots>Hey, you look sad.<end_line>
+    What's wrong?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			<three_dots>って、なんだか<partner><end_line>
 			さびしそうだけど<end_line>
 			どうしたの？<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots>Hey, you look sad.<end_line>
     What's wrong?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -493,21 +524,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			よし、町の方に出たはぐれを<end_line>
 			たおしてやる！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よーし、町の方に出たはぐれを<end_line>
-			たおしちゃおう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright, let's go<end_line>
     take care of that Stray!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よーし、町の方に出たはぐれを<end_line>
+			たおしちゃおう！<end_line>
+		</sjis>
+    <ascii>
+    Alright, let's go<end_line>
+    take care of that Stray!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -529,20 +564,23 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			なんとかしなくちゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Right!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<end_line>
 			なんとかしなくちゃ！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -550,21 +588,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			よし、町の方に出たはぐれを<end_line>
 			たおしてやる！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よーし、町の方に出たはぐれを<end_line>
-			たおしちゃおう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright, let's go<end_line>
     take care of that Stray!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よーし、町の方に出たはぐれを<end_line>
+			たおしちゃおう！<end_line>
+		</sjis>
+    <ascii>
+    Alright, let's go<end_line>
+    take care of that Stray!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -588,20 +630,23 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			なんとかしなくちゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Right!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<end_line>
 			なんとかしなくちゃ！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -609,21 +654,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			よし、町の方に出たはぐれを<end_line>
 			たおしてやる！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よーし、町の方に出たはぐれを<end_line>
-			たおしちゃおう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright, let's go<end_line>
     take care of that Stray!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よーし、町の方に出たはぐれを<end_line>
+			たおしちゃおう！<end_line>
+		</sjis>
+    <ascii>
+    Alright, let's go<end_line>
+    take care of that Stray!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -655,18 +704,21 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			出てやるぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			出てみせるから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     The road out of town!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			出てみせるから！<end_line>
+		</sjis>
+    <ascii>
+    The road out of town!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -687,21 +739,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			よし、町の方に出たはぐれを<end_line>
 			たおしてやる！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よーし、町の方に出たはぐれを<end_line>
-			たおしちゃおう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright, let's go<end_line>
     take care of that Stray!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よーし、町の方に出たはぐれを<end_line>
+			たおしちゃおう！<end_line>
+		</sjis>
+    <ascii>
+    Alright, let's go<end_line>
+    take care of that Stray!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -721,20 +777,23 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			なんとかしなくちゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Right!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<end_line>
 			なんとかしなくちゃ！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -782,22 +841,27 @@
 	<portrait_l entry="player" eye="happy" mouth="yell">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そんなことしたら今度は<end_line>
 			帰れなくなるだろ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そんなことしたら今度は<end_line>
-			帰れなくなっちゃうよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     If I did that,<end_line>
     they wouldn't let me<end_line>
     back in here!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そんなことしたら今度は<end_line>
+			帰れなくなっちゃうよ！<end_line>
+		</sjis>
+    <ascii>
+    If I did that,<end_line>
+    they wouldn't let me<end_line>
+    back in here!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1078,18 +1142,21 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだそれ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なにそれ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What's that?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なにそれ？<end_line>
+		</sjis>
+    <ascii>
+    What's that?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1211,23 +1278,27 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			ディックル鉱洞の抜け道を通って<end_line>
 			町の方まで行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Let's find the detour in the Mine,<end_line>
+    and make our way to the road!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			よぉし！<end_line>
 			ディックル鉱洞の抜け道を通って<end_line>
 			町の方まで行ってみよう！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's find the detour in the Mine,<end_line>
     and make our way to the road!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1266,23 +1337,27 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			ディックル鉱洞の抜け道を通って<end_line>
 			町の方まで行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Let's find the detour in the Mine,<end_line>
+    and make our way to the road!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			よぉし！<end_line>
 			ディックル鉱洞の抜け道を通って<end_line>
 			町の方まで行ってみよう！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's find the detour in the Mine,<end_line>
     and make our way to the road!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1350,23 +1425,27 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			ディックル鉱洞の抜け道を通って<end_line>
 			町の方まで行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Let's find the detour in the Mine,<end_line>
+    and make our way to the road!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			よぉし！<end_line>
 			ディックル鉱洞の抜け道を通って<end_line>
 			町の方まで行ってみよう！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's find the detour in the Mine,<end_line>
     and make our way to the road!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1388,24 +1467,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだと！<end_line>
 			お前がさびしそうにしてるから<end_line>
 			話し掛けてやったのに<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ<end_line>
-			あなたがさびしそうにしてるから<end_line>
-			話し掛けてあげたのに<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, sorry!<end_line>
     I'm talking to you because<end_line>
     you looked lonely.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ<end_line>
+			あなたがさびしそうにしてるから<end_line>
+			話し掛けてあげたのに<end_line>
+		</sjis>
+    <ascii>
+    Well, sorry!<end_line>
+    I'm talking to you because<end_line>
+    you looked lonely.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1429,20 +1513,23 @@
 	<portrait_l entry="player" eye="sad" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんかもう<end_line>
 			どっちでもいいや<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なんかもう<end_line>
-			どっちでもいいや<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Oh forget it<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なんかもう<end_line>
+			どっちでもいいや<end_line>
+		</sjis>
+    <ascii>
+    Oh forget it<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1463,23 +1550,27 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			ディックル鉱洞の抜け道を通って<end_line>
 			町の方まで行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Let's find the detour in the Mine,<end_line>
+    and make our way to the road!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			よぉし！<end_line>
 			ディックル鉱洞の抜け道を通って<end_line>
 			町の方まで行ってみよう！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's find the detour in the Mine,<end_line>
     and make our way to the road!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1594,18 +1685,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いい人だって！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いい人だよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     He's a good person!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いい人だよ！<end_line>
+		</sjis>
+    <ascii>
+    He's a good person!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1672,18 +1766,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			いい人だって！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いい人だよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     He's a good person!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いい人だよ！<end_line>
+		</sjis>
+    <ascii>
+    He's a good person!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1735,18 +1832,21 @@
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<portrait_r entry="partner" eye="special" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			まだ何も言ってないだろ！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			まだ何も言ってないよ！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I didn't say anything!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			まだ何も言ってないよ！？<end_line>
+		</sjis>
+    <ascii>
+    I didn't say anything!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1841,18 +1941,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="stressed">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			ちょっと待てよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ちょっと待ってよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Wait for me!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ちょっと待ってよ！<end_line>
+		</sjis>
+    <ascii>
+    Wait for me!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1901,18 +2004,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			いい人だって！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いい人だよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     But he's a good person!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いい人だよ！<end_line>
+		</sjis>
+    <ascii>
+    But he's a good person!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2075,21 +2181,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="stressed">
 	<portrait_r entry="partner" eye="special" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			お<three_dots><end_line>
 			おっそろしいこと言ってないか！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			お<three_dots><end_line>
-			おっそろしいこと言ってない！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Can you stop saying<end_line>
     things like that!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			お<three_dots><end_line>
+			おっそろしいこと言ってない！？<end_line>
+		</sjis>
+    <ascii>
+    Can you stop saying<end_line>
+    things like that!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2164,18 +2274,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			（<three_dots>って、なんでオレが<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			（<three_dots>って、なんでわたしが<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     (<three_dots>wait,<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			（<three_dots>って、なんでわたしが<end_line>
+		</sjis>
+    <ascii>
+    (<three_dots>wait,<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">

--- a/Day 02/24353772_1739bec.xml
+++ b/Day 02/24353772_1739bec.xml
@@ -4,24 +4,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			とにかくミューノの大事な魔石ってのを<end_line>
 			持って行ったヤツらをさがさないと<three_dots><end_line>
 			<three_dots>って、どこにいるんだろう？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			とにかくミューノの大事な魔石ってのを<end_line>
-			持って行った人たちをさがさないと<three_dots><end_line>
-			<three_dots>って、どこにいるんだろう？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We have to find those two.<end_line>
     They took Murno's precious stone<three_dots><end_line>
     Where could they be<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			とにかくミューノの大事な魔石ってのを<end_line>
+			持って行った人たちをさがさないと<three_dots><end_line>
+			<three_dots>って、どこにいるんだろう？<end_line>
+		</sjis>
+    <ascii>
+    We have to find those two.<end_line>
+    They took Murno's precious stone<three_dots><end_line>
+    Where could they be<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -45,24 +50,29 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			仲間、か<three_dots><end_line>
 			仲間っていうと、ボスタフ工房には<end_line>
 			いるはずだよな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			仲間、か<three_dots><end_line>
-			仲間っていうと、ボスタフ工房には<end_line>
-			いるはずだよね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Comrades<three_dots><end_line>
     Bostaph's Workshop then.<end_line>
     Let's check it out.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			仲間、か<three_dots><end_line>
+			仲間っていうと、ボスタフ工房には<end_line>
+			いるはずだよね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Comrades<three_dots><end_line>
+    Bostaph's Workshop then.<end_line>
+    Let's check it out.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -70,24 +80,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			とにかくミューノの大事な魔石ってのを<end_line>
 			持って行ったヤツらをさがさないと<three_dots><end_line>
 			<three_dots>って、どこにいるんだろう？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			とにかくミューノの大事な魔石ってのを<end_line>
-			持って行った人たちをさがさないと<three_dots><end_line>
-			<three_dots>って、どこにいるんだろう？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We have to find those two.<end_line>
     They took Murno's precious stone<three_dots><end_line>
     Where could they be<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			とにかくミューノの大事な魔石ってのを<end_line>
+			持って行った人たちをさがさないと<three_dots><end_line>
+			<three_dots>って、どこにいるんだろう？<end_line>
+		</sjis>
+    <ascii>
+    We have to find those two.<end_line>
+    They took Murno's precious stone<three_dots><end_line>
+    Where could they be<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -123,19 +138,23 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			ボスタフ工房のことか<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ボスタフ工房のことね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Bostaph's Workshop then.<end_line>
     Let's go.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ボスタフ工房のことね<end_line>
+		</sjis>
+    <ascii>
+    Bostaph's Workshop then.<end_line>
+    Let's go.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -143,24 +162,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			とにかくミューノの大事な魔石ってのを<end_line>
 			持って行ったヤツらをさがさないと<three_dots><end_line>
 			<three_dots>って、どこにいるんだろう？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			とにかくミューノの大事な魔石ってのを<end_line>
-			持って行った人たちをさがさないと<three_dots><end_line>
-			<three_dots>って、どこにいるんだろう？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We have to find those two.<end_line>
     They took Murno's precious stone<three_dots><end_line>
     Where could they be<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			とにかくミューノの大事な魔石ってのを<end_line>
+			持って行った人たちをさがさないと<three_dots><end_line>
+			<three_dots>って、どこにいるんだろう？<end_line>
+		</sjis>
+    <ascii>
+    We have to find those two.<end_line>
+    They took Murno's precious stone<three_dots><end_line>
+    Where could they be<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -197,24 +221,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			とにかくミューノの大事な魔石ってのを<end_line>
 			持って行ったヤツらをさがさないと<three_dots><end_line>
 			<three_dots>って、どこにいるんだろう？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			とにかくミューノの大事な魔石ってのを<end_line>
-			持って行った人たちをさがさないと<three_dots><end_line>
-			<three_dots>って、どこにいるんだろう？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We have to find those two.<end_line>
     They took Murno's precious stone<three_dots><end_line>
     Where could they be<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			とにかくミューノの大事な魔石ってのを<end_line>
+			持って行った人たちをさがさないと<three_dots><end_line>
+			<three_dots>って、どこにいるんだろう？<end_line>
+		</sjis>
+    <ascii>
+    We have to find those two.<end_line>
+    They took Murno's precious stone<three_dots><end_line>
+    Where could they be<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -676,21 +705,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			今は気にしてもしょうがないだろ<end_line>
 			先に行こうぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今は気にしてもしょうがないでしょ<end_line>
-			先に行こう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     No point worrying about it now.<end_line>
     Let's go.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今は気にしてもしょうがないでしょ<end_line>
+			先に行こう<end_line>
+		</sjis>
+    <ascii>
+    No point worrying about it now.<end_line>
+    Let's go.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -912,24 +945,29 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニキが跡をつけてたことか？<end_line>
 			そんな言い方するなよ<end_line>
 			オレたちを心配してくれてるんだし<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニキが跡をつけてたこと？<end_line>
-			そんな言い方しないでよ<end_line>
-			わたしたちを心配してくれてるんだし<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You mean Bro?<end_line>
     He's not strange,<end_line>
     he was just worried about us.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニキが跡をつけてたこと？<end_line>
+			そんな言い方しないでよ<end_line>
+			わたしたちを心配してくれてるんだし<end_line>
+		</sjis>
+    <ascii>
+    You mean Bro?<end_line>
+    He's not strange,<end_line>
+    he was just worried about us.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -937,18 +975,21 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="special" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			「オレたち」だと<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			「わたしたち」だと<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Us, you say<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			「わたしたち」だと<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Us, you say<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -983,18 +1024,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="neutral">
 	<portrait_r entry="partner" eye="special" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			で、<partner>にはオレが<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			で、<partner>にはわたしが<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So you're saying you'll be fine<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			で、<partner>にはわたしが<end_line>
+		</sjis>
+    <ascii>
+    So you're saying you'll be fine<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1153,21 +1197,25 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			でも、それじゃあダメなんだ<three_dots><end_line>
 			<partner><three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも、それはダメなんだよ<three_dots><end_line>
-			<partner><three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We should try to solve this<end_line>
     without fighting, <partner><three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でも、それはダメなんだよ<three_dots><end_line>
+			<partner><three_dots><end_line>
+		</sjis>
+    <ascii>
+    We should try to solve this<end_line>
+    without fighting, <partner><three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1217,21 +1265,25 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			でも、それじゃあダメなんだ<three_dots><end_line>
 			<partner><three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも、それはダメなんだよ<three_dots><end_line>
-			<partner><three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We should try to solve this<end_line>
     without fighting, <partner><three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でも、それはダメなんだよ<three_dots><end_line>
+			<partner><three_dots><end_line>
+		</sjis>
+    <ascii>
+    We should try to solve this<end_line>
+    without fighting, <partner><three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1280,21 +1332,25 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			それはダメだ<three_dots><end_line>
 			<partner><three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			それはダメだよ<three_dots><end_line>
-			<partner><three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We should try to solve this<end_line>
     without fighting, <partner><three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			それはダメだよ<three_dots><end_line>
+			<partner><three_dots><end_line>
+		</sjis>
+    <ascii>
+    We should try to solve this<end_line>
+    without fighting, <partner><three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1330,21 +1386,25 @@
 	<portrait_l name="player">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			でも、それじゃあダメなんだ<three_dots><end_line>
 			<partner><three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも、それはダメなんだよ<three_dots><end_line>
-			<partner><three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We should try to solve this<end_line>
     without fighting, <partner><three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でも、それはダメなんだよ<three_dots><end_line>
+			<partner><three_dots><end_line>
+		</sjis>
+    <ascii>
+    We should try to solve this<end_line>
+    without fighting, <partner><three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1425,18 +1485,21 @@
 	<portrait_l entry="player" eye="happy" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			おう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん！<end_line>
+		</sjis>
+    <ascii>
+    Yeah!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1840,23 +1903,27 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そっか、そうだな<end_line>
 			<partner><end_line>
 			よろしくたのむぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    You're right.<end_line>
+    I'm counting on you, <partner>!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そっか、そうだね<end_line>
 			<partner><end_line>
 			よろしくたのむね！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You're right.<end_line>
     I'm counting on you, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1950,24 +2017,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			あ、ありがとう、<partner><three_dots><end_line>
 			そうだな<end_line>
 			全力でいくぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あ、ありがとう、<partner><three_dots><end_line>
-			そうだね<end_line>
-			全力でいこう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     T-thanks, <partner><three_dots><end_line>
     You're right.<end_line>
     Let's give it everything we've got!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あ、ありがとう、<partner><three_dots><end_line>
+			そうだね<end_line>
+			全力でいこう！<end_line>
+		</sjis>
+    <ascii>
+    T-thanks, <partner><three_dots><end_line>
+    You're right.<end_line>
+    Let's give it everything we've got!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2019,24 +2091,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			たのもしいな、<partner><end_line>
 			なんだかオレも<end_line>
 			やれそうな気がしてきた<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			たのもしいね、<partner><end_line>
-			なんだかわたしも<end_line>
-			やれそうな気がしてきたよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Aren't you reliable.<end_line>
     Somehow I feel like<end_line>
     I can do this too.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			たのもしいね、<partner><end_line>
+			なんだかわたしも<end_line>
+			やれそうな気がしてきたよ<end_line>
+		</sjis>
+    <ascii>
+    Aren't you reliable.<end_line>
+    Somehow I feel like<end_line>
+    I can do this too.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2085,23 +2162,27 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			アニキは強いからな<end_line>
 			実はちょっとだけ<end_line>
 			不安かな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Well, kind of.<end_line>
+    I know Bro's strong.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			アニキは強いからね<end_line>
 			実はちょっとだけ<end_line>
 			不安かな<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, kind of.<end_line>
     I know Bro's strong.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2145,21 +2226,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そっか、そうだな！<end_line>
 			よし、行くぞ！　<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そっか、そうだよね！<end_line>
-			よし、行くよ！　<partner><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You're right!<end_line>
     Let's give it our all, <partner>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そっか、そうだよね！<end_line>
+			よし、行くよ！　<partner><end_line>
+		</sjis>
+    <ascii>
+    You're right!<end_line>
+    Let's give it our all, <partner>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">

--- a/Day 02/25068988_17e85bc.xml
+++ b/Day 02/25068988_17e85bc.xml
@@ -14,21 +14,25 @@
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			あの<three_dots><end_line>
 			人をさがしてるんだけど<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あの<three_dots><end_line>
-			人をさがしてるんだけど<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Um<three_dots><end_line>
     I'm looking for someone<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あの<three_dots><end_line>
+			人をさがしてるんだけど<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Um<three_dots><end_line>
+    I'm looking for someone<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
@@ -78,24 +82,29 @@
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="stressed">
 	<male>
-		<sjis>
+    <sjis>
 			あ、ちょっと！<end_line>
 			お前<three_dots>！<end_line>
 			レミィ<three_dots>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あ、ちょっと！<end_line>
-			あんた<three_dots>！<end_line>
-			レミィ<three_dots>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ah, hey!<end_line>
     That's<three_dots>!<end_line>
     Lemmy<three_dots>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あ、ちょっと！<end_line>
+			あんた<three_dots>！<end_line>
+			レミィ<three_dots>！<end_line>
+		</sjis>
+    <ascii>
+    Ah, hey!<end_line>
+    That's<three_dots>!<end_line>
+    Lemmy<three_dots>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -112,21 +121,25 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ！？<end_line>
 			ムシすんな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ！？<end_line>
-			ムシするなんて！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What the heck!?<end_line>
     Don't ignore me!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ！？<end_line>
+			ムシするなんて！<end_line>
+		</sjis>
+    <ascii>
+    What the heck!?<end_line>
+    Don't ignore me!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">

--- a/Day 02/25070140_17e8a3c.xml
+++ b/Day 02/25070140_17e8a3c.xml
@@ -15,7 +15,7 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="zakk" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ザック！<end_line>
 			いいところに来た！<end_line>
 			あいつはドコか知らないか？<end_line>
@@ -25,9 +25,9 @@
       Perfect timing!<end_line>
       You know where those guys are?<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			ザック！<end_line>
 			助かったよ～！<end_line>
 			あいつはドコか知らない？<end_line>
@@ -37,7 +37,7 @@
       I'm so glad I found you!<end_line>
       Do you know where those guys are?<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -56,24 +56,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="zakk" eye="surprised" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			あいつだよ！　えーと<three_dots><end_line>
 			いっつもオレにからんでくる<end_line>
 			目つきの悪い、アタマにまいてる<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あいつよ！　えーと<three_dots><end_line>
-			いっつもわたしにからんでくる<end_line>
-			目つきの悪い、アタマにまいてる<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You know! Umm<three_dots><end_line>
     They always want to fight me,<end_line>
     glare at me, and have spiky hair<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あいつよ！　えーと<three_dots><end_line>
+			いっつもわたしにからんでくる<end_line>
+			目つきの悪い、アタマにまいてる<three_dots><end_line>
+		</sjis>
+    <ascii>
+    You know! Umm<three_dots><end_line>
+    They always want to fight me,<end_line>
+    glare at me, and have spiky hair<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -93,24 +98,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="zakk" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			あいつらにすごく大事なものを<end_line>
 			持って行かれちまったんだ<three_dots><end_line>
 			だから<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あいつらにすごく大事なものを<end_line>
-			持って行かれちゃったんだよ<three_dots><end_line>
-			だから<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     They took something<end_line>
     very important to us<three_dots><end_line>
     So<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あいつらにすごく大事なものを<end_line>
+			持って行かれちゃったんだよ<three_dots><end_line>
+			だから<three_dots><end_line>
+		</sjis>
+    <ascii>
+    They took something<end_line>
+    very important to us<three_dots><end_line>
+    So<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -243,21 +253,25 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="zakk" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ディックル鉱洞の奥のトビラだな<end_line>
 			とりあえず行ってみるよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ディックル鉱洞の奥のトビラね<end_line>
-			とりあえず行ってみるよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     A door deep inside the mine<three_dots><end_line>
     I'll go check it out.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ディックル鉱洞の奥のトビラね<end_line>
+			とりあえず行ってみるよ<end_line>
+		</sjis>
+    <ascii>
+    A door deep inside the mine<three_dots><end_line>
+    I'll go check it out.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">

--- a/Day 03/000_25106700_17f190c.xml
+++ b/Day 03/000_25106700_17f190c.xml
@@ -3,24 +3,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			さて、親方が出発する前に勝負だ！<end_line>
 			最高の武器を作ってオレたちの力<end_line>
 			みせつけてやろうぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			さて、親方が出発する前に勝負だよ！<end_line>
-			最高の武器を作ってわたしたちの力<end_line>
-			みせつけちゃおう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright, we have a match<end_line>
     with Master today!<end_line>
     Let's show her what we can do!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			さて、親方が出発する前に勝負だよ！<end_line>
+			最高の武器を作ってわたしたちの力<end_line>
+			みせつけちゃおう！<end_line>
+		</sjis>
+    <ascii>
+    Alright, we have a match<end_line>
+    with Master today!<end_line>
+    Let's show her what we can do!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -30,7 +35,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -43,7 +48,7 @@
 		みゅーの様ヲ　町ニ　連レテ行クノハ<end_line>
 		本当ニ　正シイ判断　ナノデショウカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Is Bringing Lady Murno With Us<end_line>
 		Truly The Correct Decision?<end_line>
 	</ascii>
@@ -58,7 +63,7 @@
 		本当にミューノを町につれだしても<end_line>
 		良いのじゃろうか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
     Are you certain you want<end_line>
     Murno to come with us<three_dots>?<end_line>
@@ -73,7 +78,7 @@
 		まったく<end_line>
 		脳天気なやつだ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You're too careless<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -87,7 +92,7 @@
 		町につれていっても<end_line>
 		大丈夫なのか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Are you sure she should<end_line>
     be coming with us<three_dots>?<end_line>
 	</ascii>
@@ -102,7 +107,7 @@
 		本当にミューノ様を町につれだして<end_line>
 		大丈夫なんでしょうか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 		Is it really okay to<end_line>
 		bring Lady Murno with us<three_dots>?<end_line>
@@ -118,7 +123,7 @@
 		今度の相手は親方なんだぜ<end_line>
 		しっかりしてくれよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You're being pessimistic.<end_line>
     Get it together already.<end_line>
 		We still have to fight Master.<end_line>
@@ -134,7 +139,7 @@
 		ミューノまでオレたちといっしょに<end_line>
 		るすばんさせられるんだからさ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Forget Murno for a second,<end_line>
     we're going to be stuck here<end_line>
     with nothing to do if we lose.<end_line>
@@ -150,7 +155,7 @@
 		今度の相手は親方なんだよ<end_line>
 		しっかりしてよね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You're being pessimistic.<end_line>
     Get it together already.<end_line>
 		We still have to fight Master<end_line>
@@ -166,7 +171,7 @@
 		ミューノまでわたしたちといっしょに<end_line>
 		るすばんさせられちゃうんだから<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Forget Murno for a second,<end_line>
     we're going to be stuck here<end_line>
     with nothing to do if we lose.<end_line>
@@ -180,7 +185,7 @@
 	<sjis>
 		アナタト　ルスバン<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Stuck Here With You<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -193,7 +198,7 @@
 		ワカリマシタ<end_line>
 		絶対ニ　勝チマショウ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Understood.<end_line>
     I Guarantee Our Victory!<end_line>
 	</ascii>
@@ -206,7 +211,7 @@
 	<sjis>
 		おぬしとるすばん<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Stuck here with you<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -220,7 +225,7 @@
 		この勝負<end_line>
 		絶対に負けられん！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Hm.	Very well.<end_line>
 		Then we must win!<end_line>
 	</ascii>
@@ -233,7 +238,7 @@
 	<sjis>
 		キサマとるすばん<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Stuck here with you<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -246,7 +251,7 @@
 		しかたない<end_line>
 		絶対に勝ってやる<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Alright.<end_line>
 		We'll just have to win then.<end_line>
 	</ascii>
@@ -259,7 +264,7 @@
 	<sjis>
 		あなたとるすばん<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Stuck here with you<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -272,7 +277,7 @@
 		わかりました<end_line>
 		絶対に勝ちましょう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Okay!<end_line>
 		We'll win no matter what!<end_line>
 	</ascii>
@@ -282,21 +287,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			お、おお<three_dots><end_line>
 			なんだか知らんけど、その意気だ<end_line>
 			たのむな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Y-Yeah, exactly<three_dots><end_line>
+    I'm counting on you.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			あ、うん<three_dots><end_line>
 			よくわからないけど、その意気よ<end_line>
 			たのむね<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Y-Yeah, exactly<three_dots><end_line>
     I'm counting on you.<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 03/001_25108236_17f1f0c.xml
+++ b/Day 03/001_25108236_17f1f0c.xml
@@ -5,7 +5,7 @@
 		そうかい<three_dots><end_line>
 		気持ちは変わらないんだね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I see<three_dots><end_line>
 		So you're determined, huh?<end_line>
 	</ascii>
@@ -17,7 +17,7 @@
 	<sjis>
 		はい<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yes<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -30,7 +30,7 @@
 		だったらあの子たちには<end_line>
 		シッカリしてもらわないとね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Alright. In that case,<end_line>
     we'll need to keep those<end_line>
     two from doing anything stupid.<end_line>
@@ -43,7 +43,7 @@
 	<sjis>
 		<three_dots>すみません<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Sorry.<end_line>
 	</ascii>
 </dialogue>
@@ -56,7 +56,7 @@
 		アンタが一番シッカリしなきゃ<end_line>
 		ダメなんだからね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Don't get all depressed on me now.<end_line>
     I'm going to need your help.<end_line>
     Okay?<end_line>
@@ -69,7 +69,7 @@
 	<sjis>
 		<three_dots>はい！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Right!<end_line>
 	</ascii>
 </dialogue>
@@ -79,7 +79,7 @@
 	<sjis>
 		あの<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Um<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -92,7 +92,7 @@
 		こっちの準備はできてるから<end_line>
 		外で待ってるよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah, <player_nickname>.<end_line>
     I'm ready for you any time.<end_line>
     Come outside when you're done.<end_line>
@@ -105,7 +105,7 @@
 	<sjis>
 		あ、はい！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh, okay!<end_line>
 	</ascii>
 </dialogue>
@@ -118,7 +118,7 @@
 		アタシもヒマじゃないんだ<end_line>
 		いつまでも待てないからね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Jade's already left,<end_line>
 		and I don't have much free time.<end_line>
 		Can't wait forever, you know.<end_line>
@@ -133,7 +133,7 @@
 		戦った方が<end_line>
 		アンタにも勝ち目があるかもよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So, I'm not gonna waste<end_line>
 		time warming up for this.<end_line>
 		Might even give you a chance.<end_line>
@@ -146,7 +146,7 @@
 	<sjis>
 		わかった<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Right.<end_line>
 	</ascii>
 </dialogue>
@@ -157,7 +157,7 @@
 	<sjis>
 		あの<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Um<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -168,7 +168,7 @@
 	<sjis>
 		なに？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hm?<end_line>
 	</ascii>
 </dialogue>
@@ -179,7 +179,7 @@
 	<sjis>
 		あの<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -190,7 +190,7 @@
 	<sjis>
 		がんばって<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Do your best!<end_line>
 	</ascii>
 </dialogue>
@@ -201,7 +201,7 @@
 	<sjis>
 		え？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -214,7 +214,7 @@
 		あ、ああ！<end_line>
 		がんばるよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah, I will!<end_line>
 	</ascii>
 </dialogue>
@@ -227,7 +227,7 @@
 		うん！<end_line>
 		ありがとう、がんばるよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Thanks. I will!<end_line>
 	</ascii>
 </dialogue>
@@ -239,7 +239,7 @@
 	<sjis>
 		みゅーの様ノタメニ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		For Lady Murno.<end_line>
 	</ascii>
 </dialogue>
@@ -252,7 +252,7 @@
 		おぬしのためにな<end_line>
 		ミューノ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		For you, Murno.<end_line>
 	</ascii>
 </dialogue>
@@ -265,7 +265,7 @@
 		仕方ない<end_line>
 		やるしかないようだ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah, sure.<end_line>
 		I guess I have to<three_dots><end_line>
 	</ascii>
@@ -278,7 +278,7 @@
 	<sjis>
 		ミューノ様のためです！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		For Lady Murno!<end_line>
 	</ascii>
 </dialogue>
@@ -289,7 +289,7 @@
 	<sjis>
 		なーんか引っかかるけど<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That wasn't directed towards you<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -298,19 +298,23 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="murno" eye="neutral_blush" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			まあいい！<end_line>
 			絶対勝つぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			まあいいか！<end_line>
-			絶対勝つよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, whatever!<end_line>
     Let's do this!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			まあいいか！<end_line>
+			絶対勝つよ！<end_line>
+		</sjis>
+    <ascii>
+    Well, whatever!<end_line>
+    Let's do this!<end_line>
+  </ascii>
+  </female>
 </dialogue>

--- a/Day 03/011_25111692_17f2c8c.xml
+++ b/Day 03/011_25111692_17f2c8c.xml
@@ -4,7 +4,7 @@
 	<sjis>
 		やった！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yes! I won!<end_line>
 	</ascii>
 </dialogue>
@@ -16,7 +16,7 @@
 		すごい！<end_line>
 		<player_nickname>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That was amazing!<end_line>
 	</ascii>
 </dialogue>
@@ -29,7 +29,7 @@
 		アタシとしたことが<end_line>
 		負けちまうとは<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Damn it<three_dots><end_line>
     How could I lose<three_dots>?<end_line>
 	</ascii>
@@ -43,7 +43,7 @@
 		ここんとこ夏場の犬みたいにおとなしく<end_line>
 		してたとは言え、このザマとは<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I must have gotten rusty.<end_line>
 		Sure I haven't been training,<end_line>
 		but this is just pathetic<three_dots><end_line>
@@ -56,7 +56,7 @@
 	<sjis>
 		親方、やっぱケガが<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Master<three_dots><end_line>
     Your injuries must be<three_dots><end_line>
 	</ascii>
@@ -71,7 +71,7 @@
 		前回ノ動キト　比ベテ<end_line>
 		すぴーどガ　アリマセンデシタ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Compared To Our Previous Encounter,<end_line>
 		Your Speed Was Down 50%.<end_line>
 	</ascii>
@@ -84,7 +84,7 @@
 	<sjis>
 		無理ヲスルト　危険デス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Pushing Yourself Will Only<end_line>
 		Make You Grow Weaker.<end_line>
 	</ascii>
@@ -98,7 +98,7 @@
 		たしかに以前の動きとは<end_line>
 		比べものにならんかったぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Your movements have become<end_line>
     much easier to read since<end_line>
     our last encounter.<end_line>
@@ -112,7 +112,7 @@
 	<sjis>
 		あまり、ムリをするでない<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You shouldn't push yourself so hard.<end_line>
 	</ascii>
 </dialogue>
@@ -126,7 +126,7 @@
 		このあいだのキサマとは<end_line>
 		比べものにならん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Jeez<three_dots><end_line>
     It's like you were a different<end_line>
     person last time we fought.<end_line>
@@ -141,7 +141,7 @@
 		おとなしくるすばんしている方が<end_line>
 		いいのは、どっちだ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Perhaps you should be<end_line>
     the one to stay behind?<end_line>
 	</ascii>
@@ -156,7 +156,7 @@
 		動きにキレがありませんでしたわ<end_line>
 		ムリはいけませんわ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Yes, your movements are quite<end_line>
     sluggish compared to before.<end_line>
 		Don't push yourself so hard.<end_line>
@@ -171,7 +171,7 @@
 		ありがとうよ、<partner><end_line>
 		アンタけっこうやさしいんだね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Heh<three_dots><end_line>
     Thanks, <partner>.<end_line>
 		You're too kind<three_dots><end_line>
@@ -185,7 +185,7 @@
 	<sjis>
 		ヤサシイ<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Kind<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -197,7 +197,7 @@
 	<sjis>
 		なにをいうか<three_dots><end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		What are you saying<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -209,7 +209,7 @@
 	<sjis>
 		ふ、ふざけたことを言うな！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		K-kind? Me<three_dots>!?<end_line>
 	</ascii>
 </dialogue>
@@ -221,7 +221,7 @@
 	<sjis>
 		そんなことありませんわ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Not really<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -234,7 +234,7 @@
 		アンタたちなら、今のアタシでも<end_line>
 		十分勝つことができたはずだよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But you know, even like this<three_dots><end_line>
 		I could've easily<end_line>
     beat you two before.<end_line>
@@ -247,7 +247,7 @@
 	<sjis>
 		強くなったね、<player_nickname><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You've grown, <player_nickname>.<end_line>
 	</ascii>
 </dialogue>
@@ -259,7 +259,7 @@
 		あ<three_dots>ありがとう<end_line>
 		親方！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Th-Thank you, Master!<end_line>
 	</ascii>
 </dialogue>
@@ -271,7 +271,7 @@
 		ま、これも<end_line>
 		<partner>のおかげかな？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Well, I mean<three_dots><end_line>
 		This is thanks to <partner> too.<end_line>
 	</ascii>
@@ -286,7 +286,7 @@
 		ソノ可能性ガ　高イト<end_line>
 		判断シマス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 		The Probability Of That<end_line>
 		Is Exceptionally High.<end_line>
@@ -301,7 +301,7 @@
 		ふ<three_dots><end_line>
 		当然じゃ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hmph<three_dots><end_line>
 		Of course.<end_line>
 	</ascii>
@@ -315,7 +315,7 @@
 		ふ<three_dots><end_line>
 		当たり前だ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Hmph<three_dots><end_line>
 		Obviously.<end_line>
 	</ascii>
@@ -329,7 +329,7 @@
 		もちろん<end_line>
 		そのとおりですわ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Of course.<end_line>
 		That much is obvious.<end_line>
 	</ascii>
@@ -339,18 +339,21 @@
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<portrait_r entry="vee" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			なんだと！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ！？<end_line>
+		</sjis>
+    <ascii>
+    Hey!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -361,7 +364,7 @@
 		こうやってアタシに勝ったことだしね<end_line>
 		つれてってやるよ、アンタたちも<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Anyway, you did beat me.<end_line>
     I'll hold up my end of the deal.<end_line>
 	</ascii>
@@ -373,7 +376,7 @@
 	<sjis>
 		親方<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Master<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -386,7 +389,7 @@
 		さっさと出発の準備をしな<end_line>
 		ミューノもね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now that that's decided,<end_line>
 		you two hurry up and get ready.<end_line>
 		Murno too.<end_line>
@@ -400,7 +403,7 @@
 		私は準備できてますよ<end_line>
 		ヴィーさん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'm ready any time, Miss Vee.<end_line>
 	</ascii>
 </dialogue>
@@ -413,7 +416,7 @@
 		じゃ、門のところにいるから<end_line>
 		<player_nickname>も早くしなよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Great!<end_line>
 		I'll be waiting at the gate, then.<end_line>
 		Now hurry it up, <player_nickname>.<end_line>
@@ -427,7 +430,7 @@
 		わかった！<end_line>
 		門のところだね！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Okay!<end_line>
 	</ascii>
 </dialogue>
@@ -439,7 +442,7 @@
 		<player_nickname>だけじゃなくて<end_line>
 		<partner>にミューノ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ugh<three_dots><end_line>
 		Not just<player_nickname><three_dots><end_line>
 		But also <partner>, and Murno<three_dots><end_line>
@@ -453,7 +456,7 @@
 		けっこう重いねぇ<three_dots><end_line>
 		だけど<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     A blade made with the feelings of<end_line>
 		three people is quite sharp<three_dots><end_line>
 		But<three_dots><end_line>
@@ -467,7 +470,7 @@
 		なったんだね<end_line>
 		うれしいねえ、ロブ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I'm glad that kid has other<end_line>
     reasons to fight now.<end_line>
 		Right, Rob<three_dots>?<end_line>
@@ -481,7 +484,7 @@
 		あの<three_dots><end_line>
 		ヴィーさん？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Um<three_dots><end_line>
     Vee?<end_line>
 	</ascii>
@@ -494,7 +497,7 @@
 		ああ、悪い悪い<end_line>
 		行こうか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ahh, sorry. It's nothing.<end_line>
 		Shall we go?<end_line>
 	</ascii>

--- a/Day 03/014_25754108_188f9fc.xml
+++ b/Day 03/014_25754108_188f9fc.xml
@@ -1,15 +1,15 @@
 <location>
-	<sjis>
+  <sjis>
 		森洞<end_line>
 	</sjis>
 </location>
 <location>
-	<sjis>
+  <sjis>
 		バジャンの森<end_line>
 	</sjis>
 </location>
 <location>
-	<sjis>
+  <sjis>
 		バジャンの森　エリア１<end_line>
 	</sjis>
 </location>
@@ -20,7 +20,7 @@
 		修行するなら他行ってやりな<end_line>
 		街道はあぶないからな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Go train elsewhere.<end_line>
 		The main road is dangerous.<end_line>
 	</ascii>
@@ -31,7 +31,7 @@
 	<sjis>
 		修行がんばれよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Work hard on your training.<end_line>
 	</ascii>
 </dialogue>
@@ -39,19 +39,23 @@
 	<info box="simple">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			今戻ったら見つかるぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今戻ると見つかっちゃうよお<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     If we go back now,<end_line>
     they'll find us.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今戻ると見つかっちゃうよお<end_line>
+		</sjis>
+    <ascii>
+    If we go back now,<end_line>
+    they'll find us.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="special">
@@ -59,7 +63,7 @@
 		転送装置は起動中の転送装置間を一瞬で<end_line>
 		移動することができます<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		This is a teleporter.<end_line>
     It allows you to jump to<end_line>
     any other active teleporters.<end_line>
@@ -72,7 +76,7 @@
 		上に立ってＡボタンを押すことで<end_line>
 		使用することができます<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Strike with the hammer to activate,<end_line>
 		and use it by standing on top of it<end_line>
 		and pressing the A button.<end_line>
@@ -84,7 +88,7 @@
 		今は別の転送装置が起動していないため<end_line>
 		使用することはできません<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		At this time, no other teleporter<end_line>
 		is active, so it cannot be used.<end_line>
 	</ascii>

--- a/Day 03/018_25115196_17f3a3c.xml
+++ b/Day 03/018_25115196_17f3a3c.xml
@@ -7,7 +7,7 @@
 		このあたりでは<end_line>
 		めずらしいですね～<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah, a Summon Beast!<end_line>
 		They're quite rare around here.<end_line>
 	</ascii>
@@ -17,27 +17,27 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="tier" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうかな<end_line>
 			オレの相棒<end_line>
 			パートナーなんだ！<end_line>
 		</sjis>
-		<ascii>	
+    <ascii>	
 			That so?<end_line>
 			Well, this one's my partner!<end_line>
 		</ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			そう？<end_line>
 			わたしの相棒<end_line>
 			パートナーなの！<end_line>
 		</sjis>
-		<ascii>	
+    <ascii>	
 			Really?<end_line>
 			Well, this one's my partner!<end_line>
 		</ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -48,7 +48,7 @@
 		まあ！<end_line>
 		カッコイイ召喚獣ですね～！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh!<end_line>
 		It's so cool~!<end_line>
 	</ascii>
@@ -61,7 +61,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -74,7 +74,7 @@
 		ちょっと<three_dots><end_line>
 		反応うすすぎるわ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey<three_dots><end_line>
 		It's not responding at all<three_dots><end_line>
 	</ascii>
@@ -88,7 +88,7 @@
 		まあ、カワイイ！<end_line>
 		ネコちゃん召喚獣ですね～！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh, how cute!<end_line>
 		A cat Summon Beast~!<end_line>
 	</ascii>
@@ -103,7 +103,7 @@
 		ワガハイはトラの妖怪トラマタじゃ！<end_line>
 		おぬしのメガネはダテか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I am not! I'm a tiger!<end_line>
     A graceful Toramata!<end_line>
 		Do those glasses serve any purpose?!<end_line>
@@ -118,7 +118,7 @@
 		しゃべった！<end_line>
 		そしてとても怒られた！<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		Hey, he talked!<end_line>
 		And he's super angry!<end_line>
 	</ascii>
@@ -132,7 +132,7 @@
 		まあ！<end_line>
 		かしこそうな召喚獣ですね～！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh!<end_line>
 		He looks smart!<end_line>
 	</ascii>
@@ -146,7 +146,7 @@
 		なんだ、キサマ？<end_line>
 		なれなれしいぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Of course.<end_line>
 		And who might you be?<end_line>
 	</ascii>
@@ -159,7 +159,7 @@
 	<sjis>
 		扱いづらい人ですね<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		He must be hard to deal with<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -172,7 +172,7 @@
 		まあ！<end_line>
 		カワイイ召喚獣ですね～！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh!<end_line>
 		What a cute Summon Beast!<end_line>
 	</ascii>
@@ -185,7 +185,7 @@
 	<sjis>
 		ありがとうございます<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Thank you very much!<end_line>
 	</ascii>
 </dialogue>
@@ -197,7 +197,7 @@
 	<sjis>
 		素直なイイ子です～<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		She seems like a good girl~<end_line>
 	</ascii>
 </dialogue>
@@ -210,7 +210,7 @@
 		もしかして、みなさん<end_line>
 		町へ向かってます？<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		So anyway, are you<end_line>
 		all heading to town?<end_line>
 	</ascii>
@@ -222,7 +222,7 @@
 	<sjis>
 		あなた、一体<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Who are you<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -235,7 +235,7 @@
 		いえいえそんな<end_line>
 		あやしい者ではありませんよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah!<end_line>
 		No, no,<end_line>
 		I'm not suspicious at all!<end_line>
@@ -249,7 +249,7 @@
 		わたしはティエ<end_line>
 		ただのカワイイ道案内ですよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'm Tier.<end_line>
 		Just a cute guide! Hehe.<end_line>
 	</ascii>
@@ -261,7 +261,7 @@
 	<sjis>
 		え？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Eh?<end_line>
 	</ascii>
 </dialogue>
@@ -274,7 +274,7 @@
 		大きな穴がいっぱいあいちゃって<end_line>
 		この先は迷路みたいになってるんです<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     The earthquake earlier totally<end_line>
     messed up the terrain around here.<end_line>
     It's like navigating a maze.<end_line>
@@ -287,7 +287,7 @@
 	<sjis>
 		道案内があった方が断然いいですよ～<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     You'd do well to have<end_line>
     someone guide you through!<end_line>
 	</ascii>
@@ -297,18 +297,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="tier" eye="serious" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			へえ、そうなのか<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			へえ、そうなんだ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Oh, is that so<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			へえ、そうなんだ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Oh, is that so<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -317,7 +320,7 @@
 		（いける<three_dots>！<end_line>
 		　コイツはいけるわ<three_dots>！）<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     (This might just work!<end_line>
 		 Just a bit more<three_dots>!)<end_line>
 	</ascii>
@@ -331,7 +334,7 @@
 		タダじゃ無いんだろ？<end_line>
 		ティエちゃん？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We'd be grateful to have a guide,<end_line>
 		but it won't be for free, right?<end_line>
 	</ascii>
@@ -344,7 +347,7 @@
 		え！？<end_line>
 		お金とるの？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Eh?<end_line>
 		You're charging?<end_line>
 	</ascii>
@@ -357,7 +360,7 @@
 		お！？<end_line>
 		おほほほほほ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh?<end_line>
 		Ohohohohoho<three_dots><end_line>
 	</ascii>
@@ -370,7 +373,7 @@
 		ちぇっ<three_dots>！<end_line>
 		スルドイわね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Tch<three_dots>!<end_line>
 		Well, aren't you shrewd?<end_line>
 	</ascii>
@@ -382,7 +385,7 @@
 	<sjis>
 		で、いくらなんだい？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So, how much'll it be?<end_line>
 	</ascii>
 </dialogue>
@@ -395,7 +398,7 @@
 		でも、本当にこの先は<end_line>
 		迷いやすいんだから<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		200 Boam.<end_line>
     It's easy to get lost in here<three_dots><end_line>
 	</ascii>
@@ -407,7 +410,7 @@
 	<sjis>
 		案内があった方が絶対いいんだから<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Definitely better to have a guide<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -420,7 +423,7 @@
 		でもアタシは自分で確かめてみないと<end_line>
 		お金を払う気にゃなれないね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh<three_dots><end_line>
 		But unless I see it for myself,<end_line>
 		I won't feel like actually paying.<end_line>
@@ -434,7 +437,7 @@
 		あなたはどう？<end_line>
 		案内して欲しいでしょ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		And how about you?<end_line>
 		You want a guide, right?<end_line>
 	</ascii>
@@ -446,7 +449,7 @@
 	<sjis>
 		え～？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Uh<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -455,39 +458,42 @@
 	<portrait_l entry="player" eye="serious" mouth="serious">
 	<portrait_r entry="tier" eye="serious" mouth="neutral">
 	<option>
-		<sjis>
+    <sjis>
 			案内を頼んでみようかな<three_dots><end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			I guess so<three_dots><end_line>
 		</ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			自力で道を切り開こう！<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			I'll find a path myself!<end_line>
 		</ascii>
-	</option>
+  </option>
 </choice>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="tier" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			じゃあ頼むぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			じゃあお願い！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright, I'm counting on you!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			じゃあお願い！<end_line>
+		</sjis>
+    <ascii>
+    Alright, I'm counting on you!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -497,7 +503,7 @@
 		それでは案内料<end_line>
 		２００バームいただきまぁす！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     That'll be 200 Boam!<end_line>
 	</ascii>
 </dialogue>
@@ -508,7 +514,7 @@
 	<sjis>
 		まいど～！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Thank you!<end_line>
 	</ascii>
 </dialogue>
@@ -520,7 +526,7 @@
 		本日早くも２件目<end_line>
 		今日はいい日だわ～<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Already the second one today<three_dots><end_line>
 		Today's a good day~<end_line>
 	</ascii>
@@ -532,7 +538,7 @@
 	<sjis>
 		２件目って？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The second one?<end_line>
 	</ascii>
 </dialogue>
@@ -558,7 +564,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -571,7 +577,7 @@
 		ここら辺、はぐれも多いから<end_line>
 		気をつけてくださいね～<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Alright then, please follow me.<end_line>
     Please be careful, as there<end_line>
     are many Strays around too~<end_line>
@@ -584,7 +590,7 @@
 		あれ<three_dots><end_line>
 		お金が足りない<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh<three_dots><end_line>
 		You don't have enough money<three_dots><end_line>
 	</ascii>
@@ -596,7 +602,7 @@
 		ちょっと、ひやかしなの！？<end_line>
 		ひど～い！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are you trying to scam me!?<end_line>
 		That's ho~rri~ble~!<end_line>
 	</ascii>
@@ -607,7 +613,7 @@
 	<sjis>
 		いや、そういうつもりじゃ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No no, we're not<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -618,7 +624,7 @@
 		じゃあ、ここで待ってるから<end_line>
 		お金できたら来てね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Well, I'll be waiting here<end_line>
     when you do have the money.<end_line>
 	</ascii>
@@ -628,7 +634,7 @@
 	<sjis>
 		やっぱ、別にいいや<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Nah, I don't need one.<end_line>
 	</ascii>
 </dialogue>
@@ -640,7 +646,7 @@
 		そんなこと言っていられるのも<end_line>
 		今のうちだけなんだから！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No way!?<end_line>
 		Well, that's what you say now!<end_line>
 	</ascii>
@@ -652,7 +658,7 @@
 		わたし、ここにいるから<end_line>
 		その気になったら知らせてね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'll be waiting here,<end_line>
 		so come tell me when you<end_line>
 		inevitably change your mind.<end_line>

--- a/Day 03/026_25124476_17f5e7c.xml
+++ b/Day 03/026_25124476_17f5e7c.xml
@@ -7,7 +7,7 @@
 		もう少しで召喚獣トロッコの駅のある<end_line>
 		マーネイル宿場ですよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Well done~<end_line>
     Just ahead is Marneil Station.<end_line>
     There you'll find the railcar.<end_line>
@@ -22,7 +22,7 @@
 		ま、この調子なら<end_line>
 		今日中に町につくな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We're finally halfway.<end_line>
 		Well, at this rate we'll<end_line>
 		get there before dark.<end_line>
@@ -35,7 +35,7 @@
 	<sjis>
 		あと半分か<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Only halfway there, huh.<end_line>
 	</ascii>
 </dialogue>
@@ -48,7 +48,7 @@
 		みゅーの様<end_line>
 		大丈夫デスカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Lady Murno,<end_line>
 		Are You Okay?<end_line>
 	</ascii>
@@ -61,7 +61,7 @@
 	<sjis>
 		大丈夫か、ミューノ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Murno, are you alright?<end_line>
 	</ascii>
 </dialogue>
@@ -73,7 +73,7 @@
 	<sjis>
 		お前、まだ歩けるか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Can you still walk?<end_line>
 	</ascii>
 </dialogue>
@@ -86,7 +86,7 @@
 		大丈夫ですか？<end_line>
 		ミューノ様<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are you alright, Lady Murno?<end_line>
 	</ascii>
 </dialogue>
@@ -98,7 +98,7 @@
 		ええ<end_line>
 		平気よ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah.<end_line>
 		I'm fine.<end_line>
 	</ascii>
@@ -110,7 +110,7 @@
 		じゃあ、わたしに<end_line>
 		ついてきてください！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Alrighty, please follow me~!<end_line>
 	</ascii>
 </dialogue>
@@ -121,7 +121,7 @@
 		あ！？<end_line>
 		アレは<three_dots>！<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		Ah!?<end_line>
 		That's<three_dots>!<end_line>
 	</ascii>
@@ -130,16 +130,19 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なに？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What's wrong?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なに？<end_line>
+		</sjis>
+    <ascii>
+    What's wrong?<end_line>
+  </ascii>
+  </female>
 </dialogue>

--- a/Day 03/028_25125852_17f63dc.xml
+++ b/Day 03/028_25125852_17f63dc.xml
@@ -5,7 +5,7 @@
 	<sjis>
 		ハグレ召喚獣ヲ　確認<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Stray Summon Beast Confirmed.<end_line>
 	</ascii>
 </dialogue>
@@ -16,7 +16,7 @@
 	<sjis>
 		はぐれ召喚獣じゃな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's a Stray.<end_line>
 	</ascii>
 </dialogue>
@@ -27,7 +27,7 @@
 	<sjis>
 		ちっ<three_dots>はぐれ召喚獣か<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Tch<three_dots><end_line>
 		A Stray<three_dots><end_line>
 	</ascii>
@@ -39,7 +39,7 @@
 	<sjis>
 		はぐれ召喚獣ですわ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That must be a Stray.<end_line>
 	</ascii>
 </dialogue>
@@ -51,7 +51,7 @@
 		ちっちゃいけど、凶暴なのよね<three_dots><end_line>
 		でも、このあたりでははじめて見たわ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey, I know that one.<end_line>
 		It's stronger than it looks.<end_line>
     But I haven't seen it here before<three_dots><end_line>
@@ -64,7 +64,7 @@
 		やっぱり最近<end_line>
 		何かがおかしいのかも<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I knew something was off<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -73,24 +73,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="tier" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			まだこっちには<end_line>
 			気がついてないみたいだけど<end_line>
 			どうしよう？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			まだこっちには<end_line>
-			気がついてないみたいだけど<end_line>
-			どうしよう？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Looks like it hasn't<end_line>
     noticed us yet.<end_line>
     What should we do?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			まだこっちには<end_line>
+			気がついてないみたいだけど<end_line>
+			どうしよう？<end_line>
+		</sjis>
+    <ascii>
+    Looks like it hasn't<end_line>
+    noticed us yet.<end_line>
+    What should we do?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -101,7 +106,7 @@
 		ここは大人で強くてカッコイイ<end_line>
 		アタシの出番<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Well, we don't have a choice<three_dots><end_line>
 		It's time for the mature,<end_line>
 		strong, cool me to step up<three_dots><end_line>
@@ -114,7 +119,7 @@
 		（いける<three_dots>！<end_line>
 		　コレはいけるわ<three_dots>！）<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     (Wait<three_dots>!<end_line>
      If I beat the Stray<three_dots><end_line>
      Maybe I'll get a bonus<three_dots>!)<end_line>
@@ -126,7 +131,7 @@
 	<sjis>
 		ちょっとどいてもらいましょう<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Stand aside.<end_line>
 	</ascii>
 </dialogue>
@@ -137,7 +142,7 @@
 		え？<end_line>
 		ティエちゃん<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Eh?<end_line>
     Tier<three_dots>?<end_line>
 	</ascii>
@@ -147,7 +152,7 @@
 	<sjis>
 		ぐるるる<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Grrrr<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -158,7 +163,7 @@
 		ちょっとアンタ！？<end_line>
 		何してんだい！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Wait, you-!?<end_line>
 		What are you doing!?<end_line>
 	</ascii>
@@ -172,7 +177,7 @@
 		あのはぐれを<end_line>
 		たおすんですから！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey, let go of me!<end_line>
 		I'll defeat that Stray!<end_line>
 	</ascii>
@@ -184,7 +189,7 @@
 	<sjis>
 		あ！　これは別料金ですよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh, and it'll cost extra!<end_line>
 	</ascii>
 </dialogue>
@@ -195,7 +200,7 @@
 	<sjis>
 		お金とるの！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You're charging for it too!?<end_line>
 	</ascii>
 </dialogue>
@@ -208,7 +213,7 @@
 		こういうときは大人に<end_line>
 		まかせとけばいいんだ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What are you saying!?<end_line>
 		At times like these,<end_line>
 		you should let an adult handle it!<end_line>
@@ -218,24 +223,29 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			ちょっと！<end_line>
 			こんなときに何やってんだよ<end_line>
 			ふたりとも<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ちょっと！<end_line>
-			こんなときに何やってんのよ<end_line>
-			ふたりとも<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey!<end_line>
     Now's not the time<end_line>
     to argue<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ちょっと！<end_line>
+			こんなときに何やってんのよ<end_line>
+			ふたりとも<end_line>
+		</sjis>
+    <ascii>
+    Hey!<end_line>
+    Now's not the time<end_line>
+    to argue<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -244,7 +254,7 @@
 		あのこ<three_dots><end_line>
 		こっちに<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah<three_dots><end_line>
 		It's coming!<end_line>
 	</ascii>
@@ -258,7 +268,7 @@
 		コノママデハ　みゅーの様ガ<end_line>
 		危険デス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Lady Murno Will Soon Be In Danger.<end_line>
 		We Must Protect Her.<end_line>
 	</ascii>
@@ -272,7 +282,7 @@
 		この場は我らで<end_line>
 		ミューノを守るのじゃ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We'll protect Murno!<end_line>
 	</ascii>
 </dialogue>
@@ -285,7 +295,7 @@
 		仕方ない<three_dots><end_line>
 		やるか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Fine<three_dots><end_line>
     We'll take care of this!<end_line>
 	</ascii>
@@ -298,7 +308,7 @@
 	<sjis>
 		ミューノ様をお守りしなくては<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We must protect Lady Murno!<end_line>
 	</ascii>
 </dialogue>
@@ -307,19 +317,23 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			よし！<end_line>
 			行こう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん！<end_line>
-			行くよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Let's do this!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん！<end_line>
+			行くよ！<end_line>
+		</sjis>
+    <ascii>
+    Alright!<end_line>
+    Let's do this!<end_line>
+  </ascii>
+  </female>
 </dialogue>

--- a/Day 03/029_25128156_17f6cdc.xml
+++ b/Day 03/029_25128156_17f6cdc.xml
@@ -5,7 +5,7 @@
 		あ～あ、やっつけちゃった～<end_line>
 		せっかくのえものが<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ahh~ <end_line>
     There goes my bonus~<end_line>
 	</ascii>
@@ -18,7 +18,7 @@
 		まったく何言ってるんだい<end_line>
 		この娘は<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     What is wrong with<end_line>
     this girl<three_dots>?<end_line>
 	</ascii>
@@ -31,7 +31,7 @@
 		大丈夫、<player_nickname><end_line>
 		ケガはない？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are you alright, <player_nickname>?<end_line>
 	</ascii>
 </dialogue>
@@ -43,7 +43,7 @@
 		平気平気！<end_line>
 		大丈夫！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'm fine, I'm fine!<end_line>
 		But thanks for asking.<end_line>
 	</ascii>
@@ -57,7 +57,7 @@
 		薬を持ってますよ<end_line>
 		お安くしておきますよ～<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		If you're hurt,<end_line>
 		I have some medicine I<end_line>
 		can sell for reaal cheap~<end_line>
@@ -68,18 +68,21 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="tier" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			また金もうけかよ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			またお金もうけなの<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Asking for money again<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			またお金もうけなの<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Asking for money again<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -89,7 +92,7 @@
 		ずいぶんと用意がいいねぇ<end_line>
 		故郷のばーちゃんみたいだよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You're very well prepared.<end_line>
 		Like a hometown granny.<end_line>
 	</ascii>
@@ -103,7 +106,7 @@
 		森にはキケンがいっぱいですから<end_line>
 		これぐらいの準備は当然ですよ～<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I dunno about your granny,<end_line>
 		but its only natural around here.<end_line>
     There's danger around every corner.<end_line>
@@ -118,7 +121,7 @@
 		先ホドノ戦闘ハ<end_line>
 		アナタガ原因ダト　判断シマス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		To The Contrary,<end_line>
     You Yourself Have Caused Danger<end_line>
 		By Initiating The Fight Earlier.<end_line>
@@ -134,7 +137,7 @@
 		おぬしが不用意に攻撃など<end_line>
 		したからじゃぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We were forced to fight purely<end_line>
 		due to your carelessness.<end_line>
 	</ascii>
@@ -148,7 +151,7 @@
 		キサマがうかつに攻撃したおかげで<end_line>
 		こんな目にあっているのだがな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's thanks to your stupidity<end_line>
 		we had to fight that thing.<end_line>
 	</ascii>
@@ -163,7 +166,7 @@
 		こんな目にあったのは<end_line>
 		あなたのせいなんですよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     That was your fault, you know?<end_line>
 		You started the fight yourself.<end_line>
 	</ascii>
@@ -176,7 +179,7 @@
 		なんですって！？<end_line>
 		あんたたちが勝手に戦ったんでしょ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh!?<end_line>
     I did say I'd take care of it!<end_line>
 		You were the ones who butted in!<end_line>
@@ -191,7 +194,7 @@
 		わたしにまかせておけば<end_line>
 		よかったじゃない<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		If you were gonna complain,<end_line>
 		you should've let me handle it<end_line>
 		right from the beginning.<end_line>
@@ -204,7 +207,7 @@
 	<sjis>
 		ムチャ言うんじゃないよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What are you blabbering about now!?<end_line>
 	</ascii>
 </dialogue>
@@ -217,7 +220,7 @@
 		これでもわたし<end_line>
 		すっごく強いんだから～<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Don't underestimate me~<end_line>
     I'm stronger than I look.<end_line>
 	</ascii>
@@ -229,7 +232,7 @@
 	<sjis>
 		強いって<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Strong<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -241,7 +244,7 @@
 		何よ<three_dots><end_line>
 		信じないの？？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What?<end_line>
 		You don't believe me??<end_line>
 	</ascii>
@@ -253,7 +256,7 @@
 	<sjis>
 		それは<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Well<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -262,39 +265,42 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="tier" eye="decided" mouth="serious">
 	<option>
-		<sjis>
+    <sjis>
 			実はティエって結構強い気がする<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			She probably is strong.<end_line>
 		</ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			ティエは全然強そうに見えない<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Looks pretty weak to me.<end_line>
 		</ascii>
-	</option>
+  </option>
 </choice>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="tier" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			お前、強いんだろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あなたは強いんでしょ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You are strong, aren't you?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あなたは強いんでしょ？<end_line>
+		</sjis>
+    <ascii>
+    You are strong, aren't you?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -303,7 +309,7 @@
 	<sjis>
 		うん、信じてる<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah, I believe you.<end_line>
 	</ascii>
 </dialogue>
@@ -316,7 +322,7 @@
 		その言い方<end_line>
 		ゼンゼン信じてないわ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hmm<three_dots><end_line>
     You really don't, do you?<end_line>
     I can tell!<end_line>
@@ -327,18 +333,21 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="tier" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、それ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Oh come on<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Oh come on<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="nobox">
@@ -348,7 +357,7 @@
 		どう見たって強そうには<end_line>
 		見えないよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Sorry, but<three_dots><end_line>
 		You do seem pretty weak.<end_line>
 	</ascii>
@@ -362,7 +371,7 @@
 		いくらお客でも言って良いことと<end_line>
 		悪いことがあるわよ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Why you<three_dots><end_line>
 		Even if you're my customers,<end_line>
     I can't let you trash me like that<three_dots><end_line>
@@ -375,7 +384,7 @@
 	<sjis>
 		だってさ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So you say, but<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -388,7 +397,7 @@
 		その召喚獣もまとめて<end_line>
 		相手になってあげるわ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's have a match then.<end_line>
     You and your Summon Beast!<end_line>
     I'll take you both down!<end_line>
@@ -401,7 +410,7 @@
 	<sjis>
 		え！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ehhh!?<end_line>
 	</ascii>
 </dialogue>
@@ -414,7 +423,7 @@
 		アナタガ勝利スル確率ハ<end_line>
 		低イト　判断サレマスガ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Your Probability Of Victory<end_line>
     Is Zero. I Suggest You Reconsider.<end_line>
 	</ascii>
@@ -428,7 +437,7 @@
 		やめておけ<end_line>
 		おぬしでは勝負ならんぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Stop that.<end_line>
 		You can't win.<end_line>
 	</ascii>
@@ -443,7 +452,7 @@
 		そのふざけた台詞を<end_line>
 		聞かなかったことにしてやる<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Hah.<end_line>
     I'll just pretend you<end_line>
     didn't say anything.<end_line>
@@ -458,7 +467,7 @@
 		止めておいた方がいいですわ<end_line>
 		勝負になりませんよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Please stop this.<end_line>
 		You're no match for us.<end_line>
 	</ascii>
@@ -472,7 +481,7 @@
 		今のうちだけよ<end_line>
 		わたしと勝負するまでは<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Keep talking all you like.<end_line>
     Until you decide to fight me<three_dots><end_line>
 	</ascii>
@@ -484,7 +493,7 @@
 	<sjis>
 		ここから先には行かせないんだから！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I won't let you go any further!<end_line>
 	</ascii>
 </dialogue>
@@ -494,7 +503,7 @@
 	<sjis>
 		どうしよう？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So what do we do now?<end_line>
 	</ascii>
 </dialogue>
@@ -507,7 +516,7 @@
 		ちゃっちゃと先に進みたいし<end_line>
 		勝負でも何でもしてやんな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There's no helping it<three_dots><end_line>
     Look, we don't have all day.<end_line>
     Just get it over with.<end_line>
@@ -518,21 +527,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="vee" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そっか<three_dots><end_line>
 			わかったよ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そっか<three_dots><end_line>
-			仕方ないね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots><end_line>
     Okay, I guess<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そっか<three_dots><end_line>
+			仕方ないね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    <three_dots><end_line>
+    Okay, I guess<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -543,7 +556,7 @@
 		ただ勝負するってのも<end_line>
 		面白くないねぇ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Just a plain match is boring.<end_line>
     How about we up the stakes<three_dots><end_line>
 	</ascii>
@@ -555,7 +568,7 @@
 	<sjis>
 		どういうことよ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Meaning?<end_line>
 	</ascii>
 </dialogue>
@@ -568,7 +581,7 @@
 		この勝負に勝ったら<end_line>
 		さっきの案内代、チャラってことで<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		How about this?<end_line>
 		If we win, your<end_line>
 		guidance is free of charge.<end_line>
@@ -583,7 +596,7 @@
 		ええ～っ！？<end_line>
 		お金返せってことですか！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Free<three_dots><end_line>
 		EHHHHHHH!?<end_line>
 		You mean return the money!?<end_line>
@@ -597,7 +610,7 @@
 		いいじゃないか<end_line>
 		アンタ勝つ自信、あるんだろ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What's the problem?<end_line>
 		You seemed awfully confident<end_line>
 		about winning before.<end_line>
@@ -612,7 +625,7 @@
 		その程度の実力なら<end_line>
 		この勝負、みとめられないねぇ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Well, I won't force you into it, but<end_line>
 		if that's all your talk led up to,<end_line>
 		I won't be approving this match.<end_line>
@@ -625,7 +638,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -636,7 +649,7 @@
 	<sjis>
 		わかったわ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Fine.<end_line>
 	</ascii>
 </dialogue>
@@ -649,7 +662,7 @@
 		そうこなくっちゃな！<end_line>
 		絶対勝つんだよ、<player_nickname>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah!<end_line>
 		Now you're talking!<end_line>
 		Make sure to win, <player_nickname>!<end_line>
@@ -663,7 +676,7 @@
 		あ<three_dots><end_line>
 		はい<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh<three_dots>?<end_line>
 		Yeah, sure.<end_line>
 	</ascii>
@@ -676,7 +689,7 @@
 		んじゃ、各自<end_line>
 		勝負の準備をととのえな！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     That settles it!<end_line>
     Now go get ready!<end_line>
 	</ascii>
@@ -689,7 +702,7 @@
 	<sjis>
 		親方ハ　味方ナノデショウカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Does Master Really<end_line>
     Care About Us?<end_line>
 	</ascii>
@@ -703,7 +716,7 @@
 		<three_dots><end_line>
 		そのはずよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 		I hope so.<end_line>
 	</ascii>
@@ -717,7 +730,7 @@
 		親方<three_dots><end_line>
 		油断できぬ女よ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Master<three_dots><end_line>
 		She's a dangerous one<three_dots><end_line>
 	</ascii>
@@ -730,7 +743,7 @@
 	<sjis>
 		そ<three_dots>そうね<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yes<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -743,7 +756,7 @@
 		あの女<three_dots><end_line>
 		なかなかやるな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That woman<three_dots><end_line>
 		Not bad<three_dots><end_line>
 	</ascii>
@@ -756,7 +769,7 @@
 	<sjis>
 		そ<three_dots>そうね<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I guess<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -769,7 +782,7 @@
 		親方さん<three_dots><end_line>
 		ちょっとコワイですわ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Master<three_dots><end_line>
 		She can be scary<three_dots><end_line>
 	</ascii>
@@ -782,7 +795,7 @@
 	<sjis>
 		そ<three_dots>そうかも<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Y-You might be right<three_dots><end_line>
 	</ascii>
 </dialogue>

--- a/Day 03/030_25131180_17f78ac.xml
+++ b/Day 03/030_25131180_17f78ac.xml
@@ -5,7 +5,7 @@
 	<sjis>
 		勝負の準備はいい？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are you ready?<end_line>
 	</ascii>
 </dialogue>
@@ -14,21 +14,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="tier" eye="decided" mouth="neutral">
 	<option>
-		<sjis>
+    <sjis>
 			勝負の準備はもうカンペキ<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Definitely!<end_line>
 		</ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			もう少し待って欲しい<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Could you wait a bit?<end_line>
 		</ascii>
-	</option>
+  </option>
 </choice>
 <dialogue>
 	<info box="right">
@@ -38,7 +38,7 @@
 		この勝負、勝たないと<end_line>
 		先には進めないと思いな！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Listen, you two.<end_line>
 		Think of it this way:<end_line>
 		If you don't win, we can't progress!<end_line>
@@ -49,21 +49,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="vee" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			う<three_dots><end_line>
 			わかったよ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			う<three_dots><end_line>
-			わかりました<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ugh<three_dots><end_line>
     I got it already<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			う<three_dots><end_line>
+			わかりました<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Ugh<three_dots><end_line>
+    I got it already<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -72,7 +76,7 @@
 	<sjis>
 		ふたりとも、がんばってね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Do your best, you two.<end_line>
 	</ascii>
 </dialogue>
@@ -81,21 +85,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="murno" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			よし！<end_line>
 			行くぞ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よぉし！<end_line>
-			行くよ、<partner>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
     Let's do this, <partner>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よぉし！<end_line>
+			行くよ、<partner>！<end_line>
+		</sjis>
+    <ascii>
+    Yeah!<end_line>
+    Let's do this, <partner>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -105,7 +113,7 @@
 	<sjis>
 		オー！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yes!<end_line>
 	</ascii>
 </dialogue>
@@ -117,7 +125,7 @@
 	<sjis>
 		承知！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Understood!<end_line>
 	</ascii>
 </dialogue>
@@ -129,7 +137,7 @@
 	<sjis>
 		好きにしろ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah. She's done for.<end_line>
 	</ascii>
 </dialogue>
@@ -141,7 +149,7 @@
 	<sjis>
 		はい！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Got it!<end_line>
 	</ascii>
 </dialogue>

--- a/Day 03/031_25132284_17f7cfc.xml
+++ b/Day 03/031_25132284_17f7cfc.xml
@@ -7,7 +7,7 @@
 		<player_nickname>、<partner><end_line>
 		アンタたち、よくやったよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Alright!<end_line>
 		<player_nickname>, <partner>,<end_line>
 		well done!<end_line>
@@ -20,7 +20,7 @@
 	<sjis>
 		これでタダだ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hehe, who's paying now eh?<end_line>
 	</ascii>
 </dialogue>
@@ -29,18 +29,21 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="vee" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			お金はオレが払ったのに<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			お金はわたしが払ったのに<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     That was MY money, you know<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			お金はわたしが払ったのに<three_dots><end_line>
+		</sjis>
+    <ascii>
+    That was MY money, you know<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -49,7 +52,7 @@
 	<sjis>
 		親方<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Master<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -62,7 +65,7 @@
 		トテモ　ウレシソウデスネ<three_dots><end_line>
 		記録シテオキマス<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You Seem Very Happy.<end_line>
 		I Will Record This Event.<end_line>
 	</ascii>
@@ -77,7 +80,7 @@
 		まあ、良かったということに<end_line>
 		しておこうか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     She's way too excited<three_dots><end_line>
     Well, as long as she's satisfied<three_dots><end_line>
 	</ascii>
@@ -92,7 +95,7 @@
 		タダなのがそんなに<end_line>
 		うれしかったのか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Such an intense aura<three_dots><end_line>
     She's much too<end_line>
     excited about this<three_dots><end_line>
@@ -107,7 +110,7 @@
 		タダなのがうれしいんですね<three_dots><end_line>
 		ちょっと切ないですわ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Wow<three_dots><end_line>
 		I don't think I've seen her<end_line>
 		any happier than this<three_dots><end_line>
@@ -122,7 +125,7 @@
 		実力がわかって満足だろ？<end_line>
 		ほら、約束通りお金を<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now that the little lady<end_line>
 		knows our true strength,<end_line>
 		might we get our money back?<end_line>
@@ -135,7 +138,7 @@
 	<sjis>
 		<three_dots><three_dots>い<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><three_dots>N<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -146,7 +149,7 @@
 	<sjis>
 		え？　何？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hm<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -159,7 +162,7 @@
 		女の子相手に<three_dots><end_line>
 		本気で戦うだなんて<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		How cruel<three_dots><end_line>
     You went all out against a girl<three_dots><end_line>
 	</ascii>
@@ -174,7 +177,7 @@
 		勝負しろって言ったのは<end_line>
 		そっちだろ！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh!?<end_line>
     You're the one who<end_line>
     wanted to fight me!<end_line>
@@ -190,7 +193,7 @@
 		勝負しようって言ったのは<end_line>
 		あなたでしょ！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh!?<end_line>
 		You're the one who<end_line>
     wanted to fight me!<end_line>
@@ -205,7 +208,7 @@
 		<three_dots>っていうかわたしも<end_line>
 		女の子なんだけど<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>And I'm a girl too!<end_line>
 	</ascii>
 </dialogue>
@@ -216,7 +219,7 @@
 	<sjis>
 		あ、いたっ<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah, oww<three_dots>!<end_line>
 	</ascii>
 </dialogue>
@@ -228,7 +231,7 @@
 		大丈夫？<end_line>
 		ケガしてるの？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are you okay?<end_line>
 	</ascii>
 </dialogue>
@@ -240,7 +243,7 @@
 		大丈夫、です<three_dots><end_line>
 		あ、いた<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'm<three_dots>fine<three_dots><end_line>
 		Ah, tchh<three_dots>!<end_line>
 	</ascii>
@@ -254,7 +257,7 @@
 		あなた、薬持ってるんでしょ？<end_line>
 		じゃあ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Does it hurt<three_dots>?<end_line>
 		Do you have some medicine?<end_line>
 		I'll<three_dots><end_line>
@@ -269,7 +272,7 @@
 		売り物の薬を使うことなんて<end_line>
 		できません<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I can't<three_dots><end_line>
     This is my merchandise<three_dots><end_line>
     I can't use it on myself<three_dots><end_line>
@@ -283,7 +286,7 @@
 		でも<three_dots><end_line>
 		どこかで手当しないと<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But<three_dots><end_line>
 		We have to treat you or<three_dots><end_line>
 	</ascii>
@@ -297,7 +300,7 @@
 		近くにマーネイル宿場がありますし<end_line>
 		そこまで行けば<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's okay<three_dots><end_line>
 		Marneil Station is close<three_dots><end_line>
     If we make it there<three_dots><end_line>
@@ -310,7 +313,7 @@
 	<sjis>
 		<player_nickname><three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<player_nickname><three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -321,7 +324,7 @@
 	<sjis>
 		え？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Eh?<end_line>
 	</ascii>
 </dialogue>
@@ -330,42 +333,46 @@
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<portrait_r entry="murno" eye="sad" mouth="serious">
 	<option>
-		<sjis>
+    <sjis>
 			<three_dots>わかった<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			<three_dots>Okay.<end_line>
 		</ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			なに<three_dots>？<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			What<three_dots>?<end_line>
 		</ascii>
-	</option>
+  </option>
 </choice>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="murno" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>わかったよ<end_line>
 			宿場までつれていってやるよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots>わかったわ<end_line>
-			宿場までつれていってあげる<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots>Okay.<end_line>
     I'll take her to town.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots>わかったわ<end_line>
+			宿場までつれていってあげる<end_line>
+		</sjis>
+    <ascii>
+    <three_dots>Okay.<end_line>
+    I'll take her to town.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -375,7 +382,7 @@
 		ありがとう<end_line>
 		<player_nickname><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Thanks.<end_line>
 	</ascii>
 </dialogue>
@@ -389,7 +396,7 @@
 		彼女ヲ　宿場マデ<end_line>
 		送レバイイノデスネ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Understood.<end_line>
 		All We Must Do<end_line>
 		Is Escort Her To Town.<end_line>
@@ -405,7 +412,7 @@
 		その娘を宿場まで<end_line>
 		送ってやるとするか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We don't have a choice then.<end_line>
     We'll escort you to town.<end_line>
 	</ascii>
@@ -419,7 +426,7 @@
 		そいつを宿場まで送りたいのだろ？<end_line>
 		好きにすればいい<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You want to escort her to town?<end_line>
 		Fine.<end_line>
 	</ascii>
@@ -434,7 +441,7 @@
 		宿場まで送っていって<end_line>
 		あげましょう<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		That's right.<end_line>
 		Let's escort her back to town.<end_line>
 	</ascii>
@@ -447,7 +454,7 @@
 		ありがとう<end_line>
 		<partner><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Thanks, <partner>.<end_line>
 	</ascii>
 </dialogue>
@@ -459,7 +466,7 @@
 		すみません<three_dots><end_line>
 		じゃあ、おねがいします<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Sorry about this<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -470,7 +477,7 @@
 	<sjis>
 		早く行きましょう？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Shall we go?<end_line>
 	</ascii>
 </dialogue>
@@ -482,7 +489,7 @@
 		あの<three_dots><end_line>
 		お金<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Um<three_dots><end_line>
 		My money<three_dots><end_line>
 	</ascii>
@@ -494,7 +501,7 @@
 	<sjis>
 		いたっ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oww<three_dots><end_line>
     Ah, it hurts<three_dots><end_line>
 	</ascii>
@@ -505,7 +512,7 @@
 	<sjis>
 		う<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ugh<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -515,7 +522,7 @@
 	<sjis>
 		しかたない、か<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I guess there's no helping it<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -526,7 +533,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -537,7 +544,7 @@
 	<sjis>
 		なんだい、その目は？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Why are you staring<end_line>
     at me like that?<end_line>
 	</ascii>
@@ -550,7 +557,7 @@
 	<sjis>
 		かめらデス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Staring? I Am Not.<end_line>
 		These Are Cameras.<end_line>
     I Am Simply Recording Your Image.<end_line>
@@ -565,7 +572,7 @@
 		<three_dots><end_line>
 		なんでもない<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 		Forget it.<end_line>
 	</ascii>
@@ -578,7 +585,7 @@
 	<sjis>
 		<three_dots>別に<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>It's nothing<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -591,7 +598,7 @@
 		え！？<end_line>
 		なにか気にさわりました？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Eh!?<end_line>
     Oh no, I wasn't<three_dots><end_line>
 	</ascii>
@@ -604,7 +611,7 @@
 		もういい！<end_line>
 		行くよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Forget it!<end_line>
 		Let's go!<end_line>
 	</ascii>
@@ -616,7 +623,7 @@
 	<sjis>
 		はーい<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Okaaay~<end_line>
 	</ascii>
 </dialogue>
@@ -626,7 +633,7 @@
 	<sjis>
 		ふふ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Heheh<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -638,7 +645,7 @@
 		？<end_line>
 		大丈夫？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		?<end_line>
 		You okay?<end_line>
 	</ascii>
@@ -652,7 +659,7 @@
 		はいはい<three_dots>！<end_line>
 		行きましょう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Eh?<end_line>
 		Y-Yeah<three_dots>!<end_line>
     C'mon, let's go already!<end_line>

--- a/Day 03/032_24372060_173e35c.xml
+++ b/Day 03/032_24372060_173e35c.xml
@@ -1,10 +1,10 @@
 <location>
-	<sjis>
+  <sjis>
 		マーネイル宿場<end_line>
 	</sjis>
 </location>
 <location>
-	<sjis>
+  <sjis>
 		マーネイル宿場　ほほえみ亭前<end_line>
 	</sjis>
 </location>
@@ -12,15 +12,15 @@
 	<info box="simple">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			まずほほえみ亭って宿屋に行こう<end_line>
 		</sjis>
     <ascii>
       I should head to Smile Inn first.<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			先にほほえみ亭って<end_line>
 			宿屋に行きたいな<three_dots><end_line>
 		</sjis>
@@ -28,38 +28,41 @@
       I should really check out<end_line>
       this 'Smile Inn' first<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ほほえみ亭に戻るか<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ほほえみ亭に戻ろう<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's head back to the inn.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ほほえみ亭に戻ろう<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Let's head back to the inn.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			まずほほえみ亭って宿屋に行こう<end_line>
 		</sjis>
     <ascii>
       I should head to Smile Inn first.<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			先にほほえみ亭って<end_line>
 			宿屋に行きたいな<three_dots><end_line>
 		</sjis>
@@ -67,7 +70,7 @@
       I should really check out<end_line>
       this 'Smile Inn' first<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
@@ -104,7 +107,7 @@
 		ところであなたは、鍛冶師みたいだけど<end_line>
 		強化の情報を聞いていかない？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You're a Craftknight, aren't you?<end_line>
 		Want to hear about enhancement?<end_line>
 	</ascii>
@@ -136,7 +139,7 @@
 		使うと、必殺技の「二連撃」が武器に<end_line>
 		付加されるの<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Well, there's this special material.<end_line>
 		If you use it on your weapon,<end_line>
 		you'll get 'Double Attack'.<end_line>
@@ -150,7 +153,7 @@
 		必殺技が付加されない場合があるから<end_line>
 		気を付けてね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah! But depending on the weapon type<end_line>
 		some abilities become unusable.<end_line>
 		So, watch out, okay?<end_line>
@@ -164,7 +167,7 @@
 		「加速ゼンマイ」を、３５０バームで<end_line>
 		販売中なの～<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But anyway, I have this special<end_line>
 		material on sale right now,<end_line>
 		at a paltry price of 350 Boam~<end_line>
@@ -176,28 +179,28 @@
 	<sjis>
 		買ってくれます？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Wanna buy it?<end_line>
 	</ascii>
 </dialogue>
 <choice>
 	<info box="simple">
 	<option>
-		<sjis>
+    <sjis>
 			買う<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Buy<end_line>
 		</ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			買わない<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Don't buy<end_line>
 		</ascii>
-	</option>
+  </option>
 </choice>
 <dialogue>
 	<info box="simple">
@@ -243,7 +246,7 @@
 		え～聞いてくれないの～<end_line>
 		せっかくのお客さんだと思ったのに～<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Eeh? You won't even listen?!<end_line>
 		Just when I thought<end_line>
 		I finally had a new client<three_dots><end_line>
@@ -257,7 +260,7 @@
 		薪割りを手伝って欲しいとか言いながら<end_line>
 		素人には任せられないって<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That person is such a pain.<end_line>
 		He says he wants help chopping wood,<end_line>
 		but he wants a professional<three_dots><end_line>
@@ -271,7 +274,7 @@
 		どうすれば、いいんだよ<end_line>
 		薪割り入門書でもあるのかよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Everyone's an amateur at first.<end_line>
 		If I don't get a chance, how am I<end_line>
 		going to get experience at all?<end_line>

--- a/Day 03/033_25134876_17f871c.xml
+++ b/Day 03/033_25134876_17f871c.xml
@@ -2,18 +2,21 @@
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ここがマーネイル宿場だな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ここがマーネイル宿場だね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So this is Marneil Station.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ここがマーネイル宿場だね<end_line>
+		</sjis>
+    <ascii>
+    So this is Marneil Station.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -23,7 +26,7 @@
 		どこで手当をしてもらえば<end_line>
 		いいのかしら？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Is there anywhere around here<end_line>
     we can get medical treatment?<end_line>
 	</ascii>
@@ -37,7 +40,7 @@
 		ほほえみ亭って言うんですけど<end_line>
 		いつもお世話になっていますから<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     The inn over there will do.<end_line>
 		It's called the Smile Inn.<end_line>
 		The staff know me well, so<three_dots><end_line>
@@ -49,7 +52,7 @@
 	<sjis>
 		じゃあ、行こっか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Alright then, let's go.<end_line>
 	</ascii>
 </dialogue>
@@ -62,7 +65,7 @@
 		いかがですか？<end_line>
 		あそこ、食事もおいしいですよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Oh, and I recommend you stay<end_line>
     there for a night if you can.<end_line>
 		The food there is great.<end_line>
@@ -76,7 +79,7 @@
 		自家製ケーキなんて<end_line>
 		とろけるおいしさですよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Their specialty homemade cake<end_line>
     just melts in your mouth<three_dots><end_line>
   </ascii>
@@ -88,7 +91,7 @@
 	<sjis>
 		ケーキ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Cake<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -101,7 +104,7 @@
 		アタシは甘ったるいのは<end_line>
 		ちょっと<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Cake<three_dots>?<end_line>
     I don't really care<end_line>
     for sweet things<three_dots><end_line>
@@ -112,7 +115,7 @@
 	<sjis>
 		くぅ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		*grumble*<three_dots><end_line>
 	</ascii>
 </bigtext>
@@ -122,7 +125,7 @@
 	<sjis>
 		あ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -134,7 +137,7 @@
 		あ<three_dots><end_line>
 		今の<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 		Was that<three_dots><end_line>
 	</ascii>
@@ -147,7 +150,7 @@
 	<sjis>
 		みゅーの様ノ　オナカノ音デス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The Sound Of Murno's Stomach.<end_line>
 	</ascii>
 </dialogue>
@@ -160,7 +163,7 @@
 		なっ<three_dots>！<end_line>
 		<partner>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Wha<three_dots>!<end_line>
 		<partner>!<end_line>
 	</ascii>
@@ -173,7 +176,7 @@
 	<sjis>
 		そういわれてみれば<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now that you mention it<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -183,21 +186,21 @@
 	<portrait_l entry="murno" eye="happy_blush" mouth="stressed">
 	<portrait_r entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			オレもハラへったなぁ！<end_line>
 		</sjis>
     <ascii>
       I'm starving!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			わたしもおなかすいたかな<three_dots><end_line>
 		</sjis>
     <ascii>
       I'm hungry too<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -207,7 +210,7 @@
 	<sjis>
 		うぅ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -219,7 +222,7 @@
 	<sjis>
 		にゃー！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Meowww~!<end_line>
 	</ascii>
 </bigtext>
@@ -233,7 +236,7 @@
 		まさか<three_dots><end_line>
 		ごまかしてるつもり<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>?<end_line>
     Are you<three_dots><end_line>
     Trying to cover for her<three_dots>?<end_line>
@@ -247,7 +250,7 @@
 	<sjis>
 		やかましい！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's so noisy here~!<end_line>
 	</ascii>
 </bigtext>
@@ -260,7 +263,7 @@
 		ありがとう<three_dots><end_line>
 		<partner><three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     <partner><three_dots><end_line>
 		Thank you<three_dots><end_line>
 	</ascii>
@@ -274,7 +277,7 @@
 		なんだ？<end_line>
 		何も聞こえなかったが<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What?<end_line>
 		I didn't hear anything.<end_line>
 	</ascii>
@@ -287,7 +290,7 @@
 	<sjis>
 		え<three_dots>あ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Uh<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -297,18 +300,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="talk">
 	<portrait_r entry="partner" eye="surprised" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			そ、そうだな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そ、そうだね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Y-Yup, not a thing.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そ、そうだね<end_line>
+		</sjis>
+    <ascii>
+    Y-Yup, not a thing.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -317,7 +323,7 @@
 	<sjis>
 		うぅ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -329,7 +335,7 @@
 		私、と～っても<end_line>
 		おなかがすいてしまいましたわ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah~!<end_line>
 		I'm sooo~ hungry~!<end_line>
 	</ascii>
@@ -342,7 +348,7 @@
 		なんだ<end_line>
 		<partner>のおなかか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh<three_dots><end_line>
 		So it was you, <partner><three_dots><end_line>
 	</ascii>
@@ -355,7 +361,7 @@
 		そうなんです<end_line>
 		すみません<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's right.<end_line>
 		I'm sorry about that.<end_line>
 	</ascii>
@@ -368,7 +374,7 @@
 		ありがとう<three_dots><end_line>
 		<partner><three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     <partner><three_dots><end_line>
 		Thank you<three_dots><end_line>
 	</ascii>
@@ -380,7 +386,7 @@
 		しかたないねぇ<end_line>
 		じゃ、ここでひと休みにするか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Well, it can't be helped.<end_line>
 		Let's take a break here.<end_line>
 	</ascii>
@@ -393,7 +399,7 @@
 		やった！<end_line>
 		行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yay!<end_line>
 	</ascii>
 </dialogue>

--- a/Day 03/038_25136908_17f8f0c.xml
+++ b/Day 03/038_25136908_17f8f0c.xml
@@ -5,7 +5,7 @@
 		いらっしゃい！<end_line>
 		ほほえみ亭にようこそ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Come in!<end_line>
 		Welcome to the Smile Inn!<end_line>
 	</ascii>
@@ -18,7 +18,7 @@
 		お客さんよー<end_line>
 		お泊まりが４名様～<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We have guests!<end_line>
 		Rooms for 4, please!<end_line>
 	</ascii>
@@ -30,7 +30,7 @@
 		ちょっと待った！？<end_line>
 		誰がお泊まりだ！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey, wait!<end_line>
 		We never said<three_dots>!<end_line>
 	</ascii>
@@ -43,7 +43,7 @@
 		さっき言ったじゃないですか<end_line>
 		ここで休んでいくって<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You clearly said earlier<end_line>
 		that you'd rest here.<end_line>
 	</ascii>
@@ -56,7 +56,7 @@
 		た、たしかに言ったけど<three_dots>！<end_line>
 		泊まるとは言ってないだろ！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		S-Sure I said that, but we didn't<end_line>
 		agree to spend the night!<end_line>
 	</ascii>
@@ -68,7 +68,7 @@
 		おーおー<end_line>
 		お前たちもつかまったみたいだな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh, hey.<end_line>
     She got you too?<end_line>
 	</ascii>
@@ -81,7 +81,7 @@
 		ちょっと、アンタ<end_line>
 		なんでこんなとこに？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Wait, what<three_dots>?<end_line>
 		What are you doing here?<end_line>
 	</ascii>
@@ -95,7 +95,7 @@
 		困ってる女の子を見捨てるなんて<end_line>
 		オレにできるわけないだろ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Well, I came across the girl<end_line>
 		and she seemed quite troubled,<end_line>
 		I couldn't just abandon her<three_dots><end_line>
@@ -110,7 +110,7 @@
 		どうせアンタは<end_line>
 		ケーキが目当てだろ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Right<three_dots><end_line>
 		<three_dots><end_line>
 		You just wanted some cake, right?<end_line>
@@ -125,7 +125,7 @@
 		このオレがケーキなんて<end_line>
 		甘ったるいもん<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey, hey!<end_line>
 		Do you really think I could be<end_line>
 		lured by some mere cake<three_dots>?<end_line>
@@ -139,7 +139,7 @@
 		口のはしに<end_line>
 		クリームついてるよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There's cream on your mouth.<end_line>
 	</ascii>
 </dialogue>
@@ -150,7 +150,7 @@
 	<sjis>
 		がっ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Gah!<end_line>
 	</ascii>
 </bigtext>
@@ -161,7 +161,7 @@
 	<sjis>
 		ウソ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Just kidding~<end_line>
 	</ascii>
 </dialogue>
@@ -173,7 +173,7 @@
 		ぐっ<three_dots>！<end_line>
 		キサマ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Kh<three_dots><end_line>
 		How dare you<three_dots>!<end_line>
 	</ascii>
@@ -187,7 +187,7 @@
 		本当にうまいケーキだったんだろう<end_line>
 		けどな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Wow, you're calmer than I expected.<end_line>
     Must be some really good cake.<end_line>
 	</ascii>
@@ -201,7 +201,7 @@
 		トイウコトハ<end_line>
 		マズイト　アバレルノデスネ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     So One Can Control Him With Food<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -213,7 +213,7 @@
 	<sjis>
 		マズイとあばれるのか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     So you can control him with food<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -225,7 +225,7 @@
 	<sjis>
 		マズイとあばれるのか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     So you can control him with food<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -237,7 +237,7 @@
 	<sjis>
 		マズイとあばれるんですね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     So you can control him with food<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -249,7 +249,7 @@
 		お母さんの料理は<end_line>
 		リィンバウムいちなんだから！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's right!<end_line>
 		Mom's cooking is the best<end_line>
 		in Lyndbaum, you know!<end_line>
@@ -262,7 +262,7 @@
 	<sjis>
 		お母さん！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Mom!?<end_line>
 	</ascii>
 </dialogue>
@@ -275,7 +275,7 @@
 		また娘が強引におさそいしたみたいで<end_line>
 		どーも、すみませんねー<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yes, I'm her mother, Roche.<end_line>
     My daughter must have forced<end_line>
     this upon you. I apologize.<end_line>
@@ -288,7 +288,7 @@
 	<sjis>
 		娘ぇ！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What!?<end_line>
 	</ascii>
 </bigtext>
@@ -300,7 +300,7 @@
 		そう、わたしがここの看板娘<end_line>
 		ティエよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yup, I'm the<end_line>
 		inn's poster girl!<end_line>
 	</ascii>
@@ -311,7 +311,7 @@
 	<sjis>
 		ハメられた！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Gah!<end_line>
     It's a trap!<end_line>
 	</ascii>
@@ -325,7 +325,7 @@
 		料理も美味しいし工房もあるから<end_line>
 		武器の修理もしてあげるわよ～<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Heeey now, you're already here!<end_line>
     We have super delicious food,<end_line>
     and we do weapon repairs too!<end_line>
@@ -336,21 +336,25 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="tier" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			オレは鍛冶師だ！<end_line>
 			武器の修理は自分でするよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしは鍛冶師なの！<end_line>
-			武器の修理は自分でするわよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm a Craftknight,<end_line>
     I can do that myself!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしは鍛冶師なの！<end_line>
+			武器の修理は自分でするわよ！<end_line>
+		</sjis>
+    <ascii>
+    I'm a Craftknight,<end_line>
+    I can do that myself!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -361,7 +365,7 @@
 		わたしに手を出したこと<end_line>
 		許してあげるから、ね～<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Then, if you stay the night,<end_line>
 		I'll forgive you for laying<end_line>
 		your hands on me, 'kay~?<end_line>
@@ -374,7 +378,7 @@
 	<sjis>
 		てっ、手を出した！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You what!?<end_line>
 	</ascii>
 </dialogue>
@@ -386,7 +390,7 @@
 		お母さん<end_line>
 		これには色々ふかいワケが<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Miss,<end_line>
 		I assure you there were some<end_line>
 		very specific circumstances<three_dots><end_line>
@@ -400,7 +404,7 @@
 		ま、そんなわけで<end_line>
 		１人１０００バームよろしく<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Aaanyways<three_dots><end_line>
 		That'll be 1000 Boam per person!<end_line>
 	</ascii>
@@ -414,7 +418,7 @@
 		ちぇっ<three_dots><end_line>
 		結局、金の話かよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Tch<three_dots>!<end_line>
     Of course it's all<end_line>
     about the money!<end_line>
@@ -429,7 +433,7 @@
 		オレたちをダマして金もうけなんて<end_line>
 		きたねぇじゃねぇか！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Tricking us, and taking our money<three_dots><end_line>
 		That's low!<end_line>
 	</ascii>
@@ -443,7 +447,7 @@
 		むっ<three_dots><end_line>
 		結局、お金の話なの！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Grr<three_dots>!<end_line>
     Of course it comes<end_line>
     down to money!<end_line>
@@ -458,7 +462,7 @@
 		わたしたちをダマしてお金もうけなんて<end_line>
 		ずるいじゃない！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Tricking us and taking our money<three_dots><end_line>
 		That's playing dirty!<end_line>
 	</ascii>
@@ -472,7 +476,7 @@
 		だましただなんて<three_dots><end_line>
 		ひどい<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Little old me, extorting customers?<end_line>
 		How could you even say that<three_dots><end_line>
     You're so mean<three_dots><end_line>
@@ -483,45 +487,50 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="tier" eye="surprised" mouth="stressed">
 	<option>
-		<sjis>
+    <sjis>
 			全然ヒドくなんかない！<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Says the one who cheated us!<end_line>
 		</ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			ちょっとヒドかったかも<three_dots><end_line>
 		</sjis>
-		<ascii>
+    <ascii>
       Maybe I went a little overboard<three_dots><end_line>
 		</ascii>
-	</option>
+  </option>
 </choice>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="tier" eye="surprised" mouth="stressed">
 	<male>
-		<sjis>
+    <sjis>
 			だましただろ！<end_line>
 			ケガしたってのも<end_line>
 			どうせウソなんじゃないのか！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			だましたじゃない！<end_line>
-			ケガしたっていうのも<end_line>
-			どうせウソなんでしょ！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You cheated us!<end_line>
     Saying you were injured was<end_line>
     a lie too, wasn't it!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			だましたじゃない！<end_line>
+			ケガしたっていうのも<end_line>
+			どうせウソなんでしょ！？<end_line>
+		</sjis>
+    <ascii>
+    You cheated us!<end_line>
+    Saying you were injured was<end_line>
+    a lie too, wasn't it!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="nobox">
@@ -531,7 +540,7 @@
 		う<three_dots><end_line>
 		少し言い過ぎたかな<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ugh<three_dots><end_line>
 		Did I go too far<three_dots>?<end_line>
 	</ascii>
@@ -546,7 +555,7 @@
 		ダマシタト　思ワレマス<end_line>
 		彼女ノ　ケガモ　ウソノ可能性ガ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		This Girl Definitely Decieved Us.<end_line>
 		The Probability Of Her Injury<end_line>
 		Also Being A Lie Is 99%.<end_line>
@@ -562,7 +571,7 @@
 		もしかして、ケガをしたというのも<end_line>
 		いつわりかもしれぬぞ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		If this isn't deception, what is?<end_line>
 		I wouldn't doubt that her<end_line>
 		injury was a lie as well.<end_line>
@@ -578,7 +587,7 @@
 		ケガをしたと言っていたのも<end_line>
 		ウソかもしれんぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		She definitely tricked us.<end_line>
     I'm sure she lied about<end_line>
     being injured as well.<end_line>
@@ -594,7 +603,7 @@
 		たしかにあの子は<end_line>
 		私たちをダマしました！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     You're in the right!<end_line>
 		She definitely decieved us!<end_line>
 	</ascii>
@@ -608,7 +617,7 @@
 		もしかして、ケガしたというのも<end_line>
 		ウソかもしれませんよ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		And it's possible that<end_line>
 		her injury was a lie as well<three_dots><end_line>
 	</ascii>
@@ -621,7 +630,7 @@
 		そんな、ウソツキだなんて<three_dots><end_line>
 		ひどい！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I'm not a liar<three_dots>!<end_line>
 		You're the worst!<end_line>
 	</ascii>
@@ -633,7 +642,7 @@
 		あ、これ！<end_line>
 		ティエ！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Tier!?<end_line>
     Wait!<end_line>
 	</ascii>
@@ -645,7 +654,7 @@
 		あ～あ<three_dots><end_line>
 		何やってんだい、アンタ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     There she goes<three_dots><end_line>
     Are you an idiot?<end_line>
 	</ascii>
@@ -655,21 +664,25 @@
 	<portrait_l entry="vee" eye="sad" mouth="neutral">
 	<portrait_r entry="player" eye="surprised" mouth="stressed">
 	<male>
-		<sjis>
+    <sjis>
 			ええっ！？<end_line>
 			オレのせいなの！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なんでっ！？<end_line>
-			わたしのせいなの！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Huh!?<end_line>
     How is this my fault!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なんでっ！？<end_line>
+			わたしのせいなの！？<end_line>
+		</sjis>
+    <ascii>
+    Huh!?<end_line>
+    How is this my fault!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -680,7 +693,7 @@
 		あの子ったら<three_dots><end_line>
 		とにかく連れ戻してきますよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I'm very sorry<three_dots><end_line>
     She can be a handful<three_dots><end_line>
     I'll go find her.<end_line>
@@ -694,7 +707,7 @@
 		ちょっと<end_line>
 		お店はどうするのさ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Wait, what about the inn?<end_line>
 	</ascii>
 </dialogue>
@@ -707,7 +720,7 @@
 		主人が帰ってくるまで<end_line>
 		店番してもらえます？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Well<three_dots><end_line>
 		Could you tend the inn for me<end_line>
 		until my husband returns?<end_line>
@@ -720,7 +733,7 @@
 	<sjis>
 		イヤ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No way.<end_line>
 	</ascii>
 </dialogue>
@@ -730,7 +743,7 @@
 	<sjis>
 		即答かよ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		She didn't even consider it<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -743,7 +756,7 @@
 		<player_nickname>のせいだし<end_line>
 		アタシらがさがしに行くよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		In any case, it's <player_nickname>'s fault,<end_line>
 		so we'll go look for her ourselves.<end_line>
 	</ascii>
@@ -755,7 +768,7 @@
 	<sjis>
 		ちょっとまってよ！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Wait a second here!<end_line>
 	</ascii>
 </dialogue>
@@ -768,7 +781,7 @@
 		危なくなってきたからな<end_line>
 		たしかにさがしに行った方がいいぜ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     There are more Strays than usual.<end_line>
     It would be safer for<end_line>
     us to search together.<end_line>
@@ -782,7 +795,7 @@
 		すみません<three_dots><end_line>
 		あの<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'm sorry<three_dots><end_line>
 		Um<three_dots>Your name<three_dots>?<end_line>
 	</ascii>
@@ -796,7 +809,7 @@
 		こっちは<player_name>と<partner><end_line>
 		で、あいつはジェイド<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		I'm Vee. Those two are <end_line>
     <player_name> and <partner>.<end_line>
 		And he's Jade.<end_line>
@@ -811,7 +824,7 @@
 		奥に工房がありますから<end_line>
 		自由にお使いください<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Nice to meet you all.<end_line>
     Please feel free to use our<end_line>
     workshop if you need to.<end_line>
@@ -826,7 +839,7 @@
 		ついでにミューノを<end_line>
 		お願いできるかい？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Thanks.<end_line>
 		By the way, can you take<end_line>
 		care of Murno for us?<end_line>
@@ -839,7 +852,7 @@
 	<sjis>
 		え？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Eh?<end_line>
 	</ascii>
 </dialogue>
@@ -850,7 +863,7 @@
 	<sjis>
 		外は危ないってさ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's dangerous outside.<end_line>
 	</ascii>
 </dialogue>
@@ -862,7 +875,7 @@
 		<three_dots><end_line>
 		はい<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 		Okay<three_dots><end_line>
 	</ascii>
@@ -876,7 +889,7 @@
 		すみませんが、娘を<end_line>
 		おねがいします<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yes, that will be fine.<end_line>
     I apologize once again.<end_line>
     I'll leave my daughter to you.<end_line>
@@ -890,7 +903,7 @@
 		よっしゃ<end_line>
 		じゃ、近所をさがすか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Okay.<end_line>
 		C'mon, let's have a look around.<end_line>
 	</ascii>
@@ -902,7 +915,7 @@
 		あ<end_line>
 		ちょっと<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey<three_dots><end_line>
     Wait<three_dots><end_line>
 	</ascii>
@@ -913,7 +926,7 @@
 	<sjis>
 		うぅ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ugh<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -925,7 +938,7 @@
 	<sjis>
 		ドウシタノデスカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Is There A Problem?<end_line>
 	</ascii>
 </dialogue>
@@ -938,7 +951,7 @@
 		ん？<end_line>
 		どうしたのじゃ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hm?<end_line>
 		What's the problem?<end_line>
 	</ascii>
@@ -952,7 +965,7 @@
 		ん？<end_line>
 		何してる？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What's wrong now?<end_line>
 	</ascii>
 </dialogue>
@@ -965,7 +978,7 @@
 		ん？<end_line>
 		どうかしました？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hm? What's wrong?<end_line>
 	</ascii>
 </dialogue>
@@ -974,21 +987,25 @@
 	<portrait_l entry="player" eye="happy" mouth="yell">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			オレのせいってのが<end_line>
 			ナットクいかない！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしのせいってのが<end_line>
-			ナットクできない！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I still don't get it!<end_line>
     How is any of this is my fault!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしのせいってのが<end_line>
+			ナットクできない！<end_line>
+		</sjis>
+    <ascii>
+    I still don't get it!<end_line>
+    How is any of this is my fault!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -998,7 +1015,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1011,7 +1028,7 @@
 		はあ<three_dots><end_line>
 		しかたないのか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hah<three_dots><end_line>
 		Forget it<three_dots><end_line>
 	</ascii>
@@ -1024,7 +1041,7 @@
 	<sjis>
 		人生とはそんなものじゃ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That is the way of things.<end_line>
 	</ascii>
 </dialogue>
@@ -1036,7 +1053,7 @@
 	<sjis>
 		つらいね<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Life is not always fair<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1048,7 +1065,7 @@
 	<sjis>
 		くだらない<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It doesn't matter.<end_line>
 	</ascii>
 </dialogue>
@@ -1058,18 +1075,21 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     It does to me<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ<end_line>
+		</sjis>
+    <ascii>
+    It does to me<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1080,7 +1100,7 @@
 		まあまあ<end_line>
 		元気出しましょうよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Come on now.<end_line>
     Let's find her and be done with it.<end_line>
 	</ascii>
@@ -1093,7 +1113,7 @@
 	<sjis>
 		うん<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1105,7 +1125,7 @@
 		がんばってね<end_line>
 		<player_nickname><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Good luck out there.<end_line>
 	</ascii>
 </dialogue>
@@ -1117,7 +1137,7 @@
 		うん<end_line>
 		じゃあ、行ってくる<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Thanks.<end_line>
 		We're off then.<end_line>
 	</ascii>

--- a/Day 03/044_25142012_17fa2fc.xml
+++ b/Day 03/044_25142012_17fa2fc.xml
@@ -4,7 +4,7 @@
 	<sjis>
 		あ<three_dots>、いた！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah, there she is!<end_line>
 	</ascii>
 </dialogue>
@@ -12,18 +12,21 @@
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			けど、何やってんだ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			けど、何やってるんだろ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What's she up to this time?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			けど、何やってるんだろ？<end_line>
+		</sjis>
+    <ascii>
+    What's she up to this time?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -32,7 +35,7 @@
 	<sjis>
 		アノ人物ハ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Those People<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -44,7 +47,7 @@
 		あやつら<three_dots><end_line>
 		ここまで<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Those scoundrels<three_dots><end_line>
 		Why are they here<three_dots><end_line>
 	</ascii>
@@ -58,7 +61,7 @@
 		ちっ<three_dots><end_line>
 		クズどもめ<three_dots>、ここまで<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		They're<three_dots><end_line>
 		Tch<three_dots><end_line>
 		Damn trash<three_dots><end_line>
@@ -72,7 +75,7 @@
 		あの人たちは<three_dots><end_line>
 		ここまで来ているなんて<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Those people are<three_dots><end_line>
 		Why are they here<three_dots>?<end_line>
 	</ascii>
@@ -85,7 +88,7 @@
 		ああ<three_dots><end_line>
 		あなたたち<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh<three_dots><end_line>
 		It's you two<three_dots><end_line>
 	</ascii>
@@ -95,21 +98,25 @@
 	<portrait_l entry="player" eye="serious" mouth="serious">
 	<portrait_r entry="tier" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なにやってんだよ？<end_line>
 			また呼び込みか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なにやってるの？<end_line>
-			また呼び込み？<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		What are you up to?<end_line>
 		Looking for more customers?<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			なにやってるの？<end_line>
+			また呼び込み？<end_line>
+		</sjis>
+    <ascii>
+		What are you up to?<end_line>
+		Looking for more customers?<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -119,7 +126,7 @@
 		ん、知り合いか？<end_line>
 		召喚獣づれか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You know each other?<end_line>
 		Have a Summon Beast too, huh<three_dots><end_line>
 	</ascii>
@@ -131,7 +138,7 @@
 	<sjis>
 		まてよ、あいつ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Wait a second<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -143,7 +150,7 @@
 	<sjis>
 		ロレイラルの召喚獣だぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's a Loreilan Summon Beast<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -155,7 +162,7 @@
 	<sjis>
 		シルターンの召喚獣だぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's a Silturnian Summon Beast<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -167,7 +174,7 @@
 	<sjis>
 		サプレスの召喚獣だぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's a Sapurethan Summon Beast<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -179,7 +186,7 @@
 	<sjis>
 		メイトルパの召喚獣だぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's a Maetropan Summon Beast<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -190,7 +197,7 @@
 	<sjis>
 		まさか、さっき言ってたのって<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Maybe this is it<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -203,7 +210,7 @@
 		とにかく宿に<end_line>
 		行きましょうよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now, now, guys.<end_line>
 		Why don't we all<end_line>
 		go back to the inn?<end_line>
@@ -219,7 +226,7 @@
 		全然ちがうじゃないか<end_line>
 		コイツ、４つ足だぞ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No way.<end_line>
 		It's completely different.<end_line>
 		This one has 4 feet.<end_line>
@@ -234,7 +241,7 @@
 	<sjis>
 		しかもつれてるの男だし！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		And it's with a guy!<end_line>
 	</ascii>
 </dialogue>
@@ -248,7 +255,7 @@
 		全然ちがうじゃないか<end_line>
 		コイツ、ネコだぞ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No way.<end_line>
 		It's completely different.<end_line>
 		This one's a cat.<end_line>
@@ -263,7 +270,7 @@
 	<sjis>
 		しかもつれてるの男だし！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		And it's with a guy!<end_line>
 	</ascii>
 </dialogue>
@@ -277,7 +284,7 @@
 		全然ちがうじゃないか<end_line>
 		コイツ、子供だぞ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No way.<end_line>
 		It's completely different.<end_line>
 		This one's a kid, you know?<end_line>
@@ -292,7 +299,7 @@
 	<sjis>
 		しかもつれてるの男だし！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		And it's with a guy!<end_line>
 	</ascii>
 </dialogue>
@@ -306,7 +313,7 @@
 		アタマはバクハツしてないが<end_line>
 		たしかににているな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hmm<three_dots><end_line>
 		Their hair isn't as spiky,<end_line>
 		but they do look similar<three_dots><end_line>
@@ -321,7 +328,7 @@
 	<sjis>
 		しかしつれてるのは、男だぞ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But the person with em's a guy!<end_line>
 	</ascii>
 </dialogue>
@@ -335,7 +342,7 @@
 		しかし、つれている子供が<end_line>
 		全然ちがう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Her partner's totally<end_line>
 		different though!<end_line>
 	</ascii>
@@ -349,7 +356,7 @@
 		もうお前に用はない<end_line>
 		行くぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We have no business with you now.<end_line>
 		We're leaving.<end_line>
 	</ascii>
@@ -362,7 +369,7 @@
 		大丈夫ですって<end_line>
 		とにかく宿に<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No<three_dots>!<end_line>
 		Come on!<end_line>
 		Let's just go the inn and<three_dots><end_line>
@@ -376,7 +383,7 @@
 		うるさい！<end_line>
 		はなせ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Shut it!<end_line>
 		I said we're leaving!<end_line>
 	</ascii>
@@ -388,7 +395,7 @@
 	<sjis>
 		そんなこと言わないで<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Don't say that<three_dots>!<end_line>
 	</ascii>
 </dialogue>
@@ -399,7 +406,7 @@
 		あーあー<three_dots><end_line>
 		またもめてるよ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I gotta give her credit,<end_line>
 		she's persistent<three_dots><end_line>
 	</ascii>
@@ -414,7 +421,7 @@
 		みゅーの様ニ　近ヅケテハ<end_line>
 		ナリマセン<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		They Are The Enemy.<end_line>
 		They Cannot Be Allowed<end_line>
 		Near Lady Murno.<end_line>
@@ -429,7 +436,7 @@
 		敵って<three_dots><end_line>
 		な、なにを<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The enemy<three_dots>?<end_line>
 		W-What are you talking about?<end_line>
 	</ascii>
@@ -442,7 +449,7 @@
 	<sjis>
 		戦イマショウ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We Must Fight Them.<end_line>
 	</ascii>
 </dialogue>
@@ -456,7 +463,7 @@
 		ミューノのところに<end_line>
 		近づけてはならん！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		They're the enemy!<end_line>
 		We can't let them<end_line>
 		get close to Murno, or<three_dots>!<end_line>
@@ -471,7 +478,7 @@
 		敵って<three_dots><end_line>
 		な、なにを<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The enemy<three_dots>?<end_line>
 		W-What are you talking about?<end_line>
 	</ascii>
@@ -484,7 +491,7 @@
 	<sjis>
 		むろん、戦うのみじゃ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It doesn't matter, we must fight!<end_line>
 	</ascii>
 </dialogue>
@@ -498,7 +505,7 @@
 		宿に近づけるわけには<end_line>
 		いかん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		They're the enemy<three_dots><end_line>
 		We can't let them<end_line>
 		get near Murno<three_dots><end_line>
@@ -513,7 +520,7 @@
 		敵って<three_dots><end_line>
 		な、なにを<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The enemy<three_dots>?<end_line>
 		W-What are you talking about?<end_line>
 	</ascii>
@@ -527,7 +534,7 @@
 		決まっている<end_line>
 		戦うんだ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Obviously, we fight!<end_line>
 	</ascii>
 </dialogue>
@@ -541,7 +548,7 @@
 		ミューノ様に近づけるわけには<end_line>
 		いきませんわ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Those people are enemies!<end_line>
 		We can't let them get close<end_line>
 		to Lady Murno!<end_line>
@@ -556,7 +563,7 @@
 		敵って<three_dots><end_line>
 		な、なにを<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The enemy<three_dots>?<end_line>
 		W-What are you talking about?<end_line>
 	</ascii>
@@ -570,7 +577,7 @@
 		もちろん<end_line>
 		戦います！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Fighting them, of course!<end_line>
 	</ascii>
 </dialogue>
@@ -581,7 +588,7 @@
 	<sjis>
 		た、戦うって<three_dots>！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Fight them<three_dots>!?<end_line>
 	</ascii>
 </dialogue>
@@ -592,7 +599,7 @@
 		ええい<three_dots><end_line>
 		いいかげんにしろ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ugh<three_dots>!?<end_line>
 		Knock it off already!<end_line>
 	</ascii>
@@ -604,7 +611,7 @@
 	<sjis>
 		きゃっ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Kya!<end_line>
 	</ascii>
 </dialogue>
@@ -616,7 +623,7 @@
 		いくら子供でも<end_line>
 		痛い目を見るぞ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Stop getting in our way!<end_line>
 		You're this close<end_line>
 		to getting a beating!<end_line>
@@ -628,7 +635,7 @@
 	<sjis>
 		あ、ティエ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Tier!<end_line>
 	</ascii>
 </dialogue>
@@ -640,7 +647,7 @@
 	<sjis>
 		しすてむヲ　戦闘もーどニ　移行<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Entering Combat Mode.<end_line>
 	</ascii>
 </dialogue>
@@ -652,7 +659,7 @@
 	<sjis>
 		行くぞ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's go!<end_line>
 	</ascii>
 </dialogue>
@@ -664,7 +671,7 @@
 	<sjis>
 		行くぞ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's do this!<end_line>
 	</ascii>
 </dialogue>
@@ -676,7 +683,7 @@
 	<sjis>
 		行きますよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's go!<end_line>
 	</ascii>
 </dialogue>
@@ -687,7 +694,7 @@
 	<sjis>
 		<partner><three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<partner><three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -696,88 +703,91 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="yell">
 	<male>
-		<option>
-			<sjis>
+    <option>
+      <sjis>
 				わかった！　戦おう<end_line>
 			</sjis>
-			<ascii>
+      <ascii>
 				I'm with you!<end_line>
 			</ascii>
-		</option>
-		<option>
-			<sjis>
+    </option>
+    <option>
+      <sjis>
 				ちょっと待て！<end_line>
 			</sjis>
-			<ascii>
+      <ascii>
 				Wait a second!<end_line>
 			</ascii>
-		</option>
-	</male>
-	<female>
-		<option>
-			<sjis>
+    </option>
+  </male>
+  <female>
+    <option>
+      <sjis>
 				わかった！　戦おう<end_line>
 			</sjis>
-			<ascii>
+      <ascii>
 				I'm with you!<end_line>
 			</ascii>
-		</option>
-		<option>
-			<sjis>
+    </option>
+    <option>
+      <sjis>
 				ちょっと待って！<end_line>
 			</sjis>
-			<ascii>
+      <ascii>
 				Wait a second!<end_line>
 			</ascii>
-		</option>
-	</female>
+    </option>
+  </female>
 </choice>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			こうなったら<three_dots><end_line>
 			仕方ないか！<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Guess I have no choice!<end_line>
 		</ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			わかった！<end_line>
 			もうだまって見てられないよね！<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Alright!<end_line>
 			I can't just stand and watch!<end_line>
 		</ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="nobox">
 	<male>
-		<sjis>
+    <sjis>
 			でも、オレ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも、わたし<three_dots><end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		But, what<three_dots><end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			でも、わたし<three_dots><end_line>
+		</sjis>
+    <ascii>
+		But, what<three_dots><end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="nobox">
 	<sjis>
 		どうすれば<three_dots>！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What should I do<three_dots>!?<end_line>
 	</ascii>
 </dialogue>
@@ -789,7 +799,7 @@
 		私ガ　敵ヲ　排除シマス！<end_line>
 		アナタハ　さぽーとヲ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I Will Eliminate The Enemy!<end_line>
 		Provide Support.<end_line>
 	</ascii>
@@ -802,7 +812,7 @@
 		おそい！<end_line>
 		先にいくぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You're too indecisive!<end_line>
 		I'm going on ahead!<end_line>
 	</ascii>
@@ -816,7 +826,7 @@
 		もういい<three_dots><end_line>
 		キサマはそこで見ていろ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		How should I know!<end_line>
 		Enough<three_dots><end_line>
 		Just don't get in my way!<end_line>
@@ -829,7 +839,7 @@
 	<sjis>
 		では、私におまかせを！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Just leave it to me!<end_line>
 	</ascii>
 </dialogue>
@@ -840,7 +850,7 @@
 		あ！<end_line>
 		もう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah!<end_line>
 		Jeez! Fine!<end_line>
 	</ascii>

--- a/Day 03/045_25144972_17fae8c.xml
+++ b/Day 03/045_25144972_17fae8c.xml
@@ -6,7 +6,7 @@
 		なんなんだ、こいつら<three_dots><end_line>
 		強いぞ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What's with these kids<three_dots><end_line>
     How are they so strong?<end_line>
 	</ascii>
@@ -19,7 +19,7 @@
 		ちっ<three_dots>！<end_line>
 		どうする？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Tch<three_dots>!<end_line>
 		What do we do now?<end_line>
 	</ascii>
@@ -33,7 +33,7 @@
 		こいつら、例の子供じゃないんだ<end_line>
 		行くぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Forget 'em, let's go.<end_line>
 		They're not who<end_line>
     we're looking for.<end_line>
@@ -46,7 +46,7 @@
 		あ、待って！<end_line>
 		せめて食事だけでも<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah, wait!<end_line>
 		At least buy some food<three_dots><end_line>
 	</ascii>
@@ -60,7 +60,7 @@
 		どうしてくれるのよ<end_line>
 		本日３件目のお客が<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Sigh<three_dots><end_line>
     That's the third one<end_line>
     to get away today<three_dots><end_line>
@@ -71,24 +71,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="tier" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なに言ってンだよ！？<end_line>
 			本気であいつらとやりあうつもり<end_line>
 			だったのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なに言ってるのよ！？<end_line>
-			本気であいつらとやりあうつもり<end_line>
-			だったの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Are you kidding me!?<end_line>
     You were actually planning on<end_line>
     keeping that charade going?!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なに言ってるのよ！？<end_line>
+			本気であいつらとやりあうつもり<end_line>
+			だったの？<end_line>
+		</sjis>
+    <ascii>
+    Are you kidding me!?<end_line>
+    You were actually planning on<end_line>
+    keeping that charade going?!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -98,7 +103,7 @@
 		それは、もちろん<three_dots><end_line>
 		<three_dots>って、もしかして<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Well obviously<three_dots><end_line>
 		<three_dots>Oh, wait<three_dots><end_line>
 	</ascii>
@@ -112,7 +117,7 @@
 		わたしを守るために<end_line>
 		戦ってくれたの？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Were you<three_dots><end_line>
     Trying to protect me?<end_line>
 	</ascii>
@@ -125,7 +130,7 @@
 		あ、いや、その<three_dots><end_line>
 		実は<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah, well<three_dots><end_line>
 		I was just<three_dots><end_line>
 	</ascii>
@@ -138,7 +143,7 @@
 		ありがとう<end_line>
 		えーと、<player_nickname>だっけ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Thanks, um<three_dots><end_line>
 		<player_nickname>, right<three_dots>?<end_line>
 	</ascii>
@@ -152,7 +157,7 @@
 		ホントは<player_name>っていうんだ<end_line>
 		コッチは<partner><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah.<end_line>
 		My full name is <player_name>.<end_line>
 		And this is <partner>.<end_line>
@@ -166,7 +171,7 @@
 		そういえば<three_dots><end_line>
 		あなたたち、鍛冶師だったわね？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That reminds me<three_dots><end_line>
 		You two are Craftknights, right?<end_line>
 	</ascii>
@@ -178,7 +183,7 @@
 	<sjis>
 		そうだけど？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah, why?<end_line>
 	</ascii>
 </dialogue>
@@ -189,7 +194,7 @@
 		（いける<three_dots>！？<end_line>
 		　コレはいけるかも<three_dots>！）<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		(I just got a great idea<three_dots><end_line>
      This could really work!)<end_line>
 	</ascii>
@@ -203,7 +208,7 @@
 		鍛冶師として<end_line>
 		ウチの宿で働かない？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey, how would you like<end_line>
 		to work at our inn,<end_line>
 		as our personal Craftknights?<end_line>
@@ -216,7 +221,7 @@
 	<sjis>
 		は！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh!?<end_line>
 	</ascii>
 </dialogue>
@@ -229,7 +234,7 @@
 		不思議な力を持つ、って<end_line>
 		聞いたことがあるの<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I've heard that weapons created<end_line>
 		with the help of Summon Beasts<end_line>
 		are especially powerful.<end_line>
@@ -243,7 +248,7 @@
 		たしかに<end_line>
 		そんな感じだけど<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah, I guess they are<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -256,7 +261,7 @@
 		特別な武器じゃない！<end_line>
 		絶対ウチの名物になるわ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     The weapons you craft<end_line>
     must be awesome then!<end_line>
 		They'd become a specialty here!<end_line>
@@ -270,7 +275,7 @@
 		武器の修理をたのみにくるお客さんも<end_line>
 		今よりずっとふえるはずよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     And we'd have more customers<end_line>
     coming for repair jobs too!<end_line>
 	</ascii>
@@ -282,7 +287,7 @@
 	<sjis>
 		え！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Uhh<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -294,7 +299,7 @@
 		おねがいよ<end_line>
 		一緒にウチの宿屋を救って！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Please!<end_line>
 		Help me save the inn!<end_line>
 	</ascii>
@@ -306,7 +311,7 @@
 	<sjis>
 		ええ～！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Whaa<three_dots>!?<end_line>
 	</ascii>
 </dialogue>
@@ -319,7 +324,7 @@
 		ね！？<end_line>
 		ね～！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     You'll do it, right?<end_line>
 		Right!?<end_line>
 		Right~!?<end_line>
@@ -333,7 +338,7 @@
 		う～ん<three_dots><end_line>
 		どうしようかな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hmm<three_dots><end_line>
 		What should I do<three_dots><end_line>
 	</ascii>
@@ -343,21 +348,21 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="tier" eye="happy" mouth="neutral">
 	<option>
-		<sjis>
+    <sjis>
 			考えてみてもいいかなぁ<three_dots><end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Maybe I should consider it<three_dots><end_line>
 		</ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			ダメ！　ゼッタイ！<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			No way!<end_line>
 		</ascii>
-	</option>
+  </option>
 </choice>
 <dialogue>
 	<partner name="run-dor">
@@ -367,7 +372,7 @@
 	<sjis>
 		私ハ、オ断リシマス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I Refuse.<end_line>
 	</ascii>
 </dialogue>
@@ -379,7 +384,7 @@
 	<sjis>
 		断る！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I refuse!<end_line>
 	</ascii>
 </dialogue>
@@ -392,7 +397,7 @@
 		ふざけるな<end_line>
 		私は絶対に手伝わんぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Don't be ridiculous.<end_line>
 		I have no interest in that.<end_line>
 	</ascii>
@@ -406,7 +411,7 @@
 		私は絶対に<end_line>
 		お断りします！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I must refuse!<end_line>
 	</ascii>
 </dialogue>
@@ -418,7 +423,7 @@
 		え～！？<end_line>
 		なんで～！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ehh~!?<end_line>
 		Whyy?!<end_line>
 	</ascii>
@@ -433,7 +438,7 @@
 		アナタノ店デ　仕事ヲスルコトデハ<end_line>
 		アリマセン<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		My Mission Is Protecting Lady Murno.<end_line>
 		Not Working At Your Inn.<end_line>
 	</ascii>
@@ -448,7 +453,7 @@
 		おぬしの店で働くことなど<end_line>
 		断じてできん！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I swore to protect Murno.<end_line>
     I cannot break an oath!<end_line>
 	</ascii>
@@ -462,7 +467,7 @@
 		どうして私がキサマの店のために<end_line>
 		働かなくてはならないのだ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     What reason do I<end_line>
     have to help you?<end_line>
 	</ascii>
@@ -477,7 +482,7 @@
 		あなたのお店で働くことでは<end_line>
 		ありませんわ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     My duty is to protect Lady Murno.<end_line>
     I will not take my duty lightly!<end_line>
 	</ascii>
@@ -487,47 +492,56 @@
 	<portrait_l entry="player" eye="serious" mouth="serious">
 	<portrait_r entry="tier" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			まあな、今は町に行かなきゃ<end_line>
 			ならないしな<end_line>
 			ここに残るなんてこと<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Well, we were just passing<end_line>
+    through to begin with<three_dots><end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			まあ、今は町に行かなきゃ<end_line>
 			ならないから<end_line>
 			ここには残れないよね<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, we were just passing<end_line>
     through to begin with<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="nobox">
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="tier" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			オレたちは町に行く途中なんだ<end_line>
 			ここで鍛冶の手伝いなんて<end_line>
 			してる場合じゃないんだよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしたちは町に行く途中なの<end_line>
-			ここで鍛冶の手伝いなんて<end_line>
-			してる場合じゃないんだから<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We're just passing through.<end_line>
     I don't have time to<end_line>
     stick around right now.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしたちは町に行く途中なの<end_line>
+			ここで鍛冶の手伝いなんて<end_line>
+			してる場合じゃないんだから<end_line>
+		</sjis>
+    <ascii>
+    We're just passing through.<end_line>
+    I don't have time to<end_line>
+    stick around right now.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -537,7 +551,7 @@
 		ようするに<end_line>
 		今はだめってことね？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		In other words,<end_line>
 		you can some other time?<end_line>
 	</ascii>
@@ -549,7 +563,7 @@
 	<sjis>
 		今は、って<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's not what I-<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -562,7 +576,7 @@
 		いいわ<three_dots>絶対わたしが<end_line>
 		その気にさせてみせるんだから！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Heh heh heh<three_dots><end_line>
     Resist while you can.<end_line>
 		I'll make you come around!<end_line>
@@ -573,18 +587,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="stressed">
 	<portrait_r entry="tier" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ちょっと、待てよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			え！？　ちょっと、どういう事！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Huh? Hey, wait!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			え！？　ちょっと、どういう事！？<end_line>
+		</sjis>
+    <ascii>
+    Huh? Hey, wait!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -594,7 +611,7 @@
 		そうと決まったら<end_line>
 		お母さんたちにしらせなきゃ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     It's decided then!<end_line>
 		I have to go tell mom and dad!<end_line>
 	</ascii>
@@ -605,7 +622,7 @@
 	<sjis>
 		行っちゃったよ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     What just happened<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -617,7 +634,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -629,7 +646,7 @@
 	<sjis>
 		なんて娘じゃ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What an odd girl<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -641,7 +658,7 @@
 	<sjis>
 		なんてニンゲンだ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What a weirdo<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -653,7 +670,7 @@
 	<sjis>
 		大変な女の子ですね<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		She's quite troublesome<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -662,24 +679,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			<partner><three_dots><end_line>
 			あの<three_dots>さっきの男たちって何？<end_line>
 			ミューノは一体<three_dots>？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<partner><three_dots>、あの<three_dots><end_line>
-			さっきの男の人たちって何？<end_line>
-			ミューノは一体<three_dots>？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Oh, I forgot to ask<three_dots><end_line>
     Who were those guys earlier?<end_line>
     What's their deal with Murno?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<partner><three_dots>、あの<three_dots><end_line>
+			さっきの男の人たちって何？<end_line>
+			ミューノは一体<three_dots>？<end_line>
+		</sjis>
+    <ascii>
+    Oh, I forgot to ask<three_dots><end_line>
+    Who were those guys earlier?<end_line>
+    What's their deal with Murno?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -689,7 +711,7 @@
 	<sjis>
 		教エルコトハ　デキマセン<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I Cannot Say.<end_line>
 	</ascii>
 </dialogue>
@@ -701,7 +723,7 @@
 	<sjis>
 		すまんが、何も話せん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'm sorry, but I can't say.<end_line>
 	</ascii>
 </dialogue>
@@ -713,7 +735,7 @@
 	<sjis>
 		キサマに話すことは、何もない<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Nothing you need to know.<end_line>
 	</ascii>
 </dialogue>
@@ -738,7 +760,7 @@
 	<sjis>
 		なっ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Wha<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -751,7 +773,7 @@
 		スミマセン<end_line>
 		みゅーの様トノ　約束ナノデス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I Am Sorry.<end_line>
     I Promised Lady Murno.<end_line>
 	</ascii>
@@ -766,7 +788,7 @@
 		約束なんじゃ<end_line>
 		ミューノとの、な<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I promised Murno.<end_line>
 		I swore upon this topknot<end_line>
 		I wouldn't say it anyone.<end_line>
@@ -782,7 +804,7 @@
 		させられたのだが<three_dots><end_line>
 		キサマは、やぶって欲しいか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I made a promise with Murno<three_dots><end_line>
     Want me to break it?<end_line>
 	</ascii>
@@ -796,7 +818,7 @@
 		ミューノ様との<end_line>
 		約束ですから<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     I made a promise with Murno<three_dots><end_line>
     So<three_dots><end_line>
 	</ascii>
@@ -809,7 +831,7 @@
 		約束<three_dots><end_line>
 		そっか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I see<three_dots><end_line>
 		That's fair.<end_line>
 	</ascii>
@@ -821,7 +843,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -830,18 +852,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			じゃあオレたちも<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			じゃあわたしたちも<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			じゃあわたしたちも<end_line>
+		</sjis>
+    <ascii>
+    So<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -850,7 +875,7 @@
 	<sjis>
 		みんなのとこへ戻ろうか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Shall we head back?<end_line>
 	</ascii>
 </dialogue>
@@ -862,7 +887,7 @@
 	<sjis>
 		了解デス<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Roger<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -875,7 +900,7 @@
 		承知した<three_dots><end_line>
 		<player_nickname>、すまんの<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Understood<three_dots><end_line>
 		Sorry, <player_nickname><three_dots><end_line>
 	</ascii>
@@ -888,7 +913,7 @@
 	<sjis>
 		わかった<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -902,7 +927,7 @@
 		<player_nickname>さん<three_dots><end_line>
 		ありがとうございます<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yes<three_dots><end_line>
 		<player_nickname><three_dots><end_line>
 		Thanks for understanding<three_dots><end_line>

--- a/Day 03/046_25148476_17fbc3c.xml
+++ b/Day 03/046_25148476_17fbc3c.xml
@@ -41,7 +41,7 @@
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			お前たち<three_dots><end_line>
 			なにやってんだ？<end_line>
 		</sjis>
@@ -49,9 +49,9 @@
       It's you two<three_dots><end_line>
       What are you doing?<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			ふたりしてここで<end_line>
 			なにやってるの？<end_line>
 		</sjis>
@@ -59,7 +59,7 @@
       What are you two<end_line>
       doing here?<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -263,7 +263,7 @@
 	<portrait_l entry="player" eye="sad" mouth="neutral">
 	<portrait_r entry="zakk" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そっか<three_dots><end_line>
 			そりゃ、よかったな<three_dots><end_line>
 		</sjis>
@@ -271,9 +271,9 @@
       I see<three_dots><end_line>
       That's great<three_dots><end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			そうなんだ<three_dots><end_line>
 			あはは<three_dots>よかったね<three_dots><end_line>
 		</sjis>
@@ -281,7 +281,7 @@
       I see<three_dots><end_line>
       Ahaha<three_dots> That's great<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -303,23 +303,27 @@
 	<portrait_l entry="player" eye="sad" mouth="talk">
 	<portrait_r entry="lemmy" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			ふ<three_dots><end_line>
 			メシはうまいって話だぜ<three_dots><end_line>
 			はは<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    It'd be easier if that were true<three_dots><end_line>
+    Haha<three_dots><end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			ふ<three_dots><end_line>
 			ごはんはおいしいって話だけどね<three_dots><end_line>
 			はは<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     It'd be easier if that were true<three_dots><end_line>
     Haha<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -359,21 +363,25 @@
 	<info box="left">
 	<portrait_l entry="player" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			あー<three_dots><end_line>
 			オレたちも行こうか<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			はぁ<three_dots><end_line>
-			わたしたちも行こうか<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Sigh<three_dots><end_line>
     Guess we should get going too.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			はぁ<three_dots><end_line>
+			わたしたちも行こうか<end_line>
+		</sjis>
+    <ascii>
+    Sigh<three_dots><end_line>
+    Guess we should get going too.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">

--- a/Day 03/047_25150732_17fc50c.xml
+++ b/Day 03/047_25150732_17fc50c.xml
@@ -313,15 +313,18 @@
     <sjis>
       お前、まだその話を<three_dots>！？<end_line>
     </sjis>
+    <ascii>
+    This again<three_dots>!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あなた、まだその話を<three_dots>！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This again<three_dots>!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <player gender="male">
@@ -622,15 +625,18 @@
     <sjis>
       どうしてそうなるんだよ！<end_line>
     </sjis>
+    <ascii>
+    It's not like that!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしてそうなるの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's not like that!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 03/048_25159532_17fe76c.xml
+++ b/Day 03/048_25159532_17fe76c.xml
@@ -17,6 +17,10 @@
       なんでこんなことに<end_line>
       なってるんだろ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ugh<three_dots><end_line>
+    Why is this happening to me<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -24,11 +28,11 @@
       なんでこんなことに<end_line>
       なってるのかなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ugh<three_dots><end_line>
     Why is this happening to me<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -39,6 +43,11 @@
       誰かいるのか？<end_line>
       まさか<three_dots><end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    Is someone there?<end_line>
+    Is that<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -46,12 +55,12 @@
       誰かいるの？<end_line>
       まさか<three_dots><end_line>
     </sjis>
-  </female>  
-  <ascii>
+    <ascii>
     Huh?<end_line>
     Is someone there?<end_line>
     Is that<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <menu>
   <option>

--- a/Day 03/049_25160332_17fea8c.xml
+++ b/Day 03/049_25160332_17fea8c.xml
@@ -41,17 +41,21 @@
       え<three_dots>？<end_line>
       いや、別にいいと思うけど<three_dots><end_line>
     </sjis>
+    <ascii>
+    Eh<three_dots>?<end_line>
+    I don't see why not<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え<three_dots>？<end_line>
       別にいいと思うけど<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh<three_dots>?<end_line>
     I don't see why not<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -78,6 +82,11 @@
       ミューノはオレがあんなことすると<end_line>
       本気で思ってるのかよ！<end_line>
     </sjis>
+    <ascii>
+    This again<three_dots>?<end_line>
+    Murno, do you really think<end_line>
+    I'd do something like that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -85,12 +94,12 @@
       ミューノはわたしがあんなことすると<end_line>
       本気で思ってるの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This again<three_dots>?<end_line>
     Murno, do you really think<end_line>
     I'd do something like that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 03/050_25162028_17ff12c.xml
+++ b/Day 03/050_25162028_17ff12c.xml
@@ -80,6 +80,11 @@
       気が重くって<three_dots><end_line>
       オレはどうなっちまうんだろう<three_dots><end_line>
     </sjis>
+    <ascii>
+    Sigh<three_dots><end_line>
+    There's just a lot to take in<three_dots><end_line>
+    What should I do<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -87,12 +92,12 @@
       気が重くって<three_dots><end_line>
       わたしどうなっちゃうんだろう<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sigh<three_dots><end_line>
     There's just a lot to take in<three_dots><end_line>
     What should I do<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -398,15 +403,18 @@
     <sjis>
       わかってるよ、そんなこと<end_line>
     </sjis>
+    <ascii>
+    I know that.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わかってるわよ、そんなこと<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know that.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -651,6 +659,10 @@
       オレだってどうしたらいいか<end_line>
       考えてるんだからさ<end_line>
     </sjis>
+    <ascii>
+    Don't say that<three_dots><end_line>
+    I'm taking this seriously.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -658,11 +670,11 @@
       わたしだってどうしたらいいか<end_line>
       考えてるんだから<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't say that<three_dots><end_line>
     I'm taking this seriously.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -687,15 +699,18 @@
     <sjis>
       わかってるよ、そんなこと<end_line>
     </sjis>
+    <ascii>
+    I know that.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わかってるわよ、そんなこと<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know that.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -897,17 +912,21 @@
       そっか<three_dots><end_line>
       ヒミツだったな<three_dots><end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    It's a secret, huh<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっか<three_dots><end_line>
       ヒミツだったよね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     It's a secret, huh<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -940,18 +959,23 @@
       ああ<three_dots><end_line>
       まったくどうしたらいいんだか<three_dots><end_line>
     </sjis>
+    <ascii>
+    Yeah<three_dots><end_line>
+    I have no idea what I'm<end_line>
+    supposed to do now<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん<three_dots><end_line>
       ホントにどうしたらいいんだろ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah<three_dots><end_line>
     I have no idea what I'm<end_line>
     supposed to do now<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -976,15 +1000,18 @@
     <sjis>
       そりゃあ、わかってるけど<three_dots><end_line>
     </sjis>
+    <ascii>
+    Yeah, I know that<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       それは、わかってるけど<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, I know that<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 03/051_25165100_17ffd2c.xml
+++ b/Day 03/051_25165100_17ffd2c.xml
@@ -42,6 +42,11 @@
       オレがこんなんなってるのは<end_line>
       親方のせいでもあるんだぞ！<end_line>
     </sjis>
+    <ascii>
+    What are you saying!<end_line>
+    It's your fault I'm going<end_line>
+    through all this trouble!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -49,12 +54,12 @@
       わたしがこんなんなってるのは<end_line>
       親方のせいでもあるんだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What are you saying!<end_line>
     It's your fault I'm going<end_line>
     through all this trouble!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -79,16 +84,20 @@
     <sjis>
       か、鍛冶師は関係ないだろ！？<end_line>
     </sjis>
+    <ascii>
+    W-what does being a Craftknight<end_line>
+    have to do with this!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       か、鍛冶師は関係ないでしょ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     W-what does being a Craftknight<end_line>
     have to do with this!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -271,17 +280,21 @@
       アンタもあれだけモテるんだから<end_line>
       一流になれる才能があるんだよ<end_line>
     </sjis>
+    <ascii>
+    With your popularity, you also have<end_line>
+    potential to be a great Craftknight.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       アンタもあれだけ人気なんだから<end_line>
       一流になれる才能があるんだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     With your popularity, you also have<end_line>
     potential to be a great Craftknight.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -306,6 +319,11 @@
       アタシがほれるような<end_line>
       カッコイイ男になりな！<end_line>
     </sjis>
+    <ascii>
+    So keep up with your training,<end_line>
+    and become so awesome even<end_line>
+    I would fall for you!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -313,12 +331,12 @@
       アタシがほれるような<end_line>
       カッコイイ女になりな！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So keep up with your training,<end_line>
     and become so awesome even<end_line>
     I would fall for you!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <player gender="male">

--- a/Day 03/052_25166796_18003cc.xml
+++ b/Day 03/052_25166796_18003cc.xml
@@ -43,17 +43,21 @@
       はあ<three_dots><end_line>
       そうか<three_dots><end_line>
     </sjis>
+    <ascii>
+    Oh<three_dots><end_line>
+    I see<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       はあ<three_dots><end_line>
       そっか<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh<three_dots><end_line>
     I see<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -241,17 +245,21 @@
       なんだと<three_dots>？<end_line>
       オレは真剣に悩んでたんだよ！<end_line>
     </sjis>
+    <ascii>
+    What<three_dots>?<end_line>
+    I'm taking this seriously over here!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なんですって<three_dots>？<end_line>
       わたしは真剣に悩んでるのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What<three_dots>?<end_line>
     I'm taking this seriously over here!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -288,17 +296,21 @@
       な<three_dots>、なんだよ！<end_line>
       ムカつく！<end_line>
     </sjis>
+    <ascii>
+    Wha<three_dots> What!<end_line>
+    You piss me off!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な<three_dots>、なによ、それ！<end_line>
       ムカつく！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wha<three_dots> What!<end_line>
     You piss me off!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 03/053_25168556_1800aac.xml
+++ b/Day 03/053_25168556_1800aac.xml
@@ -42,17 +42,21 @@
       なんだよ、アニキまで<end_line>
       人が真剣に悩んでるのに<end_line>
     </sjis>
+    <ascii>
+    Now you're messing with me too?<end_line>
+    I'm seriously worried over here.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、アニキまで<end_line>
       人が真剣に悩んでるのに<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Now you're messing with me too?<end_line>
     I'm seriously worried over here.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -78,17 +82,21 @@
       そんなことないだろ<end_line>
       オレはちゃんと<three_dots><end_line>
     </sjis>
+    <ascii>
+    That's not it,<end_line>
+    I'm was just<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなことないよ<end_line>
       わたしはちゃんと<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's not it,<end_line>
     I'm was just<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 03/054_25170332_180119c.xml
+++ b/Day 03/054_25170332_180119c.xml
@@ -173,17 +173,21 @@
       ええっ！？<end_line>
       どうしてそうなるんだ！？<end_line>
     </sjis>
+    <ascii>
+    Ehhh!?<end_line>
+    I just said<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ええっ！？<end_line>
       どうしてそうなるの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ehhh!?<end_line>
     I just said<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 03/24379820_17401ac.xml
+++ b/Day 03/24379820_17401ac.xml
@@ -6,7 +6,7 @@
 		親方と勝負だ<end_line>
 		しっかり準備しなきゃ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So we're having match with Master.<end_line>
 		I have to make sure I'm prepared!<end_line>
 	</ascii>
@@ -20,7 +20,7 @@
 		みゅーの様ノタメニ<end_line>
 		必ズ　親方ニ勝チマショウ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		For Lady Murno's Sake,<end_line>
 		We Will Win!<end_line>
 	</ascii>
@@ -34,7 +34,7 @@
 		はりきってるのはいいんだけど<end_line>
 		なーんか、ひっかかるなぁ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You only get excited when<end_line>
 		it involves Murno, huh<three_dots><end_line>
 	</ascii>
@@ -48,7 +48,7 @@
 		親方と勝負だ<end_line>
 		しっかり準備しなきゃ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So we're having match with Master.<end_line>
 		I have to make sure I'm prepared!.<end_line>
 	</ascii>
@@ -62,7 +62,7 @@
 		そして必ず勝つのじゃ！<end_line>
 		ミューノを守るために！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		And we must to win!<end_line>
 		For Murno!<end_line>
 	</ascii>
@@ -73,24 +73,29 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>って別に親方は<end_line>
 			ミューノになんかしようって気は<end_line>
 			ないんだから<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots>って別に親方は<end_line>
-			ミューノになんかしようって気は<end_line>
-			ないんだから<three_dots><end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		<three_dots>Hey, I'm sure Master<end_line>
 		won't make her do all<end_line>
 		that much work<three_dots><end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots>って別に親方は<end_line>
+			ミューノになんかしようって気は<end_line>
+			ないんだから<three_dots><end_line>
+		</sjis>
+    <ascii>
+		<three_dots>Hey, I'm sure Master<end_line>
+		won't make her do all<end_line>
+		that much work<three_dots><end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -102,7 +107,7 @@
 		るすばんさせようと<end_line>
 		しておるじゃろ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's you I'm worried about!<end_line>
 		You two will be together,<end_line>
 		all alone in an empty house!<end_line>
@@ -117,7 +122,7 @@
 		親方と勝負だ<end_line>
 		しっかり準備しなきゃ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So we're having match with Master.<end_line>
 		I have to make sure I'm prepared!.<end_line>
 	</ascii>
@@ -132,7 +137,7 @@
 		負けてもいいなどと<end_line>
 		少しでも考えてみろ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Of course.<end_line>
 		If you even think about losing<end_line>
 		even for a second<three_dots><end_line>
@@ -146,7 +151,7 @@
 	<sjis>
 		キサマを消すぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'll erase you.<end_line>
 	</ascii>
 </dialogue>
@@ -156,18 +161,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<portrait_r entry="partner" eye="special" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そ、そんなにるすばんがイヤなのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そ、そんなにるすばんがイヤなんだ？<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Y-you really want to go, huh?<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そ、そんなにるすばんがイヤなんだ？<end_line>
+		</sjis>
+    <ascii>
+		Y-you really want to go, huh?<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -177,7 +185,7 @@
 		親方と勝負だ<end_line>
 		しっかり準備しなきゃ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So we're having match with Master.<end_line>
 		I have to make sure I'm prepared!.<end_line>
 	</ascii>
@@ -191,7 +199,7 @@
 		ミューノ様におるすばんなんか<end_line>
 		させるわけには絶対にいきませんわ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Of course you do!<end_line>
 		We cannot have her sit here<end_line>
 		and watch the house!<end_line>
@@ -202,21 +210,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな！<end_line>
 			がんばろう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね！<end_line>
-			がんばろう！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		That's right!<end_line>
 		Let's do our best!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね！<end_line>
+			がんばろう！<end_line>
+		</sjis>
+    <ascii>
+		That's right!<end_line>
+		Let's do our best!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -227,7 +239,7 @@
 		少しかみ合ってないみたいですが<end_line>
 		勝ちたい気持ちは同じですわ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Y-yes!<end_line>
 		We're not completely in sync,<end_line>
 		but we do have the same goal!<end_line>
@@ -243,7 +255,7 @@
 		プロスバンの町に行くために<end_line>
 		準備をしなくちゃ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now then!<end_line>
 		Let's get ready for<end_line>
 		our trip to Prosban!<end_line>
@@ -259,7 +271,7 @@
 		待ッテイマスカラ<end_line>
 		急ギマショウ<end_line>
 	</sjis>
-	<ascii>	
+  <ascii>	
 		Lady Murno Is Waiting<end_line>
 		Near The Gate.<end_line>
 		We Must Hurry.<end_line>
@@ -275,7 +287,7 @@
 		早くプロスバンの町に行くための<end_line>
 		準備をしなくちゃ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Everyone is waiting at the gate.<end_line>
 		We should head over as<end_line>
 		soon as we're ready!<end_line>
@@ -291,7 +303,7 @@
 		備えあれば憂いなし！<end_line>
 		忘れるでないぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Mm.<end_line>
 		Prepare well, travel well!<end_line>
 		Don't forget anything.<end_line>
@@ -307,7 +319,7 @@
 		プロスバンの町に行くために<end_line>
 		準備をしなくちゃ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now then!<end_line>
 		Let's get ready for<end_line>
 		our trip to Prosban!<end_line>
@@ -321,7 +333,7 @@
 	<sjis>
 		もたもたするなよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hurry it up.<end_line>
 	</ascii>
 </dialogue>
@@ -331,21 +343,25 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			門のところでミューノも待ってるし<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-			門のところでミューノも待ってるし<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Right.<end_line>
 		Murno's waiting at the gate.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+			門のところでミューノも待ってるし<end_line>
+		</sjis>
+    <ascii>
+		Right.<end_line>
+		Murno's waiting at the gate.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -355,7 +371,7 @@
 	<sjis>
 		あ、あいつは関係ない！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Th-this has nothing to do with her!<end_line>
 	</ascii>
 </dialogue>
@@ -368,7 +384,7 @@
 		プロスバンの町に行くために<end_line>
 		準備をしなくちゃ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now then!<end_line>
 		Let's get ready for<end_line>
 		our trip to Prosban!<end_line>
@@ -383,7 +399,7 @@
 		待っていますわ<end_line>
 		早くしましょう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Murno is waiting for<end_line>
 		us at the gate.<end_line>
 		Let's not waste time!<end_line>
@@ -396,7 +412,7 @@
 	<sjis>
 		わかった<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Got it.<end_line>
 	</ascii>
 </dialogue>
@@ -408,7 +424,7 @@
 		町までの道は結構あるから<end_line>
 		みんな、はぐれるんじゃないよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now then, onto Prosban!<end_line>
 		The way there can be confusing.<end_line>
 		Try not to get lost, you hear?<end_line>
@@ -422,7 +438,7 @@
 		親方こそ、方向音痴なんだから<end_line>
 		ちゃんとついてきてよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'm more worried about you, Master.<end_line>
 		You have no sense of direction.<end_line>
 	</ascii>
@@ -436,7 +452,7 @@
 		勝手に迷子になられても<end_line>
 		困るからね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It'd be troublesome if you<end_line>
 		get lost like that one<end_line>
 		time during training.<end_line>
@@ -451,7 +467,7 @@
 		アレはアンタを試してたんだって！<end_line>
 		そう言ってるだろ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I-I wasn't lost!<end_line>
 		I was just testing you!<end_line>
 		Remember!?<end_line>
@@ -466,7 +482,7 @@
 		じゃあ今回はそうやって試すのは<end_line>
 		ナシだからね！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I know, I know.<end_line>
 		How about this time,<end_line>
 		you don't test me like that!<end_line>
@@ -480,7 +496,7 @@
 		へー<end_line>
 		どーしよっかなー<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hmmm.<end_line>
 		Do I, or do I not<three_dots><end_line>
 	</ascii>
@@ -493,7 +509,7 @@
 		なんだかちょっと<end_line>
 		心配になってきたわ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now I'm worried<end_line>
 		about both of them<three_dots><end_line>
 	</ascii>
@@ -507,7 +523,7 @@
 		大丈夫デス<end_line>
 		みゅーの様ハ　私ガ　守リマス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Do Not Worry.<end_line>
 		I Will Protect You.<end_line>
 	</ascii>
@@ -521,7 +537,7 @@
 		安心せい<end_line>
 		おぬしは必ずワガハイが守る<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Don't worry.<end_line>
 		I will protect you.<end_line>
 	</ascii>
@@ -535,7 +551,7 @@
 		あいつらのことは<end_line>
 		気にしない方がいい<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Those two aren't<end_line>
 		worth your attention.<end_line>
 	</ascii>
@@ -549,7 +565,7 @@
 		大丈夫ですわ<end_line>
 		ミューノ様には私がついています！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Don't worry about it.<end_line>
 		I will be by your side!<end_line>
 	</ascii>
@@ -561,7 +577,7 @@
 	<sjis>
 		とりあえず町を目指そう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Onwards to Prosban!<end_line>
 	</ascii>
 </dialogue>
@@ -574,7 +590,7 @@
 		先ホドノ道案内ハ　タノマナクテモ<end_line>
 		大丈夫ナノデスカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are You Certain Will Not<end_line>
 		Rely On The Guide?<end_line>
 	</ascii>
@@ -588,7 +604,7 @@
 		先ほどの道案内はたのまなくても<end_line>
 		良いのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are you sure you don't<end_line>
 		want to ask the guide?<end_line>
 	</ascii>
@@ -602,7 +618,7 @@
 		さっきの道案内は<end_line>
 		たのまなくていいのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You're sure you don't<end_line>
 		want to ask the guide?<end_line>
 	</ascii>
@@ -616,7 +632,7 @@
 		さっきの道案内はたのまなくても<end_line>
 		良かったですか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are you sure you don't<end_line>
 		want to ask the guide?<end_line>
 	</ascii>
@@ -628,7 +644,7 @@
 	<sjis>
 		アタシはお金は出さないよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'm not paying for it.<end_line>
 	</ascii>
 </dialogue>
@@ -640,7 +656,7 @@
 		親方はちゃんとついてきてくれるだけで<end_line>
 		いいです<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We're fine as long as Master<end_line>
 		doesn't get separated from us.<end_line>
 	</ascii>
@@ -654,7 +670,7 @@
 		そんなクチきいてタダですむと<end_line>
 		思ってンのかい？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You're so disrespectful.<end_line>
 		Keep talking like that,<end_line>
 		I dare you.<end_line>
@@ -667,7 +683,7 @@
 	<sjis>
 		け、ケンカはダメですよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		D-don't fight!<end_line>
 	</ascii>
 </dialogue>
@@ -678,7 +694,7 @@
 	<sjis>
 		ケンカ<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -691,7 +707,7 @@
 		ミューノはやさしいね！<end_line>
 		ホンっト、いい子だよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Haha<three_dots><end_line>
 		You're so kind, Murno!<end_line>
 		Really, you're a good kid.<end_line>
@@ -704,7 +720,7 @@
 	<sjis>
 		？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		?<end_line>
 	</ascii>
 </dialogue>
@@ -716,7 +732,7 @@
 		とにかく<end_line>
 		町に行かなきゃなぁ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Come on, we still<end_line>
 		need to go to Prosban.<end_line>
 	</ascii>
@@ -730,7 +746,7 @@
 		先ホドノ道案内ハ　タノマナクテモ<end_line>
 		大丈夫ナノデスカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are You Certain Will Not<end_line>
 		Rely On The Guide?<end_line>
 	</ascii>
@@ -744,7 +760,7 @@
 		先ほどの道案内はたのまなくても<end_line>
 		良いのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are you sure you don't<end_line>
 		want to ask the guide?<end_line>
 	</ascii>
@@ -758,7 +774,7 @@
 		さっきの道案内は<end_line>
 		たのまなくていいのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You're sure you don't<end_line>
 		want to ask the guide?<end_line>
 	</ascii>
@@ -772,7 +788,7 @@
 		さっきの道案内はたのまなくても<end_line>
 		良かったですか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are you sure you don't<end_line>
 		want to ask the guide?<end_line>
 	</ascii>
@@ -785,7 +801,7 @@
 		２００バームだなんて<end_line>
 		アタシは出すつもりないからね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's 200 Boam.<end_line>
 		I'm not paying for that.<end_line>
 	</ascii>
@@ -798,7 +814,7 @@
 		親方はちゃんとついてきてくれるだけで<end_line>
 		いいです<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We're fine as long as Master<end_line>
 		doesn't get separated from us.<end_line>
 	</ascii>
@@ -812,7 +828,7 @@
 		そんなクチきいてタダですむと<end_line>
 		思ってンのかい？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You're so disrespectful.<end_line>
 		Keep talking like that,<end_line>
 		I dare you.<end_line>
@@ -825,7 +841,7 @@
 	<sjis>
 		け、ケンカはダメですよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		D-don't fight!<end_line>
 	</ascii>
 </dialogue>
@@ -836,7 +852,7 @@
 	<sjis>
 		ケンカ<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -849,7 +865,7 @@
 		ミューノはやさしいね！<end_line>
 		ホンっト、いい子だよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Haha<three_dots><end_line>
 		You're so kind, Murno!<end_line>
 		Really, you're a good kid.<end_line>
@@ -862,7 +878,7 @@
 	<sjis>
 		？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		?<end_line>
 	</ascii>
 </dialogue>
@@ -873,7 +889,7 @@
 	<sjis>
 		ティエについて行こう<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's follow Tier.<end_line>
 	</ascii>
 </dialogue>
@@ -887,7 +903,7 @@
 		彼女ヲ信用シテモ<end_line>
 		イイノデショウカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 		Are You Certain<end_line>
 		We Can Trust Her?<end_line>
@@ -902,7 +918,7 @@
 		あの娘<three_dots><end_line>
 		信用しても良いのじゃろうか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That girl<three_dots><end_line>
 		Can we trust her<three_dots>?<end_line>
 	</ascii>
@@ -916,7 +932,7 @@
 		キサマ<three_dots><end_line>
 		あのニンゲンを信用しているのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That girl<three_dots><end_line>
 		Are you sure we can trust her?<end_line>
 	</ascii>
@@ -929,7 +945,7 @@
 		あの子<three_dots><end_line>
 		信用してもいいんでしょうか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That girl<three_dots><end_line>
 		Are you sure about this?<end_line>
 	</ascii>
@@ -939,24 +955,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			大丈夫だろ？<end_line>
 			自分で言っていたみたいに<end_line>
 			ただのカワイイ道案内じゃないの？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			大丈夫でしょ？<end_line>
-			自分で言っていたみたいに<end_line>
-			ただのカワイイ道案内じゃないの？<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Why not?<end_line>
 		She said she's just<end_line>
 		a guide, right?<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			大丈夫でしょ？<end_line>
+			自分で言っていたみたいに<end_line>
+			ただのカワイイ道案内じゃないの？<end_line>
+		</sjis>
+    <ascii>
+		Why not?<end_line>
+		She said she's just<end_line>
+		a guide, right?<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -966,7 +987,7 @@
 		そんなにカンタンに他人を<end_line>
 		信用するのはどうかと思うけど<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I don't think you should<end_line>
 		trust someone that easily.<end_line>
 	</ascii>
@@ -979,7 +1000,7 @@
 		え？<end_line>
 		（なんか怒ってる？）<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh?<end_line>
 		(Is she mad?)<end_line>
 	</ascii>
@@ -988,21 +1009,21 @@
 	<info box="right">
 	<portrait_r entry="vee" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いいねぇ<end_line>
 			青春だねぇ<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Ah<three_dots><end_line>
 			So young and innocent.<end_line>
 		</ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			ビミョウなお年頃だねぇ<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			I suppose she's that age now<three_dots><end_line>
 		</ascii>
-	</female>
+  </female>
 </dialogue>

--- a/Day 03/24382732_1740d0c.xml
+++ b/Day 03/24382732_1740d0c.xml
@@ -598,18 +598,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			よし、がんばるよ、オレ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん、がんばるわ、わたし！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Okay, I'll try my best!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん、がんばるわ、わたし！<end_line>
+		</sjis>
+    <ascii>
+    Okay, I'll try my best!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -714,18 +717,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Right<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -835,21 +841,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>さっきの男たちのことが<end_line>
 			気になるのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots>さっきの男の人たちのことが<end_line>
-			気になるの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots>Worried about the guys<end_line>
     we saw earlier?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots>さっきの男の人たちのことが<end_line>
+			気になるの？<end_line>
+		</sjis>
+    <ascii>
+    <three_dots>Worried about the guys<end_line>
+    we saw earlier?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -977,21 +987,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>さっきの男たちのことが<end_line>
 			気になるのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots>さっきの男の人たちのことが<end_line>
-			気になるの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots>Worried about the guys<end_line>
     we saw earlier?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots>さっきの男の人たちのことが<end_line>
+			気になるの？<end_line>
+		</sjis>
+    <ascii>
+    <three_dots>Worried about the guys<end_line>
+    we saw earlier?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1121,21 +1135,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>さっきの男たちのことが<end_line>
 			気になるのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots>さっきの男の人たちのことが<end_line>
-			気になるの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots>Worried about the guys<end_line>
     we saw earlier?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots>さっきの男の人たちのことが<end_line>
+			気になるの？<end_line>
+		</sjis>
+    <ascii>
+    <three_dots>Worried about the guys<end_line>
+    we saw earlier?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1262,21 +1280,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>さっきの男たちのことが<end_line>
 			気になるのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots>さっきの男の人たちのことが<end_line>
-			気になるの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots>Worried about the guys<end_line>
     we saw earlier?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots>さっきの男の人たちのことが<end_line>
+			気になるの？<end_line>
+		</sjis>
+    <ascii>
+    <three_dots>Worried about the guys<end_line>
+    we saw earlier?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">

--- a/Day 03/25119212_17f49ec.xml
+++ b/Day 03/25119212_17f49ec.xml
@@ -18,39 +18,42 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="tier" eye="serious" mouth="neutral">
 	<option>
-		<sjis>
+    <sjis>
 			案内を頼んでみようかな<three_dots><end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			I guess so<three_dots><end_line>
 		</ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			自力で道を切り開こう！<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			I'll find a path myself!<end_line>
 		</ascii>
-	</option>
+  </option>
 </choice>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="tier" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			じゃあ頼むぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			じゃあお願い！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright, I'm counting on you!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			じゃあお願い！<end_line>
+		</sjis>
+    <ascii>
+    Alright, I'm counting on you!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -60,7 +63,7 @@
 		それでは案内料<end_line>
 		２００バームいただきまぁす！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     That'll be 200 Boam!<end_line>
 	</ascii>
 </dialogue>
@@ -71,7 +74,7 @@
 	<sjis>
 		まいど～！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Thank you!<end_line>
 	</ascii>
 </dialogue>
@@ -83,7 +86,7 @@
 		本日早くも２件目<end_line>
 		今日はいい日だわ～<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Already the second one today<three_dots><end_line>
 		Today's a good day~<end_line>
 	</ascii>
@@ -95,7 +98,7 @@
 	<sjis>
 		２件目って？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The second one?<end_line>
 	</ascii>
 </dialogue>
@@ -108,7 +111,7 @@
 		こちらの話ですから～<end_line>
 		お気づかいなく～<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh don't mind me~<end_line>
 		Just talking to myself~<end_line>
 	</ascii>
@@ -120,7 +123,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -133,7 +136,7 @@
 		ここら辺、はぐれも多いから<end_line>
 		気をつけてくださいね～<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Alright then, please follow me.<end_line>
     Please be careful, as there<end_line>
     are many Strays around too~<end_line>
@@ -146,7 +149,7 @@
 		あれ<three_dots><end_line>
 		お金が足りない<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh<three_dots><end_line>
 		You don't have enough money<three_dots><end_line>
 	</ascii>
@@ -158,7 +161,7 @@
 		ちょっと、ひやかしなの！？<end_line>
 		ひど～い！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Are you trying to scam me!?<end_line>
 		That's ho~rri~ble~!<end_line>
 	</ascii>
@@ -169,7 +172,7 @@
 	<sjis>
 		いや、そういうつもりじゃ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No no, we're not<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -180,7 +183,7 @@
 		じゃあ、ここで待ってるから<end_line>
 		お金できたら来てね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
     Well, I'll be waiting here<end_line>
     when you do have the money.<end_line>
 	</ascii>

--- a/Day 04/001_25172812_1801b4c.xml
+++ b/Day 04/001_25172812_1801b4c.xml
@@ -88,17 +88,21 @@
       たしかにチガウけど<end_line>
       いっしょの気分なんだよ<end_line>
     </sjis>
+    <ascii>
+    I know that,<end_line>
+    but it feels about the same.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       たしかにチガウけど<end_line>
       いっしょの気分なの<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know that,<end_line>
     but it feels about the same.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -123,6 +127,11 @@
       出だしなんだから、気分だけでも<end_line>
       もりあがっていかなくちゃな！<end_line>
     </sjis>
+    <ascii>
+    <three_dots>er, sorry!<end_line>
+    We did leave the village,<end_line>
+    at least there's that!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -130,12 +139,12 @@
       出だしなんだから、気分だけでも<end_line>
       もりあがっていかなくちゃね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots>er, sorry!<end_line>
     We did leave the village,<end_line>
     at least there's that!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -159,17 +168,21 @@
       よーし！<end_line>
       今日こそプロスバンの町へ行くぞ～！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    We're making it to Prosban today~!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よーし！<end_line>
       今日こそプロスバンの町へ行くよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     We're making it to Prosban today~!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -194,15 +207,18 @@
     <sjis>
       なんだよ<end_line>
     </sjis>
+    <ascii>
+    Hey, what's that supposed to mean?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, what's that supposed to mean?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -230,17 +246,21 @@
       なんだよ<end_line>
       クサいってことか？<end_line>
     </sjis>
+    <ascii>
+    Scent?<end_line>
+    You mean it smells in here?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ<end_line>
       クサいってこと？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Scent?<end_line>
     You mean it smells in here?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -322,6 +342,11 @@
       今日こそプロスバンの町に！<end_line>
       行かなくちゃな！<end_line>
     </sjis>
+    <ascii>
+    Ah, right!<end_line>
+    We're going to Prosban today!<end_line>
+    This time for sure!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -329,12 +354,12 @@
       今日こそプロスバンの町に！<end_line>
       行かなくちゃ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, right!<end_line>
     We're going to Prosban today!<end_line>
     This time for sure!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -363,6 +388,11 @@
       オレだって旅行気分を<end_line>
       少しは味わいたいんだよ！<end_line>
     </sjis>
+    <ascii>
+    Hey,<end_line>
+    we're at an inn, this was<end_line>
+    supposed to be like a vacation!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -370,12 +400,12 @@
       わたしだって旅行気分を<end_line>
       少しは味わいたいの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey,<end_line>
     we're at an inn, this was<end_line>
     supposed to be like a vacation!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">

--- a/Day 04/003_25174924_180238c.xml
+++ b/Day 04/003_25174924_180238c.xml
@@ -35,17 +35,21 @@
       あの<three_dots><end_line>
       やっぱりついてくるんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    So uh<three_dots><end_line>
+    You're really coming too<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あの<three_dots><end_line>
       やっぱりついてくるの<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So uh<three_dots><end_line>
     You're really coming too<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -170,17 +174,21 @@
       そっちこそ迷子になるな<three_dots>って<end_line>
       なんだよ、もう<three_dots><end_line>
     </sjis>
+    <ascii>
+    You're the one who needs to<end_line>
+    worry about getting lost<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっちこそ迷子になっちゃ<three_dots>って<end_line>
       なによ、もう<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're the one who needs to<end_line>
     worry about getting lost<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -206,17 +214,21 @@
       ちょっと<three_dots><end_line>
       なに言ってるんだよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Huh<three_dots><end_line>
+    But<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちょっと<three_dots><end_line>
       なに言ってるのよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh<three_dots><end_line>
     But<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -293,15 +305,18 @@
     <sjis>
       わかったよ<end_line>
     </sjis>
+    <ascii>
+    Right.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わかったわよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Right.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 04/015_25176972_1802b8c.xml
+++ b/Day 04/015_25176972_1802b8c.xml
@@ -37,6 +37,11 @@
       迷子になってないか<end_line>
       本気で心配してたんだぜ<end_line>
     </sjis>
+    <ascii>
+    Hey<three_dots><end_line>
+    I was really worried<end_line>
+    you might get lost.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -44,12 +49,12 @@
       迷子になってないか<end_line>
       本気で心配してたんだからね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey<three_dots><end_line>
     I was really worried<end_line>
     you might get lost.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -142,15 +147,18 @@
     <sjis>
       今のなんだ？<end_line>
     </sjis>
+    <ascii>
+    What is it?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今のなに？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is it?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -361,15 +369,18 @@
     <sjis>
       なんだよ！<end_line>
     </sjis>
+    <ascii>
+    Hey!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">

--- a/Day 04/016_25179212_180344c.xml
+++ b/Day 04/016_25179212_180344c.xml
@@ -21,17 +21,21 @@
       ふう<three_dots><end_line>
       やっとついたか<three_dots><end_line>
     </sjis>
+    <ascii>
+    Phew<three_dots><end_line>
+    We're finally here<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ふう<three_dots><end_line>
       やっとついた<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Phew<three_dots><end_line>
     We're finally here<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -55,17 +59,21 @@
       なんだと<three_dots><end_line>
       ダレのせいだと思ってるんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    You know<three_dots><end_line>
+    Who's fault is that<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんな<three_dots><end_line>
       ダレのせいだと思ってるの<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You know<three_dots><end_line>
     Who's fault is that<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -135,13 +143,16 @@
     <sjis>
       いくぞ！<end_line>
     </sjis>
+    <ascii>
+    Let's go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       いくよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Let's go!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 04/017_25180780_1803a6c.xml
+++ b/Day 04/017_25180780_1803a6c.xml
@@ -729,15 +729,18 @@
     <sjis>
       じゃあ、オレは<three_dots><end_line>
     </sjis>
+    <ascii>
+    Then I'll<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       じゃあ、わたしは<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Then I'll<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -821,15 +824,18 @@
     <sjis>
       って、何が当然なんだよ！？<end_line>
     </sjis>
+    <ascii>
+    Hey, what's obvious!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       って、何が当然なのよ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, what's obvious!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -901,17 +907,21 @@
       ああ、そうか<three_dots><end_line>
       たしかにな<end_line>
     </sjis>
+    <ascii>
+    Oh, so that's it<three_dots><end_line>
+    That's true.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ああ、そっか<three_dots><end_line>
       たしかにね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, so that's it<three_dots><end_line>
     That's true.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 04/018_24402764_1745b4c.xml
+++ b/Day 04/018_24402764_1745b4c.xml
@@ -38,18 +38,23 @@
       ここがボスタフ工房の本部か<three_dots><end_line>
       今は近づかない方がいいな<end_line>
     </sjis>
+    <ascii>
+    This is Bostaph<end_line>
+    workshop's headquarters<three_dots><end_line>
+    It'd be best not to intrude.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ここがボスタフ工房の本部か<three_dots><end_line>
       今は近づかない方がいいよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This is Bostaph<end_line>
     workshop's headquarters<three_dots><end_line>
     It'd be best not to intrude.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Day 04/020_25185500_1804cdc.xml
+++ b/Day 04/020_25185500_1804cdc.xml
@@ -18,17 +18,21 @@
       ホント<end_line>
       足下に注意しろよ<end_line>
     </sjis>
+    <ascii>
+    Seriously,<end_line>
+    pay attention.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ホント<end_line>
       足下に注意しなさいよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Seriously,<end_line>
     pay attention.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -66,6 +70,11 @@
       ウチの親方が行ってるから<end_line>
       よろしくたのむな<end_line>
     </sjis>
+    <ascii>
+    Oh, that's right, my master is<end_line>
+    heading over to your place,<end_line>
+    take care of her will you?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -73,12 +82,12 @@
       ウチの親方が行ってるから<end_line>
       よろしくね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, that's right, my master is<end_line>
     heading over to your place,<end_line>
     take care of her will you?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -104,17 +113,21 @@
       まあ、色々あってさ<end_line>
       話し合いとか<three_dots><end_line>
     </sjis>
+    <ascii>
+    Well, stuff.<end_line>
+    She wants to have a meeting<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       まあ、色々あってね<end_line>
       話し合いとか<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, stuff.<end_line>
     She wants to have a meeting<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -177,6 +190,11 @@
       オレたちちょっと急いでるんだ<end_line>
       ムダ話してる時間はないんだよ<end_line>
     </sjis>
+    <ascii>
+    Ah, that's right.<end_line>
+    We're kinda busy.<end_line>
+    No time for idle conversation.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -184,12 +202,12 @@
       わたしたちちょっと急いでるんだ<end_line>
       ムダ話してる時間はないの<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, that's right.<end_line>
     We're kinda busy.<end_line>
     No time for idle conversation.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 04/024_25187020_18052cc.xml
+++ b/Day 04/024_25187020_18052cc.xml
@@ -94,13 +94,16 @@
     <sjis>
       そうそう、この奥か<three_dots><end_line>
     </sjis>
+    <ascii>
+    Right right<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そうそう、この奥ね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Right right<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 04/026_25188140_180572c.xml
+++ b/Day 04/026_25188140_180572c.xml
@@ -95,17 +95,21 @@
       なあ、<partner><end_line>
       ベルヴォレンってどんなヤツなんだ？<end_line>
     </sjis>
+    <ascii>
+    Hey, <partner>,<end_line>
+    what kind of person is Velworen?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ねえ、<partner><end_line>
       ベルヴォレンってどんなヒトなの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, <partner>,<end_line>
     what kind of person is Velworen?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 04/028_25189708_1805d4c.xml
+++ b/Day 04/028_25189708_1805d4c.xml
@@ -280,17 +280,21 @@
       どうして<three_dots><end_line>
       あんたのせいか！？<end_line>
     </sjis>
+    <ascii>
+    Why<three_dots>?<end_line>
+    What did you do!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうして<three_dots><end_line>
       あなたのせいですか！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Why<three_dots>?<end_line>
     What did you do!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -758,17 +762,21 @@
       じゃあ<end_line>
       オレたちは<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Hmm<three_dots><end_line>
+    So what do we do<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       じゃあ<end_line>
       わたしたちは<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hmm<three_dots><end_line>
     So what do we do<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 04/032_25194044_1806e3c.xml
+++ b/Day 04/032_25194044_1806e3c.xml
@@ -868,6 +868,11 @@
       わかったよ！<end_line>
       つれていけばいいんだろ！<end_line>
     </sjis>
+    <ascii>
+    Ugh<three_dots>!<end_line>
+    Alright, okay!<end_line>
+    I'll come with you!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -875,12 +880,12 @@
       わかったわよ！<end_line>
       つれていけばいいんでしょ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ugh<three_dots>!<end_line>
     Alright, okay!<end_line>
     I'll come with you!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -961,17 +966,21 @@
       なっ！<end_line>
       ニヤけてなんかないよ！<end_line>
     </sjis>
+    <ascii>
+    Wha!<end_line>
+    I wasn't!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！<end_line>
       ニヤけてなんかないわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wha!<end_line>
     I wasn't!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -1040,13 +1049,16 @@
     <sjis>
       行くぞ！<end_line>
     </sjis>
+    <ascii>
+    Let's go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       行くよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Let's go!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 04/033_25198268_1807ebc.xml
+++ b/Day 04/033_25198268_1807ebc.xml
@@ -122,17 +122,21 @@
       うえっ！？<end_line>
       ホントにそうなのか！？<end_line>
     </sjis>
+    <ascii>
+    Whaaat!?<end_line>
+    Seriously!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ええっ！？<end_line>
       ホントなの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Whaaat!?<end_line>
     Seriously!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -157,6 +161,11 @@
       オレにイロイロ言ったくせに<end_line>
       自分だってケンカしてるじゃないか<end_line>
     </sjis>
+    <ascii>
+    Master<three_dots>!<end_line>
+    After all that lecturing,<end_line>
+    she's the one picking a fight.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -164,12 +173,12 @@
       わたしにイロイロ言うくせに<end_line>
       自分だってケンカしてるじゃない<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Master<three_dots>!<end_line>
     After all that lecturing,<end_line>
     she's the one picking a fight.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -193,15 +202,18 @@
     <sjis>
       そ、そうじゃないけどさ！<end_line>
     </sjis>
+    <ascii>
+    Th-that's not what I meant!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そ、そうじゃないけど！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Th-that's not what I meant!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -311,17 +323,21 @@
       そっか<end_line>
       ありがとな<end_line>
     </sjis>
+    <ascii>
+    I see.<end_line>
+    Thanks for the warning.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そうなんだ<end_line>
       ありがとね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see.<end_line>
     Thanks for the warning.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 04/041_24411948_1747f2c.xml
+++ b/Day 04/041_24411948_1747f2c.xml
@@ -15,16 +15,20 @@
     <sjis>
       リュート岩窟はコッチじゃないぜ<end_line>
     </sjis>
+    <ascii>
+    This isn't the way<end_line>
+    to Lute Cave.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       リュート岩窟はコッチじゃないよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This isn't the way<end_line>
     to Lute Cave.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Day 04/045_25202604_1808fac.xml
+++ b/Day 04/045_25202604_1808fac.xml
@@ -71,17 +71,21 @@
       んじゃあ、とりあえず<end_line>
       奥まで行ってみるか！<end_line>
     </sjis>
+    <ascii>
+    Alright, let's have<end_line>
+    a look inside!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       じゃあ、とりあえず<end_line>
       奥まで行ってみよう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright, let's have<end_line>
     a look inside!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 04/047_25201324_1808aac.xml
+++ b/Day 04/047_25201324_1808aac.xml
@@ -16,15 +16,18 @@
     <sjis>
       どうしたんだ？<end_line>
     </sjis>
+    <ascii>
+    What is it?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is it?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 04/048_25203804_180945c.xml
+++ b/Day 04/048_25203804_180945c.xml
@@ -28,15 +28,18 @@
     <sjis>
       <three_dots>なんだよ？<end_line>
     </sjis>
+    <ascii>
+    <three_dots>What is it?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>なによ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots>What is it?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -171,6 +174,11 @@
       ボスタフ工房のヤツらかよ<three_dots><end_line>
       まさか<three_dots><end_line>
     </sjis>
+    <ascii>
+    That outfit<three_dots><end_line>
+    You must be from<end_line>
+    Bostaph's workshop<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -178,12 +186,12 @@
       ボスタフ工房の人ね<three_dots><end_line>
       まさか<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That outfit<three_dots><end_line>
     You must be from<end_line>
     Bostaph's workshop<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -209,6 +217,11 @@
       親方のゲンコツはいたかっただろ？<end_line>
       かわいそうに<end_line>
     </sjis>
+    <ascii>
+    I knew it<three_dots><end_line>
+    Master's punches hurt, don't they?<end_line>
+    I feel bad for you<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -216,12 +229,12 @@
       親方のゲンコツ、いたかったでしょ？<end_line>
       かわいそうに<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I knew it<three_dots><end_line>
     Master's punches hurt, don't they?<end_line>
     I feel bad for you<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 04/049_25205628_1809b7c.xml
+++ b/Day 04/049_25205628_1809b7c.xml
@@ -463,17 +463,21 @@
       オレが連れ出したワケじゃない<end_line>
       エリエが行きたいって言ったんだ<end_line>
     </sjis>
+    <ascii>
+    I didn't bring her with me.<end_line>
+    Elieze said she wanted to go.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしが連れ出したワケじゃないわよ<end_line>
       エリエが行きたいって言ったの<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I didn't bring her with me.<end_line>
     Elieze said she wanted to go.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -520,6 +524,11 @@
       親方はお前らンとこだし<end_line>
       ミューノは金の派閥だし<three_dots><end_line>
     </sjis>
+    <ascii>
+    I was uh, free, since Master's<end_line>
+    at your place, and Murno's<end_line>
+    at the Gold Council<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -527,12 +536,12 @@
       親方はあんたたちのところだし<end_line>
       ミューノは金の派閥だし<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I was uh, free, since Master's<end_line>
     at your place, and Murno's<end_line>
     at the Gold Council<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -672,15 +681,18 @@
     <sjis>
       なんだよ、それ？<end_line>
     </sjis>
+    <ascii>
+    What's that supposed to mean?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's that supposed to mean?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -700,15 +712,18 @@
     <sjis>
       あ、おい<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Ah, wait<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、ちょっと<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, wait<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -796,15 +811,19 @@
       よっしゃ！<end_line>
       行くか！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Let's go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉーし！<end_line>
       行こ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Let's go!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 04/050_25208748_180a7ac.xml
+++ b/Day 04/050_25208748_180a7ac.xml
@@ -119,17 +119,21 @@
       あ、こっちはオレのパートナー<end_line>
       仲間なんです！<end_line>
     </sjis>
+    <ascii>
+    Ah, this is my partner,<end_line>
+    they're on our side!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、こっちはわたしのパートナー<end_line>
       仲間なんです！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, this is my partner,<end_line>
     they're on our side!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -214,6 +218,10 @@
       　なんだ<three_dots>っ！？<end_line>
       　このアタマ<three_dots>！？）<end_line>
     </sjis>
+    <ascii>
+    (What the<three_dots>!<end_line>
+     Is he crazy<three_dots>!?)<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -221,11 +229,11 @@
       　なによ<three_dots>っ！？<end_line>
       　このアタマ<three_dots>！？）<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     (What the<three_dots>!<end_line>
      Is he crazy<three_dots>!?)<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -313,17 +321,21 @@
       ち、ちがうよ！<end_line>
       オレのパートナーだ！<end_line>
     </sjis>
+    <ascii>
+    N-no!<end_line>
+    It's my partner!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ち、ちがうわよ！<end_line>
       わたしのパートナーだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     N-no!<end_line>
     It's my partner!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -531,15 +543,18 @@
     <sjis>
       あいつ<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    This guy<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あの人<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This guy<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -573,7 +588,7 @@
       コワいはぐれだって<end_line>
       おねーちゃん<three_dots><end_line>
     </sjis>
-     <ascii>
+    <ascii>
       A scary Stray<three_dots><end_line>
       Big sis<three_dots><end_line>
     </ascii>

--- a/Day 04/051_25211724_180b34c.xml
+++ b/Day 04/051_25211724_180b34c.xml
@@ -19,17 +19,21 @@
       ああ、ティエ<end_line>
       よくここがわかったな<end_line>
     </sjis>
+    <ascii>
+    Oh, Tier.<end_line>
+    How'd you know we were here?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あっ、ティエ<end_line>
       よくここがわかったね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, Tier.<end_line>
     How'd you know we were here?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <player gender="male">
@@ -197,17 +201,21 @@
       だまって帰ったのは悪かったよ<end_line>
       でも、アニキが来いって<three_dots><end_line>
     </sjis>
+    <ascii>
+    Sorry I didn't say anything.<end_line>
+    But Bro told me to go<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ゴメン、だまって帰って<end_line>
       けど、アニキが来いって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sorry I didn't say anything.<end_line>
     But Bro told me to go<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -328,6 +336,11 @@
       この先に行きたいんだけど<end_line>
       コワイはぐれが出たらしくて<end_line>
     </sjis>
+    <ascii>
+    There's something I'm worried about.<end_line>
+    There's a Stray that's<end_line>
+    appeared further in.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -335,12 +348,12 @@
       この先に行きたいんだけど<end_line>
       コワイはぐれが出たらしくて<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There's something I'm worried about.<end_line>
     There's a Stray that's<end_line>
     appeared further in.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -454,17 +467,21 @@
       ありがとう、ティエ<end_line>
       じゃあたのんだぜ<end_line>
     </sjis>
+    <ascii>
+    Thanks, Tier.<end_line>
+    i'm counting on you.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ありがとう、ティエ<end_line>
       じゃあたのんだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Thanks, Tier.<end_line>
     i'm counting on you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -475,17 +492,21 @@
       エリエもあぶないから<end_line>
       気をつけてかえるんだぞ<end_line>
     </sjis>
+    <ascii>
+    I'll see you later then.<end_line>
+    Be careful on the way out.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       エリエもあぶないから<end_line>
       気をつけてかえるんだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'll see you later then.<end_line>
     Be careful on the way out.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 04/052_25214268_180bd3c.xml
+++ b/Day 04/052_25214268_180bd3c.xml
@@ -18,17 +18,21 @@
       なんだ？<end_line>
       今の声<three_dots><end_line>
     </sjis>
+    <ascii>
+    What was that?<end_line>
+    That voice<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに？<end_line>
       今の声<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that?<end_line>
     That voice<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 04/053_25223260_180e05c.xml
+++ b/Day 04/053_25223260_180e05c.xml
@@ -35,15 +35,18 @@
     <sjis>
       何を、言ってんだ！？<end_line>
     </sjis>
+    <ascii>
+    W-what!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに言ってんの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     W-what!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -66,17 +69,21 @@
       やめろ！<end_line>
       はぐれじゃない！<end_line>
     </sjis>
+    <ascii>
+    Stop!<end_line>
+    That isn't a Stray!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       やめて！<end_line>
       はぐれじゃないわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Stop!<end_line>
     That isn't a Stray!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -358,6 +365,11 @@
       オレは<partner>の仲間<three_dots><end_line>
       パートナーだ！<end_line>
     </sjis>
+    <ascii>
+    Owner<three_dots>? No<three_dots><end_line>
+    I'm <partner>'s equal<three_dots><end_line>
+    We're partners!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -365,12 +377,12 @@
       わたしは<partner>の仲間<three_dots><end_line>
       パートナーよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Owner<three_dots>? No<three_dots><end_line>
     I'm <partner>'s equal<three_dots><end_line>
     We're partners!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 04/054_25215148_180c0ac.xml
+++ b/Day 04/054_25215148_180c0ac.xml
@@ -117,24 +117,27 @@
 	<portrait_l entry="player" eye="surprised" mouth="stressed">
 	<portrait_r entry="pike" eye="surprised" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、コイツ！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、コイツ！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What's with him!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、コイツ！？<end_line>
+		</sjis>
+    <ascii>
+    What's with him!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
 	<portrait_r entry="guilan" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なに気色悪いこと叫んでるのよ？<end_line>
 			そこのかわいいボウヤが<end_line>
 			引いてるじゃない<end_line>
@@ -144,9 +147,9 @@
       The poor little boy is<end_line>
       scared stiff.<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			なに気色悪いこと叫んでるのよ？<end_line>
 			そこのおじょうちゃんが<end_line>
 			引いてるじゃない<end_line>
@@ -156,7 +159,7 @@
       The poor little lady is<end_line>
       scared stiff.<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -224,18 +227,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<portrait_r entry="guilan" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			あら～、ボウヤ～<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あら～、アナタ～<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Oh my~<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あら～、アナタ～<end_line>
+		</sjis>
+    <ascii>
+    Oh my~<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -351,18 +357,21 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="guilan" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そ、そうだよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そ、そうよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Th-that's right.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そ、そうよ<end_line>
+		</sjis>
+    <ascii>
+    Th-that's right.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -489,18 +498,21 @@
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			今度は女？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今度は女の人？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     A woman this time?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今度は女の人？<end_line>
+		</sjis>
+    <ascii>
+    A woman this time?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -734,21 +746,25 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="anise" eye="special" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			な<three_dots>、なんだよ<three_dots>？<end_line>
 			どうしてニラむんだ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			な<three_dots>、なによ<three_dots>？<end_line>
-			どうしてニラむの<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Wh<three_dots>, what is it<three_dots>?<end_line>
     Why are you staring<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			な<three_dots>、なによ<three_dots>？<end_line>
+			どうしてニラむの<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Wh<three_dots>, what is it<three_dots>?<end_line>
+    Why are you staring<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -1122,24 +1138,29 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			<partner><three_dots><end_line>
 			今の話、ミューノのことだよな<end_line>
 			あれ、本当なのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<partner><three_dots><end_line>
-			今の話、ミューノのことだよね<end_line>
-			本当なの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <partner><three_dots><end_line>
     He must be talking about Murno.<end_line>
     Is it true?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<partner><three_dots><end_line>
+			今の話、ミューノのことだよね<end_line>
+			本当なの？<end_line>
+		</sjis>
+    <ascii>
+    <partner><three_dots><end_line>
+    He must be talking about Murno.<end_line>
+    Is it true?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -1157,24 +1178,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			どうなんだよ！？<end_line>
 			本当にミューノのせいで<end_line>
 			はぐれがあばれてるのか！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			どうなのよ！？<end_line>
-			本当にミューノのせいで<end_line>
-			はぐれがあばれてるの！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Is it?!<end_line>
     Is it really Murno's fault<end_line>
     the Strays are out of control!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			どうなのよ！？<end_line>
+			本当にミューノのせいで<end_line>
+			はぐれがあばれてるの！？<end_line>
+		</sjis>
+    <ascii>
+    Is it?!<end_line>
+    Is it really Murno's fault<end_line>
+    the Strays are out of control!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1229,7 +1255,7 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			はぁ！？<end_line>
 			どういうことだよ、それ！？<end_line>
 		</sjis>
@@ -1237,9 +1263,9 @@
       Huh!?<end_line>
       How can you not know!?<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			なによ<three_dots><end_line>
 			どういうことなのよ、それ！？<end_line>
 		</sjis>
@@ -1247,7 +1273,7 @@
       What<three_dots><end_line>
       How can you not know!?<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1390,7 +1416,7 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			くそっ！<end_line>
 			オレはどうしたらいいんだ？<end_line>
 			親方<three_dots><end_line>
@@ -1400,9 +1426,9 @@
       What am I supposed to do?<end_line>
       Master<three_dots><end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			わたし、どうしたらいいの？<end_line>
 			親方<three_dots><end_line>
 		</sjis>
@@ -1410,5 +1436,5 @@
       What am I supposed to do?<end_line>
       Master<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>

--- a/Day 04/055_25220556_180d5cc.xml
+++ b/Day 04/055_25220556_180d5cc.xml
@@ -270,24 +270,29 @@
 <dialogue>
 	<info box="nobox">
 	<male>
-		<sjis>
+    <sjis>
 			　　　話せるわけないじゃないか　　　<end_line>
 			　　　ミューノがはぐれ召喚獣を　　　<end_line>
 			あばれさせているかもしれないなんて<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			　　　話せるわけないじゃない　　　　<end_line>
-			　　　ミューノがはぐれ召喚獣を　　　<end_line>
-			あばれさせているかもしれないなんて<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I can't just up and say,<end_line>
     Murno may have caused the<end_line>
     Strays to go berserk<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			　　　話せるわけないじゃない　　　　<end_line>
+			　　　ミューノがはぐれ召喚獣を　　　<end_line>
+			あばれさせているかもしれないなんて<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I can't just up and say,<end_line>
+    Murno may have caused the<end_line>
+    Strays to go berserk<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="nobox">

--- a/Day 04/056_25225564_180e95c.xml
+++ b/Day 04/056_25225564_180e95c.xml
@@ -7,6 +7,11 @@
       何も解決するわけないし<end_line>
       もう帰ろっかな<three_dots><end_line>
     </sjis>
+    <ascii>
+    <three_dots> Hanging around here<end_line>
+    isn't going to resolve anything.<end_line>
+    I might as well head back<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -14,12 +19,12 @@
       何も解決するわけないね<end_line>
       もう帰ろっかな<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots> Hanging around here<end_line>
     isn't going to resolve anything.<end_line>
     I might as well head back<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -30,6 +35,11 @@
       誰か来た？<end_line>
       まさか<three_dots><end_line>
     </sjis>
+    <ascii>
+    Hm?<end_line>
+    Is somewhere there?<end_line>
+    Could it be<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -37,12 +47,12 @@
       誰か来たみたい？<end_line>
       まさか<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hm?<end_line>
     Is somewhere there?<end_line>
     Could it be<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <menu>
   <option>

--- a/Day 04/057_25226364_180ec7c.xml
+++ b/Day 04/057_25226364_180ec7c.xml
@@ -48,6 +48,10 @@
       こんなとこにいて<end_line>
       大丈夫なのか？<end_line>
     </sjis>
+    <ascii>
+    Rather, is it okay<end_line>
+    for you to be here, Murno?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -55,11 +59,11 @@
       こんなとこにいて<end_line>
       大丈夫なの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Rather, is it okay<end_line>
     for you to be here, Murno?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -98,18 +102,23 @@
       なに言ってるんだよ<three_dots>！<end_line>
       本当に逃げなくて大丈夫なのか？<end_line>
     </sjis>
+    <ascii>
+    Murno<three_dots>!<end_line>
+    Are you sure you don't<end_line>
+    want to leave town?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに言ってるのよ<three_dots>！<end_line>
       本当に逃げなくて大丈夫なの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Murno<three_dots>!<end_line>
     Are you sure you don't<end_line>
     want to leave town?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -196,6 +205,11 @@
       オレの方こそゴメン<three_dots><end_line>
       ひどい言い方して<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah<three_dots><end_line>
+    No, I'm sorry<three_dots><end_line>
+    I shouldn't have said that<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -203,12 +217,12 @@
       わたしの方こそゴメン<three_dots><end_line>
       ひどい言い方して<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah<three_dots><end_line>
     No, I'm sorry<three_dots><end_line>
     I shouldn't have said that<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -234,17 +248,21 @@
       ミューノ<three_dots><end_line>
       君は一体<three_dots><end_line>
     </sjis>
+    <ascii>
+    Murno<three_dots><end_line>
+    Just what did you<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ミューノ<three_dots><end_line>
       あなたは一体<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Murno<three_dots><end_line>
     Just what did you<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 04/058_25227820_180f22c.xml
+++ b/Day 04/058_25227820_180f22c.xml
@@ -108,6 +108,11 @@
       そんなキケンなところなのに<end_line>
       どうしてミューノは逃げないんだ？<end_line>
     </sjis>
+    <ascii>
+    That's true, but<three_dots><end_line>
+    Why didn't Murno want to<end_line>
+    run away if it's so dangerous?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -115,12 +120,12 @@
       そんなキケンなところなのに<end_line>
       どうしてミューノは逃げないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's true, but<three_dots><end_line>
     Why didn't Murno want to<end_line>
     run away if it's so dangerous?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -146,6 +151,11 @@
       ま、いつもどおりヒミツ<end_line>
       なんだろうけどな<three_dots><end_line>
     </sjis>
+    <ascii>
+    If I just knew what<three_dots><end_line>
+    Well, she wants to keep it a secret,<end_line>
+    just like everything else<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -153,12 +163,12 @@
       ま、いつもどおりヒミツ<end_line>
       なんだろうけどね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     If I just knew what<three_dots><end_line>
     Well, she wants to keep it a secret,<end_line>
     just like everything else<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -182,17 +192,21 @@
       はあ<three_dots><end_line>
       わからないことだらけだな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Sigh<three_dots><end_line>
+    So many things I don't know<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       はあ<three_dots><end_line>
       わからないことだらけだよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sigh<three_dots><end_line>
     So many things I don't know<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -374,6 +388,11 @@
       でもお前だって<end_line>
       鍛冶師の約束を<three_dots><end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots><end_line>
+    Would you really break your<end_line>
+    oath as a Craftknight<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -381,12 +400,12 @@
       でもあなただって<end_line>
       鍛冶師の約束を<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots><end_line>
     Would you really break your<end_line>
     oath as a Craftknight<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -470,17 +489,21 @@
       油？<end_line>
       なんだよ、それ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Piddling?<end_line>
+    What's that mean<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       油？<end_line>
       なによ、それ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Piddling?<end_line>
     What's that mean<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -507,6 +530,11 @@
       そんなキケンなところなのに<end_line>
       どうしてミューノは逃げないんだ？<end_line>
     </sjis>
+    <ascii>
+    I know, but<three_dots><end_line>
+    Why didn't Murno want to<end_line>
+    run away if it's so dangerous?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -514,12 +542,12 @@
       そんなキケンなところなのに<end_line>
       どうしてミューノは逃げないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know, but<three_dots><end_line>
     Why didn't Murno want to<end_line>
     run away if it's so dangerous?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -547,6 +575,11 @@
       ま、いつもどおりヒミツ<end_line>
       なんだろうけどな<three_dots><end_line>
     </sjis>
+    <ascii>
+    If I just knew what<three_dots><end_line>
+    Well, she wants to keep it a secret,<end_line>
+    just like everything else<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -554,12 +587,12 @@
       ま、いつもどおりヒミツ<end_line>
       なんだろうけどね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     If I just knew what<three_dots><end_line>
     Well, she wants to keep it a secret,<end_line>
     just like everything else<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -583,17 +616,21 @@
       はあ<three_dots><end_line>
       わからないことだらけだな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Sigh<three_dots><end_line>
+    So many things I don't know<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       はあ<three_dots><end_line>
       わからないことだらけだよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sigh<three_dots><end_line>
     So many things I don't know<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -761,6 +798,11 @@
       でもお前だって<end_line>
       鍛冶師の約束を<three_dots><end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots><end_line>
+    Would you really break your<end_line>
+    oath as a Craftknight<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -768,12 +810,12 @@
       でもあなただって<end_line>
       鍛冶師の約束を<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots><end_line>
     Would you really break your<end_line>
     oath as a Craftknight<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -868,6 +910,11 @@
       そんなキケンなところなのに<end_line>
       どうしてミューノは逃げないんだ？<end_line>
     </sjis>
+    <ascii>
+    I was just wondering<three_dots><end_line>
+    Why didn't Murno want to<end_line>
+    run away if it's so dangerous?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -875,12 +922,12 @@
       そんなキケンなところなのに<end_line>
       どうしてミューノは逃げないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I was just wondering<three_dots><end_line>
     Why didn't Murno want to<end_line>
     run away if it's so dangerous?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -906,17 +953,21 @@
       ヒミツってことか<end_line>
       ま、いつも通りだけど<three_dots><end_line>
     </sjis>
+    <ascii>
+    Another secret,<end_line>
+    just like always<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ヒミツってことね<end_line>
       ま、いつも通りだけど<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Another secret,<end_line>
     just like always<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -940,17 +991,21 @@
       はあ<three_dots><end_line>
       わからないことだらけだな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Sigh<three_dots><end_line>
+    So many things I don't know<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       はあ<three_dots><end_line>
       わからないことだらけだよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sigh<three_dots><end_line>
     So many things I don't know<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1118,6 +1173,11 @@
       でも、お前だって<end_line>
       鍛冶師の約束を<three_dots><end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots><end_line>
+    Would you really break your<end_line>
+    oath as a Craftknight<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1125,12 +1185,12 @@
       でも、あなただって<end_line>
       鍛冶師の約束を<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots><end_line>
     Would you really break your<end_line>
     oath as a Craftknight<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1224,6 +1284,11 @@
       そんなキケンなところなのに<end_line>
       どうしてミューノは逃げないんだ？<end_line>
     </sjis>
+    <ascii>
+    I know, but<three_dots><end_line>
+    Why didn't Murno want to<end_line>
+    run away if it's so dangerous?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1231,12 +1296,12 @@
       そんなキケンなところなのに<end_line>
       どうしてミューノは逃げないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know, but<three_dots><end_line>
     Why didn't Murno want to<end_line>
     run away if it's so dangerous?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1262,6 +1327,11 @@
       ま、いつもどおりヒミツ<end_line>
       なんだろうけどな<three_dots><end_line>
     </sjis>
+    <ascii>
+    If I just knew what<three_dots><end_line>
+    Well, she wants to keep it a secret,<end_line>
+    just like everything else<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1269,12 +1339,12 @@
       ま、いつもどおりヒミツ<end_line>
       なんだろうけどね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     If I just knew what<three_dots><end_line>
     Well, she wants to keep it a secret,<end_line>
     just like everything else<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1296,17 +1366,21 @@
       はあ<three_dots><end_line>
       わからないことだらけだな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Sigh<three_dots><end_line>
+    So many things I don't know<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       はあ<three_dots><end_line>
       わからないことだらけだよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sigh<three_dots><end_line>
     So many things I don't know<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1483,6 +1557,11 @@
       でもお前だって<end_line>
       鍛冶師の約束を<three_dots><end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots><end_line>
+    Would you really break your<end_line>
+    oath as a Craftknight<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1490,12 +1569,12 @@
       でもあなただって<end_line>
       鍛冶師の約束を<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots><end_line>
     Would you really break your<end_line>
     oath as a Craftknight<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 04/059_25231436_181004c.xml
+++ b/Day 04/059_25231436_181004c.xml
@@ -120,21 +120,25 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="vee" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			たしかにオレにも言ってたよ<end_line>
 			はぐれ狩りをやめる気はないって<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			たしかにわたしにも言ってたよ<end_line>
-			はぐれ狩りをやめる気はないって<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     He said that to me too.<end_line>
     That he won't stop hunting Strays<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			たしかにわたしにも言ってたよ<end_line>
+			はぐれ狩りをやめる気はないって<three_dots><end_line>
+		</sjis>
+    <ascii>
+    He said that to me too.<end_line>
+    That he won't stop hunting Strays<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">

--- a/Day 04/060_25233148_18106fc.xml
+++ b/Day 04/060_25233148_18106fc.xml
@@ -30,18 +30,23 @@
       オレにもよくわからん<end_line>
       歩いてたら、なんとなく<three_dots><end_line>
     </sjis>
+    <ascii>
+    I don't really know either.<end_line>
+    I went for a walk and just<end_line>
+    kinda ended up here<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしにもよくわかんない<end_line>
       歩いてたら、なんとなく<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I don't really know either.<end_line>
     I went for a walk and just<end_line>
     kinda ended up here<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -68,6 +73,10 @@
       お前そんなこと心配して<end_line>
       こんなとこまで来たのか？<end_line>
     </sjis>
+    <ascii>
+    Hm?<end_line>
+    Were you worried about me?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -75,11 +84,11 @@
       あなたそんなこと心配して<end_line>
       こんなとこまで来たの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hm?<end_line>
     Were you worried about me?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -117,6 +126,11 @@
       じゃ、リュート岩窟にいたのも<end_line>
       見回りなのか？<end_line>
     </sjis>
+    <ascii>
+    I see<three_dots> Same as Brother.<end_line>
+    Then, do you patrol<end_line>
+    around Lute Cave too?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -124,12 +138,12 @@
       じゃ、リュート岩窟にいたのも<end_line>
       見回りなの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots> Same as Brother.<end_line>
     Then, do you patrol<end_line>
     around Lute Cave too?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -163,6 +177,11 @@
       ま、おかげでオレたちも<end_line>
       助かったわけだけど<end_line>
     </sjis>
+    <ascii>
+    I see, must be hard<three_dots><end_line>
+    Well, we got out of there okay,<end_line>
+    thanks to you.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -170,12 +189,12 @@
       ま、おかげでわたしたちも<end_line>
       助かったわけだけど<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see, must be hard<three_dots><end_line>
     Well, we got out of there okay,<end_line>
     thanks to you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -200,6 +219,11 @@
       だったらお前とは<end_line>
       また勝負することになるかもな<end_line>
     </sjis>
+    <ascii>
+    You did it for Bostaph, right<three_dots><end_line>
+    In that case, we may<end_line>
+    have to have another match.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -207,12 +231,12 @@
       だったらあんたとは<end_line>
       また勝負することになるかもね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You did it for Bostaph, right<three_dots><end_line>
     In that case, we may<end_line>
     have to have another match.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 04/062_25235980_181120c.xml
+++ b/Day 04/062_25235980_181120c.xml
@@ -155,6 +155,10 @@
       忘れたも何も<end_line>
       言ってることがメチャクチャだ！<end_line>
     </sjis>
+    <ascii>
+    Forget what?<end_line>
+    You're not making any sense!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -162,11 +166,11 @@
       言ってることが<end_line>
       メチャクチャだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Forget what?<end_line>
     You're not making any sense!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 04/24262508_172376c.xml
+++ b/Day 04/24262508_172376c.xml
@@ -34,18 +34,21 @@
 	<info box="simple">
 	<portrait_l name="unknown">
 	<male>
-		<sjis>
+    <sjis>
 			通りすがりのものです<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			通りすがりのものですわ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     one who loves the bow!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			通りすがりのものですわ！<end_line>
+		</sjis>
+    <ascii>
+    one who loves the bow!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
@@ -61,18 +64,21 @@
 	<info box="simple">
 	<portrait_l name="unknown">
 	<male>
-		<sjis>
+    <sjis>
 			弓乙女と呼びます<end_line>
-		</sjis> 
-	</male>
-	<female>
-		<sjis>
-			弓乙女と呼びますわ！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     the bow maiden!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			弓乙女と呼びますわ！<end_line>
+		</sjis>
+    <ascii>
+    the bow maiden!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
@@ -88,24 +94,27 @@
 	<info box="simple">
 	<portrait_l name="archer_girl">
 	<male>
-		<sjis>
+    <sjis>
 			弓を愛用しているご様子<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			弓を愛用のようね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     harbor a love for the bow.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			弓を愛用のようね<end_line>
+		</sjis>
+    <ascii>
+    harbor a love for the bow.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
 	<portrait_l name="archer_girl">
 	<male>
-		<sjis>
+    <sjis>
 			そんなあなたにはご褒美に<end_line>
 			こちらをさしあげますわ<end_line>
 		</sjis>
@@ -113,9 +122,9 @@
       I offer this to you<end_line>
       as a sign of our camaraderie.<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			そんなあなたには<end_line>
 			これをとらせますわ！<end_line>
 		</sjis>
@@ -123,41 +132,43 @@
       You may have this<end_line>
       as a sign of our camaraderie!<end_line>
     </ascii>
-	</female> 
+  </female>
 </dialogue>
 <popup>
-	<sjis>
-		<weapon_type>をもらった！<end_line>
-	</sjis>
+  <sjis>
+    <weapon_type>をもらった！<end_line>
+	</weapon_type>
+  </sjis>
   <ascii>
     Got <weapon_type>!<end_line>
+  </weapon_type>
   </ascii>
 </popup>
 <dialogue>
 	<info box="simple">
 	<portrait_l name="archer_girl">
 	<male>
-		<sjis>
+    <sjis>
 			これからも精進なさいませ<end_line>
 		</sjis>
     <ascii>
       Until we meet again.<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			これからも精進するがよろしくてよ！<end_line>
 		</sjis>
     <ascii>
       Until next we meet!<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
 	<portrait_l name="archer_girl">
 	<male>
-		<sjis>
+    <sjis>
 			おみごとですわ！<end_line>
 			これはごほうびです<end_line>
 		</sjis>
@@ -165,9 +176,9 @@
       Impressive!<end_line>
       Here, take this.<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			よろしくてよ！<end_line>
 			ほうびをとらせますわ！<end_line>
 		</sjis>
@@ -175,14 +186,16 @@
       Wonderful!<end_line>
       Here, accept this gift!<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <popup>
-	<sjis>
-		<weapon_type>をもらった！<end_line>
-	</sjis>
+  <sjis>
+    <weapon_type>をもらった！<end_line>
+	</weapon_type>
+  </sjis>
   <ascii>
     Got <weapon_type>!<end_line>
+  </weapon_type>
   </ascii>
 </popup>
 <dialogue>
@@ -199,18 +212,21 @@
 	<info box="simple">
 	<portrait_l name="archer_girl">
 	<male>
-		<sjis>
+    <sjis>
 			全ての的を射抜かれたようですね<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			全ての的を射抜きましたのね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You've shot all the targets.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			全ての的を射抜きましたのね<end_line>
+		</sjis>
+    <ascii>
+    You've shot all the targets.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
@@ -218,7 +234,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -240,19 +256,19 @@
 	<info box="simple">
 	<portrait_l name="archer_girl">
 	<male>
-		<sjis>
+    <sjis>
 			これからも精進なさいませ<end_line>
 		</sjis>
     <ascii>
       I expect great things from you.<end_line>
-    </ascii> 
-	</male>
-	<female>
-		<sjis>
+    </ascii>
+  </male>
+  <female>
+    <sjis>
 			これからも精進するがよろしくてよ！<end_line>
 		</sjis>
     <ascii>
       Keep it up!<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>

--- a/Day 04/24427580_174bc3c.xml
+++ b/Day 04/24427580_174bc3c.xml
@@ -9,6 +9,10 @@
       プロスバンの町に行くことに<end_line>
       なったんだよなぁ<three_dots><end_line>
     </sjis>
+    <ascii>
+    So Tier's going to<end_line>
+    come to Prosban with us<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -16,11 +20,11 @@
       プロスバンの町に行くことに<end_line>
       なっちゃったなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So Tier's going to<end_line>
     come to Prosban with us<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -71,6 +75,10 @@
       プロスバンの町に行くことに<end_line>
       なったんだよなぁ<three_dots><end_line>
     </sjis>
+    <ascii>
+    So Tier's going to<end_line>
+    come to Prosban with us<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -78,11 +86,11 @@
       プロスバンの町に行くことに<end_line>
       なっちゃったなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So Tier's going to<end_line>
     come to Prosban with us<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -109,15 +117,18 @@
     <sjis>
       わかってるよ<end_line>
     </sjis>
+    <ascii>
+    I know, I know.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       忘れないよ～<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know, I know.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -130,6 +141,10 @@
       プロスバンの町に行くことに<end_line>
       なったんだよなぁ<three_dots><end_line>
     </sjis>
+    <ascii>
+    So Tier's going to<end_line>
+    come to Prosban with us<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -137,11 +152,11 @@
       プロスバンの町に行くことに<end_line>
       なっちゃったなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So Tier's going to<end_line>
     come to Prosban with us<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -189,6 +204,10 @@
       プロスバンの町に行くことに<end_line>
       なったんだよなぁ<three_dots><end_line>
     </sjis>
+    <ascii>
+    So Tier's going to<end_line>
+    come to Prosban with us<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -196,11 +215,11 @@
       プロスバンの町に行くことに<end_line>
       なっちゃったなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So Tier's going to<end_line>
     come to Prosban with us<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -225,15 +244,18 @@
     <sjis>
       わかってるよ<end_line>
     </sjis>
+    <ascii>
+    I know, I know.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       忘れないよ～<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know, I know.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -244,6 +266,11 @@
       とにかくオレたちも<end_line>
       プロスバンの町に向かおう<end_line>
     </sjis>
+    <ascii>
+    We're following Master's directions?<end_line>
+    <three_dots>Can we make it there safely?<end_line>
+    <three_dots>We should get going.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -251,12 +278,12 @@
       プロスバンの町に向かおう<end_line>
       親方が道案内じゃ、心配だよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We're following Master's directions?<end_line>
     <three_dots>Can we make it there safely?<end_line>
     <three_dots>We should get going.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -272,7 +299,7 @@
     Hurry!<end_line>
     We Must Not Fall<end_line>
     Behind Lady Murno.<end_line>
-  </ascii>  
+  </ascii>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -340,16 +367,19 @@
       誰のせいでこんな目にあってると<end_line>
       思ってるんだ！<end_line>
     </sjis>
+    <ascii>
+    Look who's talking!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       誰のせいでこんな目にあってると<end_line>
       思ってるの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Look who's talking!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -359,17 +389,21 @@
       町の近くでなんかあったらしい<end_line>
       注意していこうぜ<end_line>
     </sjis>
+    <ascii>
+    Seems like there's a problem.<end_line>
+    We should be careful around here.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       町の近くでなんかあったらしい<end_line>
       注意していきましょ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Seems like there's a problem.<end_line>
     We should be careful around here.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -401,7 +435,7 @@
     That goes for you too!<end_line>
     The next time you speak,<end_line>
     think about Murno first!<end_line>
-  </ascii>  
+  </ascii>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -461,7 +495,7 @@
     Come on now,<end_line>
     what's done is done.<end_line>
     Let's focus on the future!<end_line>
-  </ascii> 
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -472,17 +506,21 @@
       だから誰のせいでこんな目に<end_line>
       あってると思ってるんだ！<end_line>
     </sjis>
+    <ascii>
+    Like I said,<end_line>
+    look who's talking!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       だから誰のせいでこんな目に<end_line>
       あってると思ってるの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Like I said,<end_line>
     look who's talking!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -817,6 +855,11 @@
       なんかソワソワして<end_line>
       どうした？<end_line>
     </sjis>
+    <ascii>
+    That's fine, but<three_dots><end_line>
+    You're kind of restless.<end_line>
+    Is something wrong?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -824,12 +867,12 @@
       なんかソワソワして<end_line>
       どうしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's fine, but<three_dots><end_line>
     You're kind of restless.<end_line>
     Is something wrong?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -919,7 +962,7 @@
   <ascii>
     Let's gather materials<end_line>
     at Lute Cave!<end_line>
-  </ascii>    
+  </ascii>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -1394,6 +1437,11 @@
       リュート岩窟のもっと奥を<end_line>
       目指すぞ！<end_line>
     </sjis>
+    <ascii>
+    We've come this far,<end_line>
+    we might as well<end_line>
+    explore the whole thing!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1401,12 +1449,12 @@
       リュート岩窟のもっと奥を<end_line>
       目指そう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We've come this far,<end_line>
     we might as well<end_line>
     explore the whole thing!<end_line>
-  </ascii>  
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -1456,6 +1504,11 @@
       リュート岩窟のもっと奥を<end_line>
       目指すぞ！<end_line>
     </sjis>
+    <ascii>
+    We've come this far,<end_line>
+    we might as well<end_line>
+    explore the whole thing!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1463,12 +1516,12 @@
       リュート岩窟のもっと奥を<end_line>
       目指そう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We've come this far,<end_line>
     we might as well<end_line>
     explore the whole thing!<end_line>
-  </ascii>  
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -1518,6 +1571,11 @@
       リュート岩窟のもっと奥を<end_line>
       目指すぞ！<end_line>
     </sjis>
+    <ascii>
+    We've come this far,<end_line>
+    we might as well<end_line>
+    explore the whole thing!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1525,12 +1583,12 @@
       リュート岩窟のもっと奥を<end_line>
       目指そう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We've come this far,<end_line>
     we might as well<end_line>
     explore the whole thing!<end_line>
-  </ascii>  
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1580,6 +1638,11 @@
       リュート岩窟のもっと奥を<end_line>
       目指すぞ！<end_line>
     </sjis>
+    <ascii>
+    We've come this far,<end_line>
+    we might as well<end_line>
+    explore the whole thing!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1587,12 +1650,12 @@
       リュート岩窟のもっと奥を<end_line>
       目指そう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We've come this far,<end_line>
     we might as well<end_line>
     explore the whole thing!<end_line>
-  </ascii>  
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1902,15 +1965,18 @@
     <sjis>
       わかった！<end_line>
     </sjis>
+    <ascii>
+    Got it!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わかったわ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Got it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -1934,15 +2000,18 @@
     <sjis>
       おう！<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1953,7 +2022,7 @@
   </sjis>
   <ascii>
     Don't let him get away!<end_line>
-  </ascii> 
+  </ascii>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1964,15 +2033,18 @@
     <sjis>
       おう！<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1999,7 +2071,7 @@
   <ascii>
     We can't let him get away!<end_line>
     After him!<end_line>
-  </ascii>  
+  </ascii>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -2009,15 +2081,18 @@
     <sjis>
       おう！<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -2029,7 +2104,7 @@
   </sjis>
   <ascii>
     <three_dots>Let's meet up with Master.<end_line>
-  </ascii>  
+  </ascii>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -2053,7 +2128,7 @@
   </sjis>
   <ascii>
     <partner><three_dots><end_line>
-  </ascii>  
+  </ascii>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -2077,7 +2152,7 @@
   </sjis>
   <ascii>
     <three_dots>Let's meet up with Master.<end_line>
-  </ascii>  
+  </ascii>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -2101,7 +2176,7 @@
   </sjis>
   <ascii>
     <partner><three_dots><end_line>
-  </ascii>  
+  </ascii>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -2127,7 +2202,7 @@
   </sjis>
   <ascii>
     <three_dots>Let's meet up with Master.<end_line>
-  </ascii>  
+  </ascii>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -2151,7 +2226,7 @@
   </sjis>
   <ascii>
     <partner><three_dots><end_line>
-  </ascii>  
+  </ascii>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -2174,7 +2249,7 @@
   </sjis>
   <ascii>
     <three_dots>Let's meet up with Master.<end_line>
-  </ascii>  
+  </ascii>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 05/001_25238172_1811a9c.xml
+++ b/Day 05/001_25238172_1811a9c.xml
@@ -178,6 +178,10 @@
       ここで考えていても<end_line>
       しかたないな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Right<three_dots><end_line>
+    I can't just sit here all day<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -185,9 +189,9 @@
       ここでずっと考えてても<end_line>
       しかたないよね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
     I can't just sit here all day<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 05/029_25242620_1812bfc.xml
+++ b/Day 05/029_25242620_1812bfc.xml
@@ -197,15 +197,18 @@
     <sjis>
       見込みのある男だ<end_line>
     </sjis>
+    <ascii>
+    You've got potential.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       見込みのある女の子だ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You've got potential.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -476,15 +479,18 @@
     <sjis>
       見込みのある男だ<end_line>
     </sjis>
+    <ascii>
+    You're very promising.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       見込みのある女の子だ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're very promising.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Day 05/030_25244684_181340c.xml
+++ b/Day 05/030_25244684_181340c.xml
@@ -80,16 +80,20 @@
     <sjis>
       今度は南門の方か<three_dots><end_line>
     </sjis>
+    <ascii>
+    It's coming from the<end_line>
+    southern gate this time<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今度は南門の方<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's coming from the<end_line>
     southern gate this time<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -111,17 +115,21 @@
       もしかしてまたあの連中が<end_line>
       出てくるかもしれないな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Those guys might<end_line>
+    show up again<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       もしかしてまたあの人たちが<end_line>
       出てくるかもしれないね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Those guys might<end_line>
     show up again<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 05/032_25249340_181463c.xml
+++ b/Day 05/032_25249340_181463c.xml
@@ -441,24 +441,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="velworen" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			じゃあ、ミューノは<end_line>
 			はぐれ召喚獣のところに<end_line>
 			行ったかもしれない！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			じゃあ、ミューノは<end_line>
-			はぐれ召喚獣のところに<end_line>
-			行ったかもしれないの！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You think she's gone to<end_line>
     find Strays then?<end_line>
     Are you sure!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			じゃあ、ミューノは<end_line>
+			はぐれ召喚獣のところに<end_line>
+			行ったかもしれないの！？<end_line>
+		</sjis>
+    <ascii>
+    You think she's gone to<end_line>
+    find Strays then?<end_line>
+    Are you sure!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">

--- a/Day 05/035_25253132_181550c.xml
+++ b/Day 05/035_25253132_181550c.xml
@@ -16,6 +16,11 @@
       アニキたちが向かった<end_line>
       はぐれの仲間か<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Those must be<three_dots><end_line>
+    The leftovers of Jade's<end_line>
+    Stray extermination<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -23,12 +28,12 @@
       アニキたちが退治しに行った<end_line>
       はぐれ召喚獣の仲間かな<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Those must be<three_dots><end_line>
     The leftovers of Jade's<end_line>
     Stray extermination<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -93,15 +98,19 @@
       じゃあ<three_dots><end_line>
       行くしかないか！<end_line>
     </sjis>
+    <ascii>
+    Right<three_dots><end_line>
+    We have to break through!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       じゃあ<three_dots><end_line>
       行くしかないよね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
     We have to break through!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 05/036_25254220_181594c.xml
+++ b/Day 05/036_25254220_181594c.xml
@@ -7,17 +7,21 @@
       やった！<end_line>
       勝ったぞ！<end_line>
     </sjis>
+    <ascii>
+    Yes!<end_line>
+    I won!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       やった！<end_line>
       勝ったよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yes!<end_line>
     I won!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 05/038_25255116_1815ccc.xml
+++ b/Day 05/038_25255116_1815ccc.xml
@@ -191,16 +191,19 @@
       なんだと！？<end_line>
       お前、その言い方は<three_dots><end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！？<end_line>
       あんた、そんな言い方<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 05/040_25258204_18168dc.xml
+++ b/Day 05/040_25258204_18168dc.xml
@@ -19,15 +19,18 @@
     <sjis>
       お前<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    There you are<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あなた<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There you are<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -61,15 +64,18 @@
     <sjis>
       おい、ミューノはどこだよ！？<end_line>
     </sjis>
+    <ascii>
+    Hey, where is she!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ねぇ、ミューノはどこ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, where is she!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -270,15 +276,18 @@
     <sjis>
       お前、ケガして<three_dots>！？<end_line>
     </sjis>
+    <ascii>
+    Are you hurt<three_dots>!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あなた、ケガして<three_dots>！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Are you hurt<three_dots>!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 05/042_25260956_181739c.xml
+++ b/Day 05/042_25260956_181739c.xml
@@ -49,17 +49,21 @@
       やめろ！<end_line>
       お前らぁ！<end_line>
     </sjis>
+    <ascii>
+    Hey!<end_line>
+    Stop it!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       やめなさい！<end_line>
       アンタたち！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey!<end_line>
     Stop it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -190,15 +194,18 @@
     <sjis>
       なんだと<three_dots>！？<end_line>
     </sjis>
+    <ascii>
+    What<three_dots>!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ<three_dots>！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What<three_dots>!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -234,15 +241,18 @@
     <sjis>
       ウソだ！<end_line>
     </sjis>
+    <ascii>
+    That's a lie!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ウソよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's a lie!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -278,15 +288,18 @@
     <sjis>
       ウソだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    You're lying<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ウソよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're lying<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -335,17 +348,21 @@
       なんだよ、不幸って？<end_line>
       オレは<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    What misfortune?<end_line>
+    I'm<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、不幸って？<end_line>
       わたしは<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What misfortune?<end_line>
     I'm<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -401,6 +418,11 @@
       救いに来たつもりでいたのは<end_line>
       どうやらお前だけだった様だ！<end_line>
     </sjis>
+    <ascii>
+    You prance around acting like a<end_line>
+    knight in shining armor,<end_line>
+    and this is what you get!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -408,12 +430,12 @@
       助けに来たつもりでいたのは<end_line>
       どうやらお前だけだった様だ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You prance around acting like a<end_line>
     knight in shining armor,<end_line>
     and this is what you get!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -439,17 +461,21 @@
       な<three_dots>、なんだと<three_dots><end_line>
       勝手なこと言ってンじゃねぇ！<end_line>
     </sjis>
+    <ascii>
+    Wh<three_dots> why you<three_dots><end_line>
+    Don't you dare twist her words!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な<three_dots>、なによ、それ<three_dots><end_line>
       勝手なこと言わないでよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wh<three_dots> why you<three_dots><end_line>
     Don't you dare twist her words!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -567,15 +593,18 @@
     <sjis>
       なんだと！？<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -659,15 +688,18 @@
     <sjis>
       くっ<three_dots><end_line>
     </sjis>
+    <ascii>
+    <three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       えっ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 05/043_25264460_181814c.xml
+++ b/Day 05/043_25264460_181814c.xml
@@ -146,6 +146,10 @@
       ねらわれてるんだ！<end_line>
       早く助けないと<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    They're after Murno!<end_line>
+    If we don't hurry and save her<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -153,11 +157,11 @@
       ねらわれてるの！<end_line>
       早く助けないと<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     They're after Murno!<end_line>
     If we don't hurry and save her<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -287,17 +291,21 @@
       なんだと！？<end_line>
       ダレがなるか！<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+    Who would want that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！？<end_line>
       ダレがなるもんですか！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
     Who would want that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -395,17 +403,21 @@
       オレもわからない<end_line>
       だけど行かなきゃならないんだ<end_line>
     </sjis>
+    <ascii>
+    it's true or not.<end_line>
+		But<three_dots> I made a promise.<end_line>
+	</ascii>
   </male>
   <female>
     <sjis>
       わたしもわからない<end_line>
       だけど行かなきゃいけないの<end_line>
     </sjis>
-  </female>
-	<ascii>
+    <ascii>
     it's true or not.<end_line>
 		But<three_dots> I made a promise.<end_line>
 	</ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -516,6 +528,11 @@
       どうして<three_dots><end_line>
       まさかあいつらの手伝いか！？<end_line>
     </sjis>
+    <ascii>
+    Eh!?<end_line>
+    Why<three_dots><end_line>
+    Are you going to help them!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -523,12 +540,12 @@
       どうして<three_dots>?<end_line>
       あいつらを手伝うつもりなの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh!?<end_line>
     Why<three_dots><end_line>
     Are you going to help them!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -555,6 +572,11 @@
       だろ？<end_line>
       わかったよ<end_line>
     </sjis>
+    <ascii>
+		That wouldn't look good<end_line>
+		for Bostaph<three_dots> Right?<end_line>
+    Got it.<end_line>
+	</ascii>
   </male>
   <female>
     <sjis>
@@ -562,12 +584,12 @@
       <three_dots>でしょ？<end_line>
       わかったわよ<end_line>
     </sjis>
-  </female>
-	<ascii>
+    <ascii>
 		That wouldn't look good<end_line>
 		for Bostaph<three_dots> Right?<end_line>
     Got it.<end_line>
 	</ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -593,17 +615,21 @@
       そうか<three_dots><end_line>
       わかった<end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    Okay.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そう<three_dots><end_line>
       わかったわ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     Okay.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -660,6 +686,11 @@
       ミューノがあんなことする<end_line>
       はずがない<end_line>
     </sjis>
+    <ascii>
+    Of course I do.<end_line>
+    She would never do<end_line>
+    something like that!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -667,12 +698,12 @@
       ミューノがあんなことする<end_line>
       ワケない！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Of course I do.<end_line>
     She would never do<end_line>
     something like that!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -693,15 +724,18 @@
     <sjis>
       たしかめに行きたいんだ<end_line>
     </sjis>
+    <ascii>
+    That's why I need to make sure.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       たしかめに行きたいの<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's why I need to make sure.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 05/045_25267324_1818c7c.xml
+++ b/Day 05/045_25267324_1818c7c.xml
@@ -216,6 +216,11 @@
       お前<three_dots>どうして<end_line>
       親方のこと<three_dots>！？<end_line>
     </sjis>
+    <ascii>
+    Wha<three_dots> Rob<three_dots>!?<end_line>
+    H<three_dots> How do you<end_line>
+    know him<three_dots>!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -223,12 +228,12 @@
       あんた<three_dots>どうして<end_line>
       親方のこと<three_dots>！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wha<three_dots> Rob<three_dots>!?<end_line>
     H<three_dots> How do you<end_line>
     know him<three_dots>!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -681,17 +686,21 @@
       あんなでかいんだ<three_dots><end_line>
       そりゃコワイさ<three_dots><end_line>
     </sjis>
+    <ascii>
+    It's so big<three_dots><end_line>
+    Of course I'm scared<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんなに大きいんだよ<three_dots><end_line>
       そりゃコワイよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's so big<three_dots><end_line>
     Of course I'm scared<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -838,15 +847,18 @@
     <sjis>
       いけるぞ！<end_line>
     </sjis>
+    <ascii>
+    That would work!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       それなら、いけるね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That would work!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -854,15 +866,18 @@
     <sjis>
       大丈夫だ<three_dots><end_line>
     </sjis>
+    <ascii>
+    We'll be fine<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       大丈夫<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We'll be fine<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -1065,15 +1080,18 @@
     <sjis>
       オレたちは、そんなヤツに<end_line>
     </sjis>
+    <ascii>
+    We won't lose<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしたちは、そんな人になんか<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We won't lose<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -1133,15 +1151,18 @@
     <sjis>
       突っ込むぞ<end_line>
     </sjis>
+    <ascii>
+    Here we go,<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       突っ込むよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Here we go,<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 05/046_25272956_181a27c.xml
+++ b/Day 05/046_25272956_181a27c.xml
@@ -128,7 +128,7 @@
   </sjis>
   <ascii>
     <three_dots><end_line>
-  </ascii>  
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -148,15 +148,18 @@
     <sjis>
       お前<three_dots><end_line>
     </sjis>
+    <ascii>
+    You're<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あなた<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -284,15 +287,18 @@
     <sjis>
       やめろぉ！<end_line>
     </sjis>
+    <ascii>
+    Stop!!!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       やめてぇ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Stop!!!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -430,16 +436,19 @@
       落ち着けよ、ミューノ<end_line>
       おい！<end_line>
     </sjis>
+    <ascii>
+    Calm down, Murno!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       落ち着いて、ミューノ<end_line>
       ねぇ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Calm down, Murno!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 05/050_25278316_181b76c.xml
+++ b/Day 05/050_25278316_181b76c.xml
@@ -7,6 +7,11 @@
       閉じこめられなきゃならないんだよ<three_dots><end_line>
       一体なにがどうなってるんだ<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Why am I now<end_line>
+    locked up in here<three_dots><end_line>
+    Just what in the world is going on?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -14,12 +19,12 @@
       閉じこめられなきゃならないワケ？<end_line>
       一体なにがどうなってるのよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Why am I now<end_line>
     locked up in here<three_dots><end_line>
     Just what in the world is going on?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Day 05/051_25279132_181ba9c.xml
+++ b/Day 05/051_25279132_181ba9c.xml
@@ -58,15 +58,18 @@
     <sjis>
       あいつ<three_dots><end_line>
     </sjis>
+    <ascii>
+    <partner> did<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あの子<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner> did<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -146,6 +149,11 @@
       なんでオレたちがこんな風に<end_line>
       されなきゃならないんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I see<three_dots> Ugh<three_dots><end_line>
+    Why are we being<end_line>
+    treated like this<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -153,12 +161,12 @@
       なんでわたしたちがこんな風に<end_line>
       されなきゃならないの<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots> Ugh<three_dots><end_line>
     Why are we being<end_line>
     treated like this<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -211,6 +219,11 @@
       こんなことになったのは<end_line>
       アニスたちのせいじゃないか！<end_line>
     </sjis>
+    <ascii>
+    You're not to blame, Murno!<end_line>
+    If anything, this is<end_line>
+    all Anise's fault!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -218,12 +231,12 @@
       こんなことになったのは<end_line>
       アニスたちが悪いんだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're not to blame, Murno!<end_line>
     If anything, this is<end_line>
     all Anise's fault!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -289,6 +302,11 @@
       そんな危ないもの<end_line>
       ずっと持ってたのか！？<end_line>
     </sjis>
+    <ascii>
+    Destroy a city<three_dots>!?<end_line>
+    You've been holding onto such<end_line>
+    a dangrous thing the whole time!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -296,12 +314,12 @@
       そんな危ないもの<end_line>
       ずっと持ってたの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Destroy a city<three_dots>!?<end_line>
     You've been holding onto such<end_line>
     a dangrous thing the whole time!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -386,17 +404,21 @@
       それが<three_dots><end_line>
       アニスたちの仕業なのか<three_dots><end_line>
     </sjis>
+    <ascii>
+    That's<three_dots><end_line>
+    Anise's work<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       それが<three_dots><end_line>
       アニスたちの仕業なの<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's<three_dots><end_line>
     Anise's work<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -423,6 +445,11 @@
       じゃあ今、村やお父さんが<end_line>
       どうなってるかは<three_dots><end_line>
     </sjis>
+    <ascii>
+    And then you ran<three_dots><end_line>
+    So, how are the village<end_line>
+    and your father doing now<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -430,12 +457,12 @@
       じゃあ今、村やお父さんが<end_line>
       どうなってるかは<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And then you ran<three_dots><end_line>
     So, how are the village<end_line>
     and your father doing now<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -499,15 +526,18 @@
     <sjis>
       オレ、がんばるよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I'll help you<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたし、がんばるよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'll help you<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -633,6 +663,11 @@
       ここから抜け出して<end_line>
       魔石を取り返さないとな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Alright, first, we have to<end_line>
+    find a way out of here,<end_line>
+    and get the Stone back<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -640,12 +675,12 @@
       ここから抜け出して<end_line>
       魔石を取り返そう<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright, first, we have to<end_line>
     find a way out of here,<end_line>
     and get the Stone back<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 05/053_25281452_181c3ac.xml
+++ b/Day 05/053_25281452_181c3ac.xml
@@ -33,17 +33,21 @@
       よかった！<end_line>
       お前、大丈夫なのか？<end_line>
     </sjis>
+    <ascii>
+    Thank goodness!<end_line>
+    Are you okay?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よかった！<end_line>
       あなた、大丈夫なの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Thank goodness!<end_line>
     Are you okay?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -71,6 +75,11 @@
       大丈夫なんだな<three_dots><end_line>
       ミューノはどうなった？<end_line>
     </sjis>
+    <ascii>
+    I think that means<end_line>
+    you're okay then<three_dots><end_line>
+    What about Murno?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -78,12 +87,12 @@
       大丈夫なんだね<three_dots><end_line>
       ミューノはどうなったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I think that means<end_line>
     you're okay then<three_dots><end_line>
     What about Murno?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -404,15 +413,18 @@
     <sjis>
       そうなのか？<end_line>
     </sjis>
+    <ascii>
+    Really?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そうなの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Really?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -441,6 +453,11 @@
       すごい力があるって言ってたもんな<end_line>
       宝物みたいなもんなのか？<end_line>
     </sjis>
+    <ascii>
+    Guarded?<end_line>
+    You said it's really powerful.<end_line>
+    Was it like a treasure?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -448,12 +465,12 @@
       すごい力があるって言ってたもんね<end_line>
       宝物みたいなもの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Guarded?<end_line>
     You said it's really powerful.<end_line>
     Was it like a treasure?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -513,6 +530,11 @@
       じゃあ、今、村やお父さんが<end_line>
       どうなってるのかは<three_dots><end_line>
     </sjis>
+    <ascii>
+    And then you ran<three_dots><end_line>
+    So, how are the village<end_line>
+    and her father doing now<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -520,12 +542,12 @@
       じゃあ、今、村やお父さんが<end_line>
       どうなってるのかは<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And then you ran<three_dots><end_line>
     So, how are the village<end_line>
     and her father doing now<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -564,6 +586,10 @@
       ずっとだまってて<three_dots><end_line>
       ガマンして<three_dots><end_line>
     </sjis>
+    <ascii>
+    Despite all that,<end_line>
+    she didn't say anything<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -571,11 +597,11 @@
       ずっとだまってて<three_dots><end_line>
       ガマンして<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Despite all that,<end_line>
     she didn't say anything<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -674,6 +700,10 @@
       お前といっしょに<end_line>
       ミューノを守りぬくよ！<end_line>
     </sjis>
+    <ascii>
+    I'll work much, much harder,<end_line>
+    and we'll protect her together!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -681,11 +711,11 @@
       あなたといっしょに<end_line>
       ミューノを守りぬくよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'll work much, much harder,<end_line>
     and we'll protect her together!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -710,15 +740,18 @@
     <sjis>
       おう！<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -773,17 +806,21 @@
       うん！<end_line>
       <partner>は大丈夫なのか？<end_line>
     </sjis>
+    <ascii>
+    Yep!<end_line>
+    Are you okay, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん！<end_line>
       <partner>は大丈夫なの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yep!<end_line>
     Are you okay, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -1127,15 +1164,18 @@
     <sjis>
       そうなのか？<end_line>
     </sjis>
+    <ascii>
+    Really?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そうなの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Really?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -1164,6 +1204,11 @@
       すごい力があるって言ってたもんな<end_line>
       宝物みたいなもんなのか？<end_line>
     </sjis>
+    <ascii>
+    Guarded?<end_line>
+    You said it's really powerful.<end_line>
+    Was it like a treasure?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1171,12 +1216,12 @@
       すごい力があるって言ってたもんね<end_line>
       宝物みたいなもの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Guarded?<end_line>
     You said it's really powerful.<end_line>
     Was it like a treasure?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -1237,6 +1282,11 @@
       じゃあ、今<end_line>
       その村がどうなってるのかは<three_dots><end_line>
     </sjis>
+    <ascii>#425
+    And then you ran<three_dots><end_line>
+    So, how are the village<end_line>
+    and her father doing now<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1244,12 +1294,12 @@
       じゃあ、今<end_line>
       その村がどうなってるのかは<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>#425
+    <ascii>#425
     And then you ran<three_dots><end_line>
     So, how are the village<end_line>
     and her father doing now<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -1278,6 +1328,11 @@
       そんなつらい目にあってたのに<end_line>
       オレたちにはずっとだまってて<three_dots><end_line>
     </sjis>
+    <ascii>
+    No way<three_dots><end_line>
+    Despite all that,<end_line>
+    she didn't say anything<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1285,12 +1340,12 @@
       そんなつらい目にあってたのに<end_line>
       わたしたちにはずっとだまってて<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No way<three_dots><end_line>
     Despite all that,<end_line>
     she didn't say anything<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -1390,6 +1445,10 @@
       お前といっしょに<end_line>
       ミューノを守りぬくよ！<end_line>
     </sjis>
+    <ascii>
+    I'll work much, much harder,<end_line>
+    and we'll protect her together!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1397,11 +1456,11 @@
       あなたといっしょに<end_line>
       ミューノを守りぬくよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'll work much, much harder,<end_line>
     and we'll protect her together!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -1426,15 +1485,18 @@
     <sjis>
       おう！<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -1489,17 +1551,21 @@
       あったりまえだろ<end_line>
       お前こそ大丈夫なのか？<end_line>
     </sjis>
+    <ascii>
+    Of course not.<end_line>
+    What about you?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あったりまえでしょ<end_line>
       あなたこそ大丈夫なの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Of course not.<end_line>
     What about you?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1526,6 +1592,11 @@
       じゃ、ミューノは？<end_line>
       ミューノはどうなった？<end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    So, what about Murno?<end_line>
+    What happened to her?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1533,12 +1604,12 @@
       じゃ、ミューノは？<end_line>
       ミューノはどうなったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     So, what about Murno?<end_line>
     What happened to her?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1604,6 +1675,11 @@
       <partner>が助けてくれたんだな<end_line>
       ありがとう<end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    You saved us<three_dots><end_line>
+    Thanks<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1611,12 +1687,12 @@
       <partner>が助けてくれたんだね<end_line>
       ありがとう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     You saved us<three_dots><end_line>
     Thanks<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1644,17 +1720,21 @@
       はいはい<end_line>
       で、ここはどこなんだ？<end_line>
     </sjis>
+    <ascii>
+    Okay, okay.<end_line>
+    So, where are we?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       はいはい<end_line>
       で、ここはどこなの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay, okay.<end_line>
     So, where are we?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1767,6 +1847,10 @@
       そんなのをつけられたのか<three_dots><end_line>
       ヒドイことしやがる<three_dots><end_line>
     </sjis>
+    <ascii>
+    Bracelets<three_dots>?<end_line>
+    That's horrible<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1774,11 +1858,11 @@
       そんなのをつけられたの<three_dots><end_line>
       かわいそうに<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Bracelets<three_dots>?<end_line>
     That's horrible<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1930,15 +2014,18 @@
     <sjis>
       そうなのか？<end_line>
     </sjis>
+    <ascii>
+    Really?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そうなの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Really?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1979,6 +2066,11 @@
       すごい力があるって言ってたもんな<end_line>
       宝物みたいなもんなのか？<end_line>
     </sjis>
+    <ascii>
+    Guarded?<end_line>
+    You said it's really powerful.<end_line>
+    Was it like a treasure?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1986,12 +2078,12 @@
       すごい力があるって言ってたもんね<end_line>
       宝物みたいなもの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Guarded?<end_line>
     You said it's really powerful.<end_line>
     Was it like a treasure?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -2058,15 +2150,18 @@
     <sjis>
       アニスたちか<three_dots><end_line>
     </sjis>
+    <ascii>
+    Anise<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       アニスたちね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Anise<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -2095,6 +2190,11 @@
       じゃあ、今<end_line>
       その村がどうなってるのかは<three_dots><end_line>
     </sjis>
+    <ascii>
+    And then you ran<three_dots><end_line>
+    So, how are the village<end_line>
+    and her father doing now<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -2102,12 +2202,12 @@
       じゃあ、今<end_line>
       その村がどうなってるのかは<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And then you ran<three_dots><end_line>
     So, how are the village<end_line>
     and her father doing now<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -2134,6 +2234,11 @@
       そんなつらい目にあってたのに<end_line>
       オレたちにはずっとだまってたのか<three_dots><end_line>
     </sjis>
+    <ascii>
+    No way<three_dots><end_line>
+    Despite all that,<end_line>
+    she didn't say anything<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -2141,12 +2246,12 @@
       そんなつらい目にあってたのに<end_line>
       わたしたちにはずっとだまってたの<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No way<three_dots><end_line>
     Despite all that,<end_line>
     she didn't say anything<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -2175,6 +2280,11 @@
       お前がどうしてミューノを守りたいか<end_line>
       わかったような気がするよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    You know, I<three_dots><end_line>
+    I feel like I know why<end_line>
+    you want to protect her<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -2182,12 +2292,12 @@
       あなたがどうしてミューノを守りたいか<end_line>
       わかったような気がするよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You know, I<three_dots><end_line>
     I feel like I know why<end_line>
     you want to protect her<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -2284,15 +2394,18 @@
     <sjis>
       おう！<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -2347,6 +2460,11 @@
       オレは元気だぜ！<end_line>
       <partner>こそ大丈夫なのか？<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+    I'm fine!<end_line>
+    What about you, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -2354,12 +2472,12 @@
       わたしは元気だよ！<end_line>
       <partner>こそ大丈夫なの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
     I'm fine!<end_line>
     What about you, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -2383,6 +2501,11 @@
       じゃ、ミューノは？<end_line>
       ミューノはどうなった？<end_line>
     </sjis>
+    <ascii>
+    Thank goodness<three_dots><end_line>
+    So, what about Murno?<end_line>
+    What happened to her?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -2390,12 +2513,12 @@
       じゃ、ミューノは？<end_line>
       ミューノはどうなったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Thank goodness<three_dots><end_line>
     So, what about Murno?<end_line>
     What happened to her?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -2593,17 +2716,21 @@
       妙なうでわ<three_dots>？<end_line>
       そうなのか<three_dots><end_line>
     </sjis>
+    <ascii>
+    Strange bracelets<three_dots>?<end_line>
+    I see<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       妙なうでわ<three_dots>？<end_line>
       そうなんだ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Strange bracelets<three_dots>?<end_line>
     I see<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -2704,15 +2831,18 @@
     <sjis>
       そうなのか？<end_line>
     </sjis>
+    <ascii>
+    Really?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そうなの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Really?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -2740,6 +2870,11 @@
       すごい力があるって言ってたもんな<end_line>
       宝物みたいなもんなのか？<end_line>
     </sjis>
+    <ascii>
+    Guarded?<end_line>
+    You said it's really powerful.<end_line>
+    Was it like a treasure?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -2747,12 +2882,12 @@
       すごい力があるって言ってたもんね<end_line>
       宝物みたいなもの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Guarded?<end_line>
     You said it's really powerful.<end_line>
     Was it like a treasure?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -2810,6 +2945,11 @@
       じゃあ、今<end_line>
       その村がどうなってるのかは<three_dots><end_line>
     </sjis>
+    <ascii>
+    And then you ran<three_dots><end_line>
+    So, how are the village<end_line>
+    and her father doing now<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -2817,12 +2957,12 @@
       じゃあ、今<end_line>
       その村がどうなってるのかは<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And then you ran<three_dots><end_line>
     So, how are the village<end_line>
     and her father doing now<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -2848,6 +2988,11 @@
       そんなつらい目にあってたのに<end_line>
       オレたちにはずっとだまってたのか<three_dots><end_line>
     </sjis>
+    <ascii>
+    No way<three_dots><end_line>
+    Despite all that,<end_line>
+    she didn't say anything<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -2855,12 +3000,12 @@
       そんなつらい目にあってたのに<end_line>
       わたしたちにはずっとだまってたの<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No way<three_dots><end_line>
     Despite all that,<end_line>
     she didn't say anything<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -2959,6 +3104,10 @@
       お前といっしょに<end_line>
       ミューノを守りぬくよ！<end_line>
     </sjis>
+    <ascii>
+    I'll work much, much harder,<end_line>
+    and we'll protect her together!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -2966,11 +3115,11 @@
       あなたといっしょに<end_line>
       ミューノを守りぬくよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'll work much, much harder,<end_line>
     and we'll protect her together!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -2994,15 +3143,18 @@
     <sjis>
       おう！<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 05/24479548_175873c.xml
+++ b/Day 05/24479548_175873c.xml
@@ -4,21 +4,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノがねらわれてるんだ<end_line>
 			ジッとしててもはじまらないぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノがねらわれてるんだから<end_line>
-			ジッとしててもはじまらないよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Those three are after Murno.<end_line>
     We have to do something!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノがねらわれてるんだから<end_line>
+			ジッとしててもはじまらないよ！<end_line>
+		</sjis>
+    <ascii>
+    Those three are after Murno.<end_line>
+    We have to do something!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -42,24 +46,29 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			賛成したいけど<end_line>
 			ここベンソンさんの工房だぜ<end_line>
 			勝手にワナはマズイだろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			賛成したいけど<end_line>
-			ここベンソンさんの工房だよ<end_line>
-			勝手にワナはマズイって？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'd like to agree,<end_line>
     but this is Benson's Workshop.<end_line>
     We can't do whatever we want.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			賛成したいけど<end_line>
+			ここベンソンさんの工房だよ<end_line>
+			勝手にワナはマズイって？<end_line>
+		</sjis>
+    <ascii>
+    I'd like to agree,<end_line>
+    but this is Benson's Workshop.<end_line>
+    We can't do whatever we want.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -67,21 +76,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノがねらわれてるんだ<end_line>
 			ジッとしててもはじまらないぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノがねらわれてるんだから<end_line>
-			ジッとしててもはじまらないよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Those three are after Murno.<end_line>
     We have to do something!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノがねらわれてるんだから<end_line>
+			ジッとしててもはじまらないよ！<end_line>
+		</sjis>
+    <ascii>
+    Those three are after Murno.<end_line>
+    We have to do something!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -105,21 +118,25 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんとなくバカにされたような<end_line>
 			気がしたぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なんとなくバカにされたような<end_line>
-			気がしたよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Um, is that directed<end_line>
     towards me?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なんとなくバカにされたような<end_line>
+			気がしたよ！<end_line>
+		</sjis>
+    <ascii>
+    Um, is that directed<end_line>
+    towards me?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -127,21 +144,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノがねらわれてるんだ<end_line>
 			ジッとしててもはじまらないぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノがねらわれてるんだから<end_line>
-			ジッとしててもはじまらないよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Those three are after Murno.<end_line>
     We have to do something!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノがねらわれてるんだから<end_line>
+			ジッとしててもはじまらないよ！<end_line>
+		</sjis>
+    <ascii>
+    Those three are after Murno.<end_line>
+    We have to do something!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -165,21 +186,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱり<partner>も<end_line>
 			ミューノのことが心配なんだな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱり<partner>も<end_line>
-			ミューノのことが心配なんだね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <partner><three_dots><end_line>
     I knew you were worried about her.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱり<partner>も<end_line>
+			ミューノのことが心配なんだね<end_line>
+		</sjis>
+    <ascii>
+    <partner><three_dots><end_line>
+    I knew you were worried about her.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -200,21 +225,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノがねらわれてるんだ<end_line>
 			ジッとしててもはじまらないぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノがねらわれてるんだから<end_line>
-			ジッとしててもはじまらないよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Those three are after Murno.<end_line>
     We have to do something!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノがねらわれてるんだから<end_line>
+			ジッとしててもはじまらないよ！<end_line>
+		</sjis>
+    <ascii>
+    Those three are after Murno.<end_line>
+    We have to do something!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -234,18 +263,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+		</sjis>
+    <ascii>
+    Right.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -283,24 +315,29 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			走らず急げって言われてもな<three_dots><end_line>
 			ま、走ると商品がキズつきそうだし<end_line>
 			道具屋さんも待ってるから仕方ないか<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			走らず急げって言われてもね<three_dots><end_line>
-			ま、走ると商品がキズつきそうだし<end_line>
-			道具屋さんも待ってるから仕方ないか<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Or risk damaging the goods<three_dots><end_line>
     And they're waiting for us<three_dots><end_line>
     We'll just have to do what we can.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			走らず急げって言われてもね<three_dots><end_line>
+			ま、走ると商品がキズつきそうだし<end_line>
+			道具屋さんも待ってるから仕方ないか<end_line>
+		</sjis>
+    <ascii>
+    Or risk damaging the goods<three_dots><end_line>
+    And they're waiting for us<three_dots><end_line>
+    We'll just have to do what we can.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -348,24 +385,29 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			走るとキズつきそうな商品みたいだし<end_line>
 			道具屋さんも待ってるらしいからな<end_line>
 			走らず道具屋さんに行けばいいんだろ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			走るとキズつきそうな商品みたいだし<end_line>
-			道具屋さんも待ってるらしいからね<end_line>
-			走らず道具屋さんに行けばいいのよね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Or risk damaging the goods<three_dots><end_line>
     And they're waiting for us<three_dots><end_line>
     Well, just don't run and its fine.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			走るとキズつきそうな商品みたいだし<end_line>
+			道具屋さんも待ってるらしいからね<end_line>
+			走らず道具屋さんに行けばいいのよね<end_line>
+		</sjis>
+    <ascii>
+    Or risk damaging the goods<three_dots><end_line>
+    And they're waiting for us<three_dots><end_line>
+    Well, just don't run and its fine.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -415,24 +457,29 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			走るとキズつきそうな商品みたいだし<end_line>
 			道具屋さんも待ってるらしいからな<end_line>
 			走らず道具屋さんに行けばいいんだろ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			走るとキズつきそうな商品みたいだし<end_line>
-			道具屋さんも待ってるらしいからね<end_line>
-			走らず道具屋さんに行けばいいのよね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Or risk damaging the goods<three_dots><end_line>
     And they're waiting for us<three_dots><end_line>
     Well, just don't run and its fine.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			走るとキズつきそうな商品みたいだし<end_line>
+			道具屋さんも待ってるらしいからね<end_line>
+			走らず道具屋さんに行けばいいのよね<end_line>
+		</sjis>
+    <ascii>
+    Or risk damaging the goods<three_dots><end_line>
+    And they're waiting for us<three_dots><end_line>
+    Well, just don't run and its fine.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -477,24 +524,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			走るとキズつきそうな商品みたいだし<end_line>
 			道具屋さんも待ってるらしいからな<end_line>
 			走らず道具屋さんに行けばいいんだろ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			走るとキズつきそうな商品みたいだし<end_line>
-			道具屋さんも待ってるらしいからね<end_line>
-			走らず道具屋さんに行けばいいのよね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Or risk damaging the goods<three_dots><end_line>
     And they're waiting for us<three_dots><end_line>
     Well, just don't run and its fine.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			走るとキズつきそうな商品みたいだし<end_line>
+			道具屋さんも待ってるらしいからね<end_line>
+			走らず道具屋さんに行けばいいのよね<end_line>
+		</sjis>
+    <ascii>
+    Or risk damaging the goods<three_dots><end_line>
+    And they're waiting for us<three_dots><end_line>
+    Well, just don't run and its fine.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -617,21 +669,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノが心配だ<end_line>
 			工房に戻ろう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノが心配だよ<end_line>
-			工房に戻ろう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm worried about Murno.<end_line>
     To the workshop!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノが心配だよ<end_line>
+			工房に戻ろう！<end_line>
+		</sjis>
+    <ascii>
+    I'm worried about Murno.<end_line>
+    To the workshop!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -653,18 +709,21 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			お、おう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			う、うん！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Y-yeah!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			う、うん！<end_line>
+		</sjis>
+    <ascii>
+    Y-yeah!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -672,21 +731,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノが心配だ<end_line>
 			工房に戻ろう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノが心配だよ<end_line>
-			工房に戻ろう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm worried about Murno.<end_line>
     To the workshop!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノが心配だよ<end_line>
+			工房に戻ろう！<end_line>
+		</sjis>
+    <ascii>
+    I'm worried about Murno.<end_line>
+    To the workshop!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -706,18 +769,21 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			とにかく急ごう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			とにかく急ごう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Come on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			とにかく急ごう！<end_line>
+		</sjis>
+    <ascii>
+    Come on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -725,21 +791,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノが心配だ<end_line>
 			工房に戻ろう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノが心配だよ<end_line>
-			工房に戻ろう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm worried about Murno.<end_line>
     To the workshop!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノが心配だよ<end_line>
+			工房に戻ろう！<end_line>
+		</sjis>
+    <ascii>
+    I'm worried about Murno.<end_line>
+    To the workshop!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -761,39 +831,46 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			お、おう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			う、うん！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Y-yeah!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			う、うん！<end_line>
+		</sjis>
+    <ascii>
+    Y-yeah!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノが心配だ<end_line>
 			工房に戻ろう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノが心配だよ<end_line>
-			工房に戻ろう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm worried about Murno.<end_line>
     To the workshop!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノが心配だよ<end_line>
+			工房に戻ろう！<end_line>
+		</sjis>
+    <ascii>
+    I'm worried about Murno.<end_line>
+    To the workshop!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1555,24 +1632,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノがあの３人に追いかけられて<end_line>
 			ベリートの森の奥に行ったみたいだ<end_line>
 			急ごう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノがあの３人に追いかけられて<end_line>
-			ベリートの森の奥に行ったみたい<end_line>
-			急ごう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     The trio chased Murno<end_line>
     deep into Beleet Forest!<end_line>
     We have to find them!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノがあの３人に追いかけられて<end_line>
+			ベリートの森の奥に行ったみたい<end_line>
+			急ごう！<end_line>
+		</sjis>
+    <ascii>
+    The trio chased Murno<end_line>
+    deep into Beleet Forest!<end_line>
+    We have to find them!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1606,24 +1688,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ゴチャゴチャ考えるのは<end_line>
 			ミューノを見つけた後だ！<end_line>
 			行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ゴチャゴチャ考えるのは<end_line>
-			ミューノを見つけた後！<end_line>
-			行くよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's talk about that<end_line>
     after we find her!<end_line>
     Come on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ゴチャゴチャ考えるのは<end_line>
+			ミューノを見つけた後！<end_line>
+			行くよ！<end_line>
+		</sjis>
+    <ascii>
+    Let's talk about that<end_line>
+    after we find her!<end_line>
+    Come on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1631,24 +1718,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノがあの３人に追いかけられて<end_line>
 			ベリートの森の奥に行ったみたいだ<end_line>
 			急ごう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノがあの３人に追いかけられて<end_line>
-			ベリートの森の奥に行ったみたい<end_line>
-			急ごう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     The trio chased Murno<end_line>
     deep into Beleet Forest!<end_line>
     We have to find them!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノがあの３人に追いかけられて<end_line>
+			ベリートの森の奥に行ったみたい<end_line>
+			急ごう！<end_line>
+		</sjis>
+    <ascii>
+    The trio chased Murno<end_line>
+    deep into Beleet Forest!<end_line>
+    We have to find them!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1684,24 +1776,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			ゴチャゴチャ考えるのは<end_line>
 			ミューノを見つけた後だ！<end_line>
 			行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ゴチャゴチャ考えるのは<end_line>
-			ミューノを見つけた後！<end_line>
-			行くよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's talk about that<end_line>
     after we find her!<end_line>
     Come on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ゴチャゴチャ考えるのは<end_line>
+			ミューノを見つけた後！<end_line>
+			行くよ！<end_line>
+		</sjis>
+    <ascii>
+    Let's talk about that<end_line>
+    after we find her!<end_line>
+    Come on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1709,24 +1806,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノがあの３人に追いかけられて<end_line>
 			ベリートの森の奥に行ったみたいだ<end_line>
 			急ごう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノがあの３人に追いかけられて<end_line>
-			ベリートの森の奥に行ったみたい<end_line>
-			急ごう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     The trio chased Murno<end_line>
     deep into Beleet Forest!<end_line>
     We have to find them!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノがあの３人に追いかけられて<end_line>
+			ベリートの森の奥に行ったみたい<end_line>
+			急ごう！<end_line>
+		</sjis>
+    <ascii>
+    The trio chased Murno<end_line>
+    deep into Beleet Forest!<end_line>
+    We have to find them!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1762,48 +1864,58 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			ゴチャゴチャ考えるのは<end_line>
 			ミューノを見つけた後だ！<end_line>
 			行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ゴチャゴチャ考えるのは<end_line>
-			ミューノを見つけた後！<end_line>
-			行くよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's talk about that<end_line>
     after we find her!<end_line>
     Come on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ゴチャゴチャ考えるのは<end_line>
+			ミューノを見つけた後！<end_line>
+			行くよ！<end_line>
+		</sjis>
+    <ascii>
+    Let's talk about that<end_line>
+    after we find her!<end_line>
+    Come on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノがあの３人に追いかけられて<end_line>
 			ベリートの森の奥に行ったみたいだ<end_line>
 			急ごう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノがあの３人に追いかけられて<end_line>
-			ベリートの森の奥に行ったみたい<end_line>
-			急ごう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     The trio chased Murno<end_line>
     deep into Beleet Forest!<end_line>
     We have to find them!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノがあの３人に追いかけられて<end_line>
+			ベリートの森の奥に行ったみたい<end_line>
+			急ごう！<end_line>
+		</sjis>
+    <ascii>
+    The trio chased Murno<end_line>
+    deep into Beleet Forest!<end_line>
+    We have to find them!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1836,24 +1948,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ゴチャゴチャ考えるのは<end_line>
 			ミューノを見つけた後だ！<end_line>
 			行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ゴチャゴチャ考えるのは<end_line>
-			ミューノを見つけた後！<end_line>
-			行くよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's talk about that<end_line>
     after we find her!<end_line>
     Come on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ゴチャゴチャ考えるのは<end_line>
+			ミューノを見つけた後！<end_line>
+			行くよ！<end_line>
+		</sjis>
+    <ascii>
+    Let's talk about that<end_line>
+    after we find her!<end_line>
+    Come on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1861,24 +1978,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ティエにまでケガさせるなんて<three_dots><end_line>
 			あいつら、何をするかわからないぞ<end_line>
 			早くミューノを見つけないと！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ティエにまでケガさせるなんて<three_dots><end_line>
-			あいつら、何をするかわからないよ<end_line>
-			早くミューノを見つけないと！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Those three even hurt Tier<three_dots><end_line>
     We can't trust them.<end_line>
     We have to find Murno!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ティエにまでケガさせるなんて<three_dots><end_line>
+			あいつら、何をするかわからないよ<end_line>
+			早くミューノを見つけないと！<end_line>
+		</sjis>
+    <ascii>
+    Those three even hurt Tier<three_dots><end_line>
+    We can't trust them.<end_line>
+    We have to find Murno!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1900,24 +2022,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ティエにまでケガさせるなんて<three_dots><end_line>
 			あいつら、何をするかわからないぞ<end_line>
 			早くミューノを見つけないと！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ティエにまでケガさせるなんて<three_dots><end_line>
-			あいつら、何をするかわからないよ<end_line>
-			早くミューノを見つけないと！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Those three even hurt Tier<three_dots><end_line>
     We can't trust them.<end_line>
     We have to find Murno!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ティエにまでケガさせるなんて<three_dots><end_line>
+			あいつら、何をするかわからないよ<end_line>
+			早くミューノを見つけないと！<end_line>
+		</sjis>
+    <ascii>
+    Those three even hurt Tier<three_dots><end_line>
+    We can't trust them.<end_line>
+    We have to find Murno!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1937,24 +2064,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ティエにまでケガさせるなんて<three_dots><end_line>
 			あいつら、何をするかわからないぞ<end_line>
 			早くミューノを見つけないと！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ティエにまでケガさせるなんて<three_dots><end_line>
-			あいつら、何をするかわからないよ<end_line>
-			早くミューノを見つけないと！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Those three even hurt Tier<three_dots><end_line>
     We can't trust them.<end_line>
     We have to find Murno!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ティエにまでケガさせるなんて<three_dots><end_line>
+			あいつら、何をするかわからないよ<end_line>
+			早くミューノを見つけないと！<end_line>
+		</sjis>
+    <ascii>
+    Those three even hurt Tier<three_dots><end_line>
+    We can't trust them.<end_line>
+    We have to find Murno!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1977,24 +2109,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ティエにまでケガさせるなんて<three_dots><end_line>
 			あいつら、何をするかわからないぞ<end_line>
 			早くミューノを見つけないと！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ティエにまでケガさせるなんて<three_dots><end_line>
-			あいつら、何をするかわからないよ<end_line>
-			早くミューノを見つけないと！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Those three even hurt Tier<three_dots><end_line>
     We can't trust them.<end_line>
     We have to find Murno!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ティエにまでケガさせるなんて<three_dots><end_line>
+			あいつら、何をするかわからないよ<end_line>
+			早くミューノを見つけないと！<end_line>
+		</sjis>
+    <ascii>
+    Those three even hurt Tier<three_dots><end_line>
+    We can't trust them.<end_line>
+    We have to find Murno!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2015,24 +2152,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ゴヴァンの魔石さえ手に入れば<end_line>
 			ミューノはどうなってもいいだなんて<end_line>
 			あいつら<three_dots>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ゴヴァンの魔石さえ手に入れば<end_line>
-			ミューノはどうなってもいいだなんて<end_line>
-			あの人たち<three_dots>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So the trio doesn't care what<end_line>
     happens to Murno as long as<end_line>
     they can get the Demon Stone<three_dots>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ゴヴァンの魔石さえ手に入れば<end_line>
+			ミューノはどうなってもいいだなんて<end_line>
+			あの人たち<three_dots>！<end_line>
+		</sjis>
+    <ascii>
+    So the trio doesn't care what<end_line>
+    happens to Murno as long as<end_line>
+    they can get the Demon Stone<three_dots>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -2110,24 +2252,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ゴヴァンの魔石さえ手に入れば<end_line>
 			ミューノはどうなってもいいだなんて<end_line>
 			あいつら<three_dots>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ゴヴァンの魔石さえ手に入れば<end_line>
-			ミューノはどうなってもいいだなんて<end_line>
-			あの人たち<three_dots>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So the trio doesn't care what<end_line>
     happens to Murno as long as<end_line>
     they can get the Demon Stone<three_dots>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ゴヴァンの魔石さえ手に入れば<end_line>
+			ミューノはどうなってもいいだなんて<end_line>
+			あの人たち<three_dots>！<end_line>
+		</sjis>
+    <ascii>
+    So the trio doesn't care what<end_line>
+    happens to Murno as long as<end_line>
+    they can get the Demon Stone<three_dots>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2205,24 +2352,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ゴヴァンの魔石さえ手に入れば<end_line>
 			ミューノはどうなってもいいだなんて<end_line>
 			あいつら<three_dots>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ゴヴァンの魔石さえ手に入れば<end_line>
-			ミューノはどうなってもいいだなんて<end_line>
-			あの人たち<three_dots>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So the trio doesn't care what<end_line>
     happens to Murno as long as<end_line>
     they can get the Demon Stone<three_dots>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ゴヴァンの魔石さえ手に入れば<end_line>
+			ミューノはどうなってもいいだなんて<end_line>
+			あの人たち<three_dots>！<end_line>
+		</sjis>
+    <ascii>
+    So the trio doesn't care what<end_line>
+    happens to Murno as long as<end_line>
+    they can get the Demon Stone<three_dots>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2299,24 +2451,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ゴヴァンの魔石さえ手に入れば<end_line>
 			ミューノはどうなってもいいだなんて<end_line>
 			あいつら<three_dots>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ゴヴァンの魔石さえ手に入れば<end_line>
-			ミューノはどうなってもいいだなんて<end_line>
-			あの人たち<three_dots>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So the trio doesn't care what<end_line>
     happens to Murno as long as<end_line>
     they can get the Demon Stone<three_dots>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ゴヴァンの魔石さえ手に入れば<end_line>
+			ミューノはどうなってもいいだなんて<end_line>
+			あの人たち<three_dots>！<end_line>
+		</sjis>
+    <ascii>
+    So the trio doesn't care what<end_line>
+    happens to Murno as long as<end_line>
+    they can get the Demon Stone<three_dots>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">

--- a/Day 05/25248508_18142fc.xml
+++ b/Day 05/25248508_18142fc.xml
@@ -3,21 +3,25 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="zakk" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			あのさ、ザック<end_line>
 			ミューノ見なかったか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ねぇ、ザック<end_line>
-			ミューノ見なかった？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey, Zakk,<end_line>
     have you seen Murno?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ねぇ、ザック<end_line>
+			ミューノ見なかった？<end_line>
+		</sjis>
+    <ascii>
+    Hey, Zakk,<end_line>
+    have you seen Murno?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">

--- a/Day 05/25969324_18c42ac.xml
+++ b/Day 05/25969324_18c42ac.xml
@@ -18,18 +18,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="stressed">
 	<portrait_r entry="jade" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			え、オレが？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			え、わたしが？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hm? Why me?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			え、わたしが？<end_line>
+		</sjis>
+    <ascii>
+    Hm? Why me?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -60,30 +63,30 @@
   </ascii>
 </dialogue>
 <menu>
-	<title>
-		<sjis>
+  <title>
+    <sjis>
 			武器の注文受けますか？<end_line>
 		</sjis>
     <ascii>
       Accept request?<end_line>
     </ascii>
-	</title>
-	<option>
-		<sjis>
+  </title>
+  <option>
+    <sjis>
 			はい<end_line>
 		</sjis>
     <ascii>
       Yes<end_line>
     </ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			いいえ<end_line>
 		</sjis>
     <ascii>
       No<end_line>
     </ascii>
-	</option>
+  </option>
 </menu>
 <dialogue>
 	<info box="left">
@@ -101,18 +104,21 @@
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<portrait_r entry="jade" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			ええ～っと、オレには<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ええ～っと、わたしには<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, I uh<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ええ～っと、わたしには<end_line>
+		</sjis>
+    <ascii>
+    Well, I uh<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -126,30 +132,30 @@
   </ascii>
 </dialogue>
 <menu>
-	<title>
-		<sjis>
+  <title>
+    <sjis>
 			注文の武器はできていますか？<end_line>
 		</sjis>
     <ascii>
       Present your weapon?<end_line>
     </ascii>
-	</title>
-	<option>
-		<sjis>
+  </title>
+  <option>
+    <sjis>
 			はい<end_line>
 		</sjis>
     <ascii>
       Yes<end_line>
     </ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			いいえ<end_line>
 		</sjis>
     <ascii>
       No<end_line>
     </ascii>
-	</option>
+  </option>
 </menu>
 <dialogue>
 	<info box="left">

--- a/Day 06/001_25289596_181e37c.xml
+++ b/Day 06/001_25289596_181e37c.xml
@@ -45,15 +45,18 @@
     <sjis>
       は<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Huh<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -74,16 +77,19 @@
     <sjis>
       <three_dots>今度は何するつもりなんだ？<end_line>
     </sjis>
+    <ascii>
+    <three_dots> What is it this time?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ち、ちょっと<end_line>
       <three_dots>今度は何するつもり？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots> What is it this time?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Day 06/002_25290524_181e71c.xml
+++ b/Day 06/002_25290524_181e71c.xml
@@ -121,17 +121,21 @@
       お前<three_dots>！<end_line>
       よくも、<partner>に！<end_line>
     </sjis>
+    <ascii>
+    Why you<three_dots>!<end_line>
+    What did you do to <partner>!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんた<three_dots>！<end_line>
       <partner>に何してるのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Why you<three_dots>!<end_line>
     What did you do to <partner>!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 06/005_25292172_181ed8c.xml
+++ b/Day 06/005_25292172_181ed8c.xml
@@ -33,17 +33,21 @@
       なんだよ<three_dots><end_line>
       自分だって、子供じゃねぇか<three_dots><end_line>
     </sjis>
+    <ascii>
+    Hey<three_dots><end_line>
+    You're a kid too<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ<three_dots><end_line>
       自分だって、子供じゃないの<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey<three_dots><end_line>
     You're a kid too<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -66,6 +70,10 @@
       なんでオレたちがこんな目に<end_line>
       あわなきゃなんないんだよ！？<end_line>
     </sjis>
+    <ascii>
+    And what do you mean, those people!?<end_line>
+    Why'd you lock us up like that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -73,11 +81,11 @@
       なんでわたしたちがこんな目に<end_line>
       あわなきゃならないの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And what do you mean, those people!?<end_line>
     Why'd you lock us up like that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -101,15 +109,18 @@
     <sjis>
       お前<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Anise<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんた<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Anise<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -209,17 +220,21 @@
       なんだよ、お前たち<end_line>
       仲間だったのか<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+    You're working together<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、あなたたち<end_line>
       仲間だったの<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
     You're working together<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -375,17 +390,21 @@
       ヴォイジンの手下<three_dots>？<end_line>
       なんのことだよ！？<end_line>
     </sjis>
+    <ascii>
+    Voijin's subordinates<three_dots>?<end_line>
+    What?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ヴォイジンの手下<three_dots>？<end_line>
       なに言ってるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Voijin's subordinates<three_dots>?<end_line>
     What?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -427,6 +446,11 @@
       ミューノの村をおそったのは<end_line>
       お前たちの方なんだろ！<end_line>
     </sjis>
+    <ascii>
+    Wait a minute!<end_line>
+    You're the one who<end_line>
+    attacked Murno's village!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -434,12 +458,12 @@
       ミューノの村をおそったのは<end_line>
       あんたたちの方なんでしょ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wait a minute!<end_line>
     You're the one who<end_line>
     attacked Murno's village!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -528,6 +552,11 @@
       いっしょに武器を作ってるんだよ<end_line>
       ハンマーあっただろ？<end_line>
     </sjis>
+    <ascii>
+    I craft weapons with<end_line>
+    <partner> over there.<end_line>
+    I had a hammer, right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -535,12 +564,12 @@
       いっしょに武器を作ってるの<end_line>
       ハンマーがあったでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I craft weapons with<end_line>
     <partner> over there.<end_line>
     I had a hammer, right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -567,6 +596,11 @@
       ハンマーは鍛冶師の命だぞ！<end_line>
       返せよ！<end_line>
     </sjis>
+    <ascii>
+    That's right!<end_line>
+    The hammer is a Craftknight's life!<end_line>
+    So give it back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -574,12 +608,12 @@
       ハンマーは鍛冶師の命なの！<end_line>
       返してよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's right!<end_line>
     The hammer is a Craftknight's life!<end_line>
     So give it back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -682,15 +716,18 @@
     <sjis>
       何か言いたそうだな？<end_line>
     </sjis>
+    <ascii>
+    Got something to say?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       何か言いたそうだね？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Got something to say?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -713,15 +750,18 @@
     <sjis>
       うるさいな<end_line>
     </sjis>
+    <ascii>
+    Oh, shut up.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うるさいよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, shut up.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -746,15 +786,18 @@
     <sjis>
       うるさいな<end_line>
     </sjis>
+    <ascii>
+    Oh, shut up.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うるさいよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, shut up.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -777,15 +820,18 @@
     <sjis>
       うるさいな<end_line>
     </sjis>
+    <ascii>
+    Oh, shut up.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うるさいよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, shut up.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1147,17 +1193,21 @@
       たしかめるって<three_dots><end_line>
       おっちゃんにわかるのか？<end_line>
     </sjis>
+    <ascii>
+    Confirm<three_dots>?<end_line>
+    Gramps, you believe me?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       たしかめるって<three_dots><end_line>
       おじさんにわかるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Confirm<three_dots>?<end_line>
     Gramps, you believe me?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -1184,6 +1234,11 @@
       だったらオレたちの実力を<end_line>
       見せつけてやろうぜ！<end_line>
     </sjis>
+    <ascii>
+    Oh<three_dots> I see.<end_line>
+    Then we'll show you<end_line>
+    our true strength!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1191,12 +1246,12 @@
       だったらわたしたちの実力を<end_line>
       見せてあげるわ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh<three_dots> I see.<end_line>
     Then we'll show you<end_line>
     our true strength!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 06/007_25296556_181feac.xml
+++ b/Day 06/007_25296556_181feac.xml
@@ -6,15 +6,18 @@
     <sjis>
       ここ、おっちゃんの工房か？<end_line>
     </sjis>
+    <ascii>
+    This is your workshop?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ここがおじさんの工房？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This is your workshop?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -41,6 +44,11 @@
       やっぱり何か武器を作るのか？<end_line>
       それとも剣のウデをたしかめるのか？<end_line>
     </sjis>
+    <ascii>
+    So, what do I need to do?<end_line>
+    Craft a weapon?<end_line>
+    Or prove my skill with a sword?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -48,12 +56,12 @@
       やっぱり何か武器を作るのかな？<end_line>
       それとも剣のウデをたしかめるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So, what do I need to do?<end_line>
     Craft a weapon?<end_line>
     Or prove my skill with a sword?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -80,6 +88,11 @@
       何でも答えてやるぜ！<end_line>
       いくぞ、<partner>！<end_line>
     </sjis>
+    <ascii>
+    Okay!<end_line>
+    Ask me anything!<end_line>
+    Let's do this, <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -87,12 +100,12 @@
       何でも答えてあげるわ！<end_line>
       いくよ、<partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay!<end_line>
     Ask me anything!<end_line>
     Let's do this, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 06/008_25297628_18202dc.xml
+++ b/Day 06/008_25297628_18202dc.xml
@@ -42,17 +42,21 @@
       武器の種類だな！<end_line>
       そんなの決まってるぜ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Weapon types, huh!<end_line>
+    It's obviously<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       武器の種類ね！<end_line>
       そんなの決まってるよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Weapon types, huh!<end_line>
     It's obviously<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <choice>
   <info box="left">
@@ -142,17 +146,21 @@
       一番重い武器だな！<end_line>
       それなら<three_dots><end_line>
     </sjis>
+    <ascii>
+    The heaviest weapon!<end_line>
+    That's<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       一番重い武器ね！<end_line>
       それなら<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The heaviest weapon!<end_line>
     That's<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <choice>
   <info box="left">
@@ -244,17 +252,21 @@
       武器作製で大切なもの<three_dots>？<end_line>
       それは<three_dots><end_line>
     </sjis>
+    <ascii>
+    The most important thing<three_dots>?<end_line>
+    That's<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       武器作製で大切なもの<three_dots>？<end_line>
       それは<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The most important thing<three_dots>?<end_line>
     That's<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <choice>
   <info box="left">

--- a/Day 06/009_25299180_18208ec.xml
+++ b/Day 06/009_25299180_18208ec.xml
@@ -18,6 +18,11 @@
       あったりまえだぜ！<end_line>
       鍛冶師だからな！<end_line>
     </sjis>
+    <ascii>
+    Ehehe.<end_line>
+    Of course!<end_line>
+    I am a Craftknight, after all!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -25,12 +30,12 @@
       あったりまえでしょ！<end_line>
       鍛冶師だからね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ehehe.<end_line>
     Of course!<end_line>
     I am a Craftknight, after all!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -135,6 +140,11 @@
       <three_dots>と折れた剣？<end_line>
       もしかして、修理しろってこと？<end_line>
     </sjis>
+    <ascii>
+    My hammer!<end_line>
+    <three_dots> And a broken sword?<end_line>
+    So, I'm supposed to repair it?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -142,12 +152,12 @@
       <three_dots>と折れた剣？<end_line>
       もしかして、これを修理するの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     My hammer!<end_line>
     <three_dots> And a broken sword?<end_line>
     So, I'm supposed to repair it?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -171,17 +181,21 @@
       よっし！<end_line>
       やってやるぜ！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Let's do this!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       やってあげるわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Let's do this!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -441,17 +455,21 @@
       お、おい<end_line>
       急にどうしたんだよ？<end_line>
     </sjis>
+    <ascii>
+    H-hey,<end_line>
+    what's going on?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ね、ねぇ<end_line>
       急にどうしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     H-hey,<end_line>
     what's going on?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">

--- a/Day 06/010_25301772_182130c.xml
+++ b/Day 06/010_25301772_182130c.xml
@@ -44,15 +44,18 @@
     <sjis>
       そうだろ？<end_line>
     </sjis>
+    <ascii>
+    Right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そうでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -115,17 +118,21 @@
       え～<end_line>
       それはないだろ～<end_line>
     </sjis>
+    <ascii>
+    What~<end_line>
+    No way~<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え～<end_line>
       それはないよ～<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What~<end_line>
     No way~<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 06/012_25302844_182173c.xml
+++ b/Day 06/012_25302844_182173c.xml
@@ -53,15 +53,18 @@
     <sjis>
       あのさ、ミューノってまだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Um, is Murno still<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ねぇ、ミューノってまだ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Um, is Murno still<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="simple" effect="big">
@@ -91,17 +94,21 @@
       なんだよ！？<end_line>
       おい！　何があった！？<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+    Hey! What happened!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに！？<end_line>
       ちょっと！　何があったの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
     Hey! What happened!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -111,17 +118,21 @@
       おーい！<end_line>
       一体どうなってんだよ！？<end_line>
     </sjis>
+    <ascii>
+    Heeelloooo!<end_line>
+    What's going on!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       もしもーし！<end_line>
       一体どうなってるの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Heeelloooo!<end_line>
     What's going on!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -131,17 +142,21 @@
       ダレだ？<end_line>
       ミューノ？<end_line>
     </sjis>
+    <ascii>
+    Who is it?<end_line>
+    Murno?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ダレ？<end_line>
       ミューノ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Who is it?<end_line>
     Murno?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -162,15 +177,18 @@
     <sjis>
       ダレだ、お前<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Who are you<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あなた、ダレ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Who are you<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -237,15 +255,18 @@
     <sjis>
       行きたいにきまってるだろ！<end_line>
     </sjis>
+    <ascii>
+    Of course I do!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       行きたいにきまってるでしょ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Of course I do!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -266,15 +287,18 @@
     <sjis>
       なんだと<three_dots>！？<end_line>
     </sjis>
+    <ascii>
+    What<three_dots>!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なんで<three_dots>！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What<three_dots>!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -362,6 +386,10 @@
       されるっていうのか！<end_line>
       ちくしょう！　させるか！<end_line>
     </sjis>
+    <ascii>
+    Murno's going to be food!?<end_line>
+    I won't let that happen!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -369,11 +397,11 @@
       されるっていうの！？<end_line>
       そんなの、絶対許せない！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Murno's going to be food!?<end_line>
     I won't let that happen!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Day 06/013_24488668_175aadc.xml
+++ b/Day 06/013_24488668_175aadc.xml
@@ -19,16 +19,19 @@
       <partner>を牢屋から<end_line>
       出してやらなくちゃ！<end_line>
     </sjis>
+    <ascii>
+    I have to free <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner>を牢屋から<end_line>
       出してあげなくちゃ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I have to free <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Day 06/014_25304780_1821ecc.xml
+++ b/Day 06/014_25304780_1821ecc.xml
@@ -5,15 +5,18 @@
     <sjis>
       うわっ、なんだ？<end_line>
     </sjis>
+    <ascii>
+    Woah, what?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うわっ、なによ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Woah, what?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -33,17 +36,21 @@
       ねてる<three_dots>？<end_line>
       <three_dots>んだよな？<end_line>
     </sjis>
+    <ascii>
+    Sleeping<three_dots>?<end_line>
+    <three_dots> Right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ねてる<three_dots>？<end_line>
       <three_dots>んだよね？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sleeping<three_dots>?<end_line>
     <three_dots> Right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -63,17 +70,21 @@
       とにかく、急がなくっちゃ<end_line>
       <partner>、何やってる！？<end_line>
     </sjis>
+    <ascii>
+    Anyway, we have to hurry!<end_line>
+    <partner>, what are you doing!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       とにかく、急がなくっちゃ<end_line>
       <partner>、何してるの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Anyway, we have to hurry!<end_line>
     <partner>, what are you doing!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -138,15 +149,19 @@
       そっか、待ってろ！<end_line>
       オレが開けてやる！<end_line>
     </sjis>
+    <ascii>
+    Okay, give me a minute!<end_line>
+    I'll figure something out!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっか、待ってて！<end_line>
       わたしが開けるから！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay, give me a minute!<end_line>
     I'll figure something out!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 06/015_25306044_18223bc.xml
+++ b/Day 06/015_25306044_18223bc.xml
@@ -1,21 +1,23 @@
-<dialogue>
-  <info box="left">
-  <portrait_l entry="player" eye="decided" mouth="tense">
-  <male>
-    <sjis>
+<male>
+  <sjis>
       カギがかかってる<three_dots><end_line>
       ハンマーならこわせそうだ<end_line>
     </sjis>
-  </male>
-  <female>
-    <sjis>
-      カギがかかってる<three_dots><end_line>
-      ハンマーならこわせるかも<end_line>
-    </sjis>
-  </female>
   <ascii>
     It's locked<three_dots><end_line>
     Maybe I can break it <end_line>
     with my hammer.<end_line>
   </ascii>
-</dialogue>
+</male>
+  <female>
+  <sjis>
+      カギがかかってる<three_dots><end_line>
+      ハンマーならこわせるかも<end_line>
+    </sjis>
+  <ascii>
+    It's locked<three_dots><end_line>
+    Maybe I can break it <end_line>
+    with my hammer.<end_line>
+  </ascii>
+</female>
+  

--- a/Day 06/016_25306652_182261c.xml
+++ b/Day 06/016_25306652_182261c.xml
@@ -18,17 +18,21 @@
       よし、開いたぞ！<end_line>
       <partner>！<end_line>
     </sjis>
+    <ascii>
+    There, it's open!<end_line>
+    <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よし、開いたよ！<end_line>
       <partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There, it's open!<end_line>
     <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -83,17 +87,21 @@
       待ってろ！<end_line>
       今すぐその腕輪を外してやるよ！<end_line>
     </sjis>
+    <ascii>
+    Just wait!<end_line>
+    I'll get those bracelets off!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       待ってて！<end_line>
       今すぐその腕輪を外してあげる！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Just wait!<end_line>
     I'll get those bracelets off!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -153,6 +161,11 @@
       あれ？<end_line>
       こうかな<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Okay, here we go<three_dots><end_line>
+    Hm?<end_line>
+    Is it this<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -160,12 +173,12 @@
       えーと？<end_line>
       これかな<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay, here we go<three_dots><end_line>
     Hm?<end_line>
     Is it this<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 06/018_25309164_1822fec.xml
+++ b/Day 06/018_25309164_1822fec.xml
@@ -5,17 +5,21 @@
     <sjis>
       村って、たしかコッチだったな<three_dots><end_line>
     </sjis>
+    <ascii>
+    If I remember correctly,<end_line>
+    the village is this way<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       村って<end_line>
       たしかコッチだったよね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     If I remember correctly,<end_line>
     the village is this way<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -48,15 +52,18 @@
     <sjis>
       なんだよ？<end_line>
     </sjis>
+    <ascii>
+    What?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -81,15 +88,18 @@
     <sjis>
       わかってるって！<end_line>
     </sjis>
+    <ascii>
+    I know, I know!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わかってるわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know, I know!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -128,15 +138,18 @@
     <sjis>
       わかってるって！<end_line>
     </sjis>
+    <ascii>
+    I know, I know!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わかってるわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know, I know!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -175,17 +188,21 @@
       なんだよ<end_line>
       ボーッとなんかしてないだろ！？<end_line>
     </sjis>
+    <ascii>
+    What?<end_line>
+    I'm totally focused!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ<end_line>
       ボーッとなんかしてないでしょ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What?<end_line>
     I'm totally focused!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -224,15 +241,18 @@
     <sjis>
       なんだよ、コワイのか？<end_line>
     </sjis>
+    <ascii>
+    What, are you scared?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、コワイの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What, are you scared?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -273,15 +293,19 @@
       <three_dots><end_line>
       わかりましたよ<end_line>
     </sjis>
+    <ascii>
+    <three_dots><end_line>
+    I know, I know.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots><end_line>
       わかったわよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots><end_line>
     I know, I know.<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 06/019_25352604_182d99c.xml
+++ b/Day 06/019_25352604_182d99c.xml
@@ -54,15 +54,19 @@
       人か<three_dots><end_line>
       こっちには行けないな<three_dots><end_line>
     </sjis>
+    <ascii>
+    There's someone there<three_dots><end_line>
+    Can't go this way<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       人か<three_dots><end_line>
       こっちには行けないね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There's someone there<three_dots><end_line>
     Can't go this way<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 06/021_25310652_18235bc.xml
+++ b/Day 06/021_25310652_18235bc.xml
@@ -58,6 +58,11 @@
       見つかっちゃうか<three_dots><end_line>
       気をつけないと<end_line>
     </sjis>
+    <ascii>
+    We might get caught<end_line>
+    if we head this way<three_dots><end_line>
+    We'll have to be careful.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -65,10 +70,10 @@
       見つかっちゃうね<three_dots><end_line>
       気をつけよう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We might get caught<end_line>
     if we head this way<three_dots><end_line>
     We'll have to be careful.<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 06/022_25311564_182394c.xml
+++ b/Day 06/022_25311564_182394c.xml
@@ -75,13 +75,16 @@
     <sjis>
       少しのぞいてみるか？<end_line>
     </sjis>
+    <ascii>
+    Shall we have a look?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       少しのぞいてみよっか？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Shall we have a look?<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 06/024_25312572_1823d3c.xml
+++ b/Day 06/024_25312572_1823d3c.xml
@@ -48,6 +48,11 @@
       道具とかのお金はちゃんとはらうしさ<end_line>
       いいじゃん<end_line>
     </sjis>
+    <ascii>
+    I can't ask if he's not here.<end_line>
+    I'll pay for whatever I use,<end_line>
+    it'll be fine.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -55,12 +60,12 @@
       道具とかのお金はちゃんとはらうし<end_line>
       いいじゃん<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I can't ask if he's not here.<end_line>
     I'll pay for whatever I use,<end_line>
     it'll be fine.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -97,6 +102,11 @@
       道具とかのお金はちゃんとはらうしさ<end_line>
       いいじゃん<end_line>
     </sjis>
+    <ascii>
+    I can't ask if he's not here.<end_line>
+    I'll pay for whatever I use,<end_line>
+    it'll be fine.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -104,12 +114,12 @@
       道具とかのお金はちゃんとはらうし<end_line>
       いいじゃん<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I can't ask if he's not here.<end_line>
     I'll pay for whatever I use,<end_line>
     it'll be fine.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -150,6 +160,11 @@
       工房を借りるんだよ！<end_line>
       道具とかはちゃんとお金をはらうよ<end_line>
     </sjis>
+    <ascii>
+    I'm not!<end_line>
+    I'm just borrowing!<end_line>
+    I'll pay for whatever I use.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -157,12 +172,12 @@
       工房を借りるの！<end_line>
       道具とかはちゃんとお金をはらうわよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm not!<end_line>
     I'm just borrowing!<end_line>
     I'll pay for whatever I use.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -201,6 +216,11 @@
       道具とかのお金はちゃんとはらうしさ<end_line>
       大丈夫だって、怒られないよ<end_line>
     </sjis>
+    <ascii>
+    I can't ask if he's not here.<end_line>
+    I'll pay for whatever I use.<end_line>
+    I'm sure he won't be angry.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -208,12 +228,12 @@
       道具とかのお金はちゃんとはらうし<end_line>
       大丈夫だって、怒られないよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I can't ask if he's not here.<end_line>
     I'll pay for whatever I use.<end_line>
     I'm sure he won't be angry.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 06/026_24484860_1759bfc.xml
+++ b/Day 06/026_24484860_1759bfc.xml
@@ -16,15 +16,19 @@
       ミューノは地下にいるらしいから<end_line>
       きっと下のトビラだ！<end_line>
     </sjis>
+    <ascii>
+    Murno's being held underground.<end_line>
+    There must be a way in!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ミューノは地下にいるらしいから<end_line>
       きっと下のトビラだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Murno's being held underground.<end_line>
     There must be a way in!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 06/027_25313916_182427c.xml
+++ b/Day 06/027_25313916_182427c.xml
@@ -8,6 +8,11 @@
       遺跡だな<three_dots><end_line>
       でっかい<three_dots><end_line>
     </sjis>
+    <ascii>
+    This is the ruins where<end_line>
+    their master is<three_dots><end_line>
+    It's huge<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -15,12 +20,12 @@
       遺跡ね<three_dots><end_line>
       おっきい<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This is the ruins where<end_line>
     their master is<three_dots><end_line>
     It's huge<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 06/029_25314988_18246ac.xml
+++ b/Day 06/029_25314988_18246ac.xml
@@ -8,6 +8,11 @@
       空気が冷たいな<three_dots><end_line>
       水のせいか？<end_line>
     </sjis>
+    <ascii>
+    Brr<three_dots><end_line>
+    It's cold in here<three_dots><end_line>
+    Is it because of the water?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -15,12 +20,12 @@
       空気が冷たいね<three_dots><end_line>
       水のせいかな？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Brr<three_dots><end_line>
     It's cold in here<three_dots><end_line>
     Is it because of the water?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -47,15 +52,18 @@
     <sjis>
       わかったよ<end_line>
     </sjis>
+    <ascii>
+    I know.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わかったわよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -80,15 +88,18 @@
     <sjis>
       わかったって！<end_line>
     </sjis>
+    <ascii>
+    Yeah, I know!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わかってるって！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, I know!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -113,15 +124,18 @@
     <sjis>
       わかったよ<end_line>
     </sjis>
+    <ascii>
+    I know.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わかったわよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -145,15 +159,18 @@
     <sjis>
       それもわかってるって！<end_line>
     </sjis>
+    <ascii>
+    Yeah, yeah, let's go already!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       それもわかってるわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, yeah, let's go already!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -181,16 +198,19 @@
       なんだよ<end_line>
       オレがなんかしたのかよ<end_line>
     </sjis>
+    <ascii>
+    Hey, what's your problem?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ<end_line>
       わたしがなんかした？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, what's your problem?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -216,17 +236,21 @@
       なんだよ、それ<end_line>
       もう、行くぞ！<end_line>
     </sjis>
+    <ascii>
+    Ugh.<end_line>
+    Alright, let's just keep moving!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ<end_line>
       もう、行くよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ugh.<end_line>
     Alright, let's just keep moving!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -252,17 +276,21 @@
       なんだよ<end_line>
       コワイのか？<end_line>
     </sjis>
+    <ascii>
+    Hm?<end_line>
+    Are you scared?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ<end_line>
       コワイの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hm?<end_line>
     Are you scared?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -289,13 +317,16 @@
     <sjis>
       わかったよ<end_line>
     </sjis>
+    <ascii>
+    I know.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わかったわよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know.<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 06/031_25316444_1824c5c.xml
+++ b/Day 06/031_25316444_1824c5c.xml
@@ -28,17 +28,21 @@
       大丈夫か！？<end_line>
       どうして、こんなところに！？<end_line>
     </sjis>
+    <ascii>
+    Are you okay!?<end_line>
+    Why are you here!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       大丈夫！？<end_line>
       なんで、ここに！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Are you okay!?<end_line>
     Why are you here!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -136,15 +140,18 @@
     <sjis>
       ケガ、してるのか？<end_line>
     </sjis>
+    <ascii>
+    Are you hurt?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ケガ、してるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Are you hurt?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -181,17 +188,21 @@
       ちょっと待って<end_line>
       ティエ、オレたちは<three_dots><end_line>
     </sjis>
+    <ascii>
+    Sorry, not yet.<end_line>
+    Tier, we're<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちょっと待ってよ<end_line>
       ティエ、わたしたちは<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sorry, not yet.<end_line>
     Tier, we're<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -311,17 +322,21 @@
       ティエをこのままにしとく<end_line>
       わけにはいかないからな<end_line>
     </sjis>
+    <ascii>
+    I won't leave you<end_line>
+    here alone, Tier.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ティエをこのままにしとく<end_line>
       わけにはいかないからね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I won't leave you<end_line>
     here alone, Tier.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -370,6 +385,11 @@
       今はミューノが大変なんだ！<end_line>
       早く行かないと！<end_line>
     </sjis>
+    <ascii>
+    I'm sorry, Tier.<end_line>
+    Murno is in danger!<end_line>
+    I have to help her!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -377,12 +397,12 @@
       今はミューノが大変なの！<end_line>
       早く行かないと！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm sorry, Tier.<end_line>
     Murno is in danger!<end_line>
     I have to help her!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -406,17 +426,21 @@
       なんだよ、それ<end_line>
       今はそういうこと<three_dots><end_line>
     </sjis>
+    <ascii>
+    Come on,<end_line>
+    now's not the time<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ<end_line>
       今はそういうこと<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Come on,<end_line>
     now's not the time<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -441,6 +465,11 @@
       おちつけよ！<end_line>
       ちょっと待てって！？<end_line>
     </sjis>
+    <ascii>
+    Hey, Tier,<end_line>
+    calm down!<end_line>
+    W-wait!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -448,10 +477,10 @@
       おちついてよ！<end_line>
       ねぇ、待ってってば！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, Tier,<end_line>
     calm down!<end_line>
     W-wait!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 06/032_25318732_182554c.xml
+++ b/Day 06/032_25318732_182554c.xml
@@ -7,6 +7,11 @@
       オレ、何してたんだっけ<three_dots>？<end_line>
       え～っと<three_dots><end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    What was I doing<three_dots>?<end_line>
+    Umm<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -14,12 +19,12 @@
       わたし、何してたんだっけ<three_dots>？<end_line>
       え～っと<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     What was I doing<three_dots>?<end_line>
     Umm<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -58,15 +63,18 @@
     <sjis>
       大丈夫か？　おい<three_dots><end_line>
     </sjis>
+    <ascii>
+    Are you okay? Hey<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       大丈夫？　ねぇ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Are you okay? Hey<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -123,16 +131,19 @@
       なんだよ<end_line>
       <partner>だって<three_dots><end_line>
     </sjis>
+    <ascii>
+    You forgot too<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ<end_line>
       <partner>だって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You forgot too<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -187,6 +198,10 @@
       <partner>だって、わかんないんじゃ<end_line>
       ないのか？<end_line>
     </sjis>
+    <ascii>
+    What,<end_line>
+    you don't know either?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -194,11 +209,11 @@
       <partner>も、わかんないんじゃ<end_line>
       ないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What,<end_line>
     you don't know either?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -243,6 +258,10 @@
       <partner>だって、わかんないんじゃ<end_line>
       ないのか？<end_line>
     </sjis>
+    <ascii>
+    What,<end_line>
+    you don't know either?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -250,11 +269,11 @@
       <partner>も、わかんないんじゃ<end_line>
       ないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What,<end_line>
     you don't know either?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -291,7 +310,7 @@
   </sjis>
   <ascii>
     Murno<three_dots>?<end_line>
-  </ascii> 
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 06/033_25320172_1825aec.xml
+++ b/Day 06/033_25320172_1825aec.xml
@@ -63,15 +63,18 @@
     <sjis>
       どういうことだよ？<end_line>
     </sjis>
+    <ascii>
+    Meaning?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どういうこと？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Meaning?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -108,15 +111,18 @@
     <sjis>
       どうやって消えたんだよ？<end_line>
     </sjis>
+    <ascii>
+    How did she disappear?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうやって消えたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How did she disappear?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -170,17 +176,21 @@
       <three_dots>って、なんだよそれ！？<end_line>
       人が消えるわけないだろ？<end_line>
     </sjis>
+    <ascii>
+    <three_dots> What!?<end_line>
+    People don't just disappear, right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>って、なによそれ！？<end_line>
       人が消えるわけないでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots> What!?<end_line>
     People don't just disappear, right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -209,6 +219,11 @@
       さっきのティエは<end_line>
       人じゃないって<three_dots><end_line>
     </sjis>
+    <ascii>
+    Wait, so does that mean<three_dots><end_line>
+    The Tier we saw just<end_line>
+    now isn't human<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -216,12 +231,12 @@
       さっきのティエは<end_line>
       人じゃないって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wait, so does that mean<three_dots><end_line>
     The Tier we saw just<end_line>
     now isn't human<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <partner name="enzi">
@@ -275,17 +290,21 @@
       <three_dots>って、なんだよそれ！？<end_line>
       人が消えるわけないだろ？<end_line>
     </sjis>
+    <ascii>
+    <three_dots> What!?<end_line>
+    People don't just disappear, right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>って、なによそれ！？<end_line>
       人が消えるわけないでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots> What!?<end_line>
     People don't just disappear, right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -312,6 +331,11 @@
       さっきのティエは<end_line>
       人じゃないって<three_dots><end_line>
     </sjis>
+    <ascii>
+    Wait, so does that mean<three_dots><end_line>
+    The Tier we saw just<end_line>
+    now isn't human<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -319,12 +343,12 @@
       さっきのティエは<end_line>
       人じゃないって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wait, so does that mean<three_dots><end_line>
     The Tier we saw just<end_line>
     now isn't human<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <partner name="killfith">
@@ -378,17 +402,21 @@
       オレが聞いてるんだって！<end_line>
       魔法とかじゃないのかよ？<end_line>
     </sjis>
+    <ascii>
+    Don't ask me!<end_line>
+    Was it magic or something?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしが聞いてるんだけど<three_dots><end_line>
       魔法とかじゃないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't ask me!<end_line>
     Was it magic or something?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -416,17 +444,21 @@
       だといいけどな<three_dots><end_line>
       もしかして<three_dots><end_line>
     </sjis>
+    <ascii>
+    That'd be nice<three_dots><end_line>
+    But maybe<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       だといいけど<three_dots><end_line>
       もしかすると<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That'd be nice<three_dots><end_line>
     But maybe<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -464,15 +496,18 @@
     <sjis>
       そ、そうだった！<end_line>
     </sjis>
+    <ascii>
+    R-right!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そ、そうだね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     R-right!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 06/034_25805740_189c3ac.xml
+++ b/Day 06/034_25805740_189c3ac.xml
@@ -16,15 +16,19 @@
       近くに誰かいるみたいだ<three_dots><end_line>
       たしかめてみよう<end_line>
     </sjis>
+    <ascii>
+    There's someone there<three_dots><end_line>
+    Let's have a look.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       近くに誰かいるみたい<three_dots><end_line>
       行ってみよう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There's someone there<three_dots><end_line>
     Let's have a look.<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 06/035_25322156_18262ac.xml
+++ b/Day 06/035_25322156_18262ac.xml
@@ -16,17 +16,21 @@
       なんだ？<end_line>
       今の声、親方<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Hm?<end_line>
+    Was that Master<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに？<end_line>
       今の声、親方<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hm?<end_line>
     Was that Master<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -94,15 +98,19 @@
       あれ<three_dots>？<end_line>
       誰かいるぞ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Huh<three_dots>?<end_line>
+    Someone's there<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あれ<three_dots>？<end_line>
       誰かいる<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh<three_dots>?<end_line>
     Someone's there<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 06/036_25323196_18266bc.xml
+++ b/Day 06/036_25323196_18266bc.xml
@@ -87,16 +87,19 @@
       オレたちは大丈夫だけど<end_line>
       ミューノが<three_dots><end_line>
     </sjis>
+    <ascii>
+    We're fine, but Murno is<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしたちは大丈夫だけど<end_line>
       ミューノが<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We're fine, but Murno is<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -280,6 +283,11 @@
       そのかわりミューノのこと<end_line>
       たのんだぜ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Okay<three_dots> I'll go back<three_dots><end_line>
+    You have to protect her<end_line>
+    in my place<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -287,12 +295,12 @@
       そのかわりミューノのこと<end_line>
       たのんだからね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay<three_dots> I'll go back<three_dots><end_line>
     You have to protect her<end_line>
     in my place<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -343,6 +351,10 @@
       ミューノが心配なんだ！<end_line>
       オレも助けに行きたいよ！<end_line>
     </sjis>
+    <ascii>
+    I can't not worry about her!<end_line>
+    I'm going too!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -350,11 +362,11 @@
       ミューノが心配だよ！<end_line>
       わたしも助けに行く！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I can't not worry about her!<end_line>
     I'm going too!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 06/037_25326620_182741c.xml
+++ b/Day 06/037_25326620_182741c.xml
@@ -6,17 +6,21 @@
       なんだ<three_dots>？<end_line>
       ふたりとも、感じが全然ちがう<three_dots><end_line>
     </sjis>
+    <ascii>
+    What's with them<three_dots>?<end_line>
+    They were acting so different<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なにこれ<three_dots>？<end_line>
       ふたりとも、感じが全然ちがう<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's with them<three_dots>?<end_line>
     They were acting so different<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -26,17 +30,21 @@
       おい！？<end_line>
       またかよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Huh!?<end_line>
+    Gone again<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あれ！？<end_line>
       またなの<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh!?<end_line>
     Gone again<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -79,6 +87,10 @@
       ここで悩んでてもしかたないな<end_line>
       とにかく前に進もうぜ！<end_line>
     </sjis>
+    <ascii>
+    Well, no point worrying about it.<end_line>
+    Let's just keep going!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -86,11 +98,11 @@
       ここで悩んでてもしかたないよ<end_line>
       とにかく前に進もう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, no point worrying about it.<end_line>
     Let's just keep going!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -119,6 +131,10 @@
       ここで悩んでてもしかたないな<end_line>
       とにかく前に進もうぜ！<end_line>
     </sjis>
+    <ascii>
+    Well, no point worrying about it.<end_line>
+    Let's just keep going!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -126,11 +142,11 @@
       ここで悩んでてもしかたないよ<end_line>
       とにかく前に進もう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, no point worrying about it.<end_line>
     Let's just keep going!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -159,6 +175,10 @@
       ここで悩んでてもしかたないな<end_line>
       とにかく前に進もうぜ！<end_line>
     </sjis>
+    <ascii>
+    Well, no point worrying about it.<end_line>
+    Let's just keep going!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -166,11 +186,11 @@
       ここで悩んでてもしかたないよ<end_line>
       とにかく前に進もう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, no point worrying about it.<end_line>
     Let's just keep going!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -199,6 +219,11 @@
       考えててもしかたない<end_line>
       行くぜ！<end_line>
     </sjis>
+    <ascii>
+    I see.<end_line>
+    Well, no point worrying about it.<end_line>
+    Let's just keep going!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -206,10 +231,10 @@
       考えててもしかたないから<end_line>
       行こう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see.<end_line>
     Well, no point worrying about it.<end_line>
     Let's just keep going!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 06/039_25328124_18279fc.xml
+++ b/Day 06/039_25328124_18279fc.xml
@@ -66,6 +66,11 @@
       ケガしてないか？<end_line>
       それに、ヌシさまってヤツは<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Murno, are you okay?<end_line>
+    Any injuries?<end_line>
+    And where's that master thing<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -73,12 +78,12 @@
       ケガしてない？<end_line>
       それに、ヌシさまってのは<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Murno, are you okay?<end_line>
     Any injuries?<end_line>
     And where's that master thing<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -129,15 +134,18 @@
     <sjis>
       あ、ああ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Y-yeah<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       う、うん<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Y-yeah<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <choice>
   <info box="left">

--- a/Day 06/040_25331020_182854c.xml
+++ b/Day 06/040_25331020_182854c.xml
@@ -180,6 +180,11 @@
       仲間<three_dots>？<end_line>
       な<three_dots>、なに言ってるんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Murno<three_dots><end_line>
+    You're Voijin's accomplice<three_dots>?<end_line>
+    Wha<three_dots> What are you saying<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -187,12 +192,12 @@
       仲間<three_dots>？<end_line>
       な<three_dots>、なに言ってるの<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Murno<three_dots><end_line>
     You're Voijin's accomplice<three_dots>?<end_line>
     Wha<three_dots> What are you saying<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -468,6 +473,10 @@
       仲間<three_dots>？<end_line>
       な<three_dots>、なに言ってるんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    You're Voijin's accomplice<three_dots>?<end_line>
+    Wha<three_dots> What are you saying<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -475,11 +484,11 @@
       仲間<three_dots>？<end_line>
       な<three_dots>、なに言ってるの<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're Voijin's accomplice<three_dots>?<end_line>
     Wha<three_dots> What are you saying<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -754,6 +763,10 @@
       仲間<three_dots>？<end_line>
       な<three_dots>、なに言ってるんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    You're Voijin's accomplice<three_dots>?<end_line>
+    Wha<three_dots> What are you saying<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -761,11 +774,11 @@
       仲間<three_dots>？<end_line>
       な<three_dots>、なに言ってるの<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're Voijin's accomplice<three_dots>?<end_line>
     Wha<three_dots> What are you saying<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1041,6 +1054,10 @@
       仲間<three_dots>？<end_line>
       な<three_dots>、なに言ってるんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    You're Voijin's accomplice<three_dots>?<end_line>
+    Wha<three_dots> What are you saying<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1048,11 +1065,11 @@
       仲間<three_dots>？<end_line>
       な<three_dots>、なに言ってるの<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're Voijin's accomplice<three_dots>?<end_line>
     Wha<three_dots> What are you saying<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 06/041_25333804_182902c.xml
+++ b/Day 06/041_25333804_182902c.xml
@@ -32,17 +32,21 @@
       オレは<three_dots><end_line>
       オレは<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    I<three_dots><end_line>
+    I<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしは<three_dots><end_line>
       わたしは<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I<three_dots><end_line>
     I<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <choice>
   <info box="left">
@@ -234,17 +238,21 @@
       お前は<three_dots>！？<end_line>
       こいつ<three_dots>、一体どういう<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    You're<three_dots>!?<end_line>
+    Wha<three_dots> What's going on<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんたは<three_dots>！？<end_line>
       これって<three_dots>、一体どういう<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're<three_dots>!?<end_line>
     Wha<three_dots> What's going on<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <player gender="male">
@@ -314,15 +322,18 @@
     <sjis>
       だまれ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Shut up<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       だまってよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Shut up<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -332,15 +343,18 @@
     <sjis>
       早く戻ろうぜ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Go back<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       早く戻ろうよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Go back<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -350,15 +364,18 @@
     <sjis>
       だまれって言ってるだろ！<end_line>
     </sjis>
+    <ascii>
+    I said, shut up!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       だまってって言ってるでしょ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I said, shut up!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>#Believe Murno
   <info box="nobox">
@@ -367,17 +384,21 @@
       わかった<three_dots><end_line>
       戻ろう<three_dots><end_line>
     </sjis>
+    <ascii>
+    Okay<three_dots><end_line>
+    Let's leave<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わかったわ<three_dots><end_line>
       戻ろう<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay<three_dots><end_line>
     Let's leave<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -414,6 +435,10 @@
       でもニセモノだって<end_line>
       どうやって証明するんだよ！<end_line>
     </sjis>
+    <ascii>
+    Even if that's true,<end_line>
+    how are we supposed to prove it!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -421,11 +446,11 @@
       でもニセモノだって<end_line>
       どうやって証明するの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Even if that's true,<end_line>
     how are we supposed to prove it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -450,6 +475,10 @@
       こんなところに残しておくわけには<end_line>
       いかないだろ<end_line>
     </sjis>
+    <ascii>
+    Without proof, we can't just<end_line>
+    leave her alone here, right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -457,11 +486,11 @@
       こんなところに残しておくわけには<end_line>
       いかないじゃない<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Without proof, we can't just<end_line>
     leave her alone here, right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -566,6 +595,10 @@
       でもニセモノだって<end_line>
       どうやって証明するんだよ！<end_line>
     </sjis>
+    <ascii>
+    Even if that's true,<end_line>
+    how are we supposed to prove it!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -573,11 +606,11 @@
       でもニセモノだって<end_line>
       どうやって証明するの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Even if that's true,<end_line>
     how are we supposed to prove it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -601,6 +634,10 @@
       こんなところに残しておくわけには<end_line>
       いかないだろ<end_line>
     </sjis>
+    <ascii>
+    Without proof, we can't risk<end_line>
+    leaving her here alone, right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -608,11 +645,11 @@
       こんなところに残しておくわけには<end_line>
       いかないじゃない<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Without proof, we can't risk<end_line>
     leaving her here alone, right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -720,6 +757,10 @@
       でもニセモノだって<end_line>
       証明できるのか！？<end_line>
     </sjis>
+    <ascii>
+    I do, but<three_dots><end_line>
+    Can you prove she's an imposter?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -727,11 +768,11 @@
       でもニセモノだって<end_line>
       証明できるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I do, but<three_dots><end_line>
     Can you prove she's an imposter?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -754,6 +795,10 @@
       ミューノをこんなところに<end_line>
       残しておくわけにはいかないだろ<end_line>
     </sjis>
+    <ascii>
+    Without proof, we can't risk<end_line>
+    leaving her here alone, right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -761,11 +806,11 @@
       ミューノをこんなところに<end_line>
       残しておけないでしょ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Without proof, we can't risk<end_line>
     leaving her here alone, right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -876,6 +921,10 @@
       でもニセモノだって<end_line>
       どうやって証明するんだよ！<end_line>
     </sjis>
+    <ascii>
+    Even if that's true,<end_line>
+    we have no way to prove it!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -883,11 +932,11 @@
       でもニセモノだって<end_line>
       どうやって証明するの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Even if that's true,<end_line>
     we have no way to prove it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -912,6 +961,10 @@
       こんなところに残しておくわけには<end_line>
       いかないだろ<end_line>
     </sjis>
+    <ascii>
+    Without proof, we can't risk<end_line>
+    leaving her here alone, right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -919,11 +972,11 @@
       こんなところに残しておくわけには<end_line>
       いかないじゃない<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Without proof, we can't risk<end_line>
     leaving her here alone, right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 06/042_25337052_1829cdc.xml
+++ b/Day 06/042_25337052_1829cdc.xml
@@ -324,17 +324,21 @@
       な、なんだよ<end_line>
       こっちこそよろしくたのむよ<end_line>
     </sjis>
+    <ascii>
+    Uh, right.<end_line>
+    Same to you.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な、なによ<end_line>
       こっちこそよろしくね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uh, right.<end_line>
     Same to you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -371,15 +375,18 @@
     <sjis>
       おう！<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -480,17 +487,21 @@
       な、なんだよ<end_line>
       こっちこそよろしくたのむよ<end_line>
     </sjis>
+    <ascii>
+    Uh, right.<end_line>
+    Same to you.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な、なによ<end_line>
       こっちこそよろしくね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uh, right.<end_line>
     Same to you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -628,6 +639,11 @@
       オレはミューノのことばっか<end_line>
       考えてるワケじゃ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Wh-what?<end_line>
+    Of course I think about<end_line>
+    other things<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -635,12 +651,12 @@
       わたしはミューノのことばっか<end_line>
       考えてるワケじゃ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wh-what?<end_line>
     Of course I think about<end_line>
     other things<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -773,17 +789,21 @@
       な、なんだよ<end_line>
       こっちこそよろしくたのむよ<end_line>
     </sjis>
+    <ascii>
+    Uh, right.<end_line>
+    Same to you.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な、なによ<end_line>
       こっちこそよろしくね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uh, right.<end_line>
     Same to you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 06/044_25339756_182a76c.xml
+++ b/Day 06/044_25339756_182a76c.xml
@@ -21,16 +21,19 @@
       お<three_dots><end_line>
       お前ら<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Anise<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ<three_dots><end_line>
       あんたたち<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Anise<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -56,17 +59,21 @@
       キサマ<three_dots>！<end_line>
       ミューノを返せ！<end_line>
     </sjis>
+    <ascii>
+    You<three_dots>!<end_line>
+    Give Murno back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんた<three_dots>！<end_line>
       ミューノを返して！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You<three_dots>!<end_line>
     Give Murno back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -91,6 +98,11 @@
       お前たちがここでミューノを<end_line>
       ヌシさまってヤツのエサに<three_dots><end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+    Didn't you bring her here<end_line>
+    to feed her to your master<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -98,12 +110,12 @@
       あんたたちがここでミューノを<end_line>
       ヌシさまって召喚獣のエサに<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
     Didn't you bring her here<end_line>
     to feed her to your master<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -141,15 +153,18 @@
     <sjis>
       言い訳だと！？<end_line>
     </sjis>
+    <ascii>
+    Excuse!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       言い訳！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Excuse!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -175,17 +190,21 @@
       <three_dots>何言ってるんだ！<end_line>
       ミューノはどこに<three_dots>！？<end_line>
     </sjis>
+    <ascii>
+    <three_dots> What are you talking about!?<end_line>
+    Where's Murno<three_dots>!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>何言ってるの！<end_line>
       ミューノはどこなの<three_dots>！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots> What are you talking about!?<end_line>
     Where's Murno<three_dots>!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -219,15 +238,18 @@
     <sjis>
       どういう意味だ、それ！？<end_line>
     </sjis>
+    <ascii>
+    What's that supposed to mean!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どういう意味よ、それ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's that supposed to mean!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -274,15 +296,18 @@
     <sjis>
       どういうことだよ！<end_line>
     </sjis>
+    <ascii>
+    What's that supposed to mean!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どういうこと！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's that supposed to mean!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -307,16 +332,19 @@
       な<three_dots><end_line>
       なんだって！？<end_line>
     </sjis>
+    <ascii>
+    Wh-what!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な<three_dots><end_line>
       なによそれ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wh-what!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -339,15 +367,18 @@
     <sjis>
       どういうことだよ！<end_line>
     </sjis>
+    <ascii>
+    What's that supposed to mean!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どういうこと！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's that supposed to mean!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -373,16 +404,19 @@
       な<three_dots><end_line>
       なんだって！？<end_line>
     </sjis>
+    <ascii>
+    Wh-what!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な<three_dots><end_line>
       なによそれ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wh-what!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -405,15 +439,18 @@
     <sjis>
       どういうことだよ！<end_line>
     </sjis>
+    <ascii>
+    What's that supposed to mean!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どういうこと！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's that supposed to mean!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -439,16 +476,19 @@
       な<three_dots><end_line>
       なんだって！？<end_line>
     </sjis>
+    <ascii>
+    Wh-what!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な<three_dots><end_line>
       なによそれ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wh-what!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -609,15 +649,18 @@
     <sjis>
       でかい<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    It's huge<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       おっきい<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's huge<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -646,6 +689,11 @@
       こんなヤツと戦って、オレは<end_line>
       生きていられるのか<three_dots><end_line>
     </sjis>
+    <ascii>
+    This is bad<three_dots><end_line>
+    Can I survive a<end_line>
+    fight with that<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -653,12 +701,12 @@
       こんなのと戦って、わたし<end_line>
       生きていられるかな<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This is bad<three_dots><end_line>
     Can I survive a<end_line>
     fight with that<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -725,6 +773,11 @@
       こんなヤツと戦って、オレは<end_line>
       生きていられるのか<three_dots><end_line>
     </sjis>
+    <ascii>
+    This is bad<three_dots><end_line>
+    Can I survive a<end_line>
+    fight with that<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -732,12 +785,12 @@
       こんなのと戦って、わたし<end_line>
       生きていられるかな<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This is bad<three_dots><end_line>
     Can I survive a<end_line>
     fight with that<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -804,6 +857,11 @@
       こんなヤツと戦って、オレは<end_line>
       生きていられるのか<three_dots><end_line>
     </sjis>
+    <ascii>
+    This is bad<three_dots><end_line>
+    Can I survive a<end_line>
+    fight with that<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -811,12 +869,12 @@
       こんなのと戦って、わたし<end_line>
       生きていられるかな<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This is bad<three_dots><end_line>
     Can I survive a<end_line>
     fight with that<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -883,6 +941,11 @@
       こんなヤツと戦って、オレは<end_line>
       生きていられるのか<three_dots><end_line>
     </sjis>
+    <ascii>
+    This is bad<three_dots><end_line>
+    Can I survive a<end_line>
+    fight with that<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -890,12 +953,12 @@
       こんなのと戦って、わたし<end_line>
       生きていられるかな<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This is bad<three_dots><end_line>
     Can I survive a<end_line>
     fight with that<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 06/045_25343244_182b50c.xml
+++ b/Day 06/045_25343244_182b50c.xml
@@ -50,17 +50,21 @@
       よし、<partner>！<end_line>
       カクゴきめて、行くぞ！<end_line>
     </sjis>
+    <ascii>
+    Okay, <partner>!<end_line>
+    Get ready, here we go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner>！<end_line>
       カクゴきめて、行くよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay, <partner>!<end_line>
     Get ready, here we go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -142,17 +146,21 @@
       <partner>！<end_line>
       お前<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    <partner>!<end_line>
+    You<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner>！<end_line>
       あなた<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner>!<end_line>
     You<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -174,17 +182,21 @@
       <partner>、お前<three_dots><end_line>
       カッコイイぜ！<end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots><end_line>
+    You look awesome!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner>、あなた<three_dots><end_line>
       カッコイイよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots><end_line>
     You look awesome!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -257,17 +269,21 @@
       よし、<partner>！<end_line>
       カクゴきめて、行くぞ！<end_line>
     </sjis>
+    <ascii>
+    Okay, <partner>!<end_line>
+    Get ready, here we go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner>！<end_line>
       カクゴきめて、行くよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay, <partner>!<end_line>
     Get ready, here we go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -379,17 +395,21 @@
       <partner>！<end_line>
       お前<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    <partner>!<end_line>
+    You<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner>！<end_line>
       あなた<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner>!<end_line>
     You<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -411,17 +431,21 @@
       <partner>、お前<three_dots><end_line>
       カッコイイぜ！<end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots><end_line>
+    You look awesome!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner>、あなた<three_dots><end_line>
       カッコイイよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots><end_line>
     You look awesome!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -496,17 +520,21 @@
       よし、<partner>！<end_line>
       カクゴきめて、行くぞ！<end_line>
     </sjis>
+    <ascii>
+    Okay, <partner>!<end_line>
+    Get ready, here we go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner>！<end_line>
       カクゴきめて、行くよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay, <partner>!<end_line>
     Get ready, here we go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -603,17 +631,21 @@
       <partner>！<end_line>
       お前<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    <partner>!<end_line>
+    You<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner>！<end_line>
       あなた<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner>!<end_line>
     You<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -637,17 +669,21 @@
       <partner>、お前<three_dots><end_line>
       カッコイイぜ！<end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots><end_line>
+    You look awesome!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner>、あなた<three_dots><end_line>
       カッコイイよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots><end_line>
     You look awesome!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -720,17 +756,21 @@
       よし、<partner>！<end_line>
       カクゴきめて、行くぞ！<end_line>
     </sjis>
+    <ascii>
+    Okay, <partner>!<end_line>
+    Get ready, here we go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner>！<end_line>
       カクゴきめて、行くよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay, <partner>!<end_line>
     Get ready, here we go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -842,17 +882,21 @@
       <partner>！<end_line>
       お前<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    <partner>!<end_line>
+    You<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner>！<end_line>
       あなた<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner>!<end_line>
     You<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -874,17 +918,21 @@
       ああ<three_dots><end_line>
       カッコイイぜ！<end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots><end_line>
+    You look awesome!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん<three_dots><end_line>
       カッコイイよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots><end_line>
     You look awesome!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 06/046_25346348_182c12c.xml
+++ b/Day 06/046_25346348_182c12c.xml
@@ -462,6 +462,11 @@
       そこまでわかるなんて<end_line>
       まるで現場にいたみたいじゃないか<three_dots><end_line>
     </sjis>
+    <ascii>
+    On the contrary, for you to know<end_line>
+    so much from their explanation,<end_line>
+    it's almost as if you were there<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -469,12 +474,12 @@
       そこまでわかるなんて<end_line>
       まるで現場にいたみたいじゃないか<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     On the contrary, for you to know<end_line>
     so much from their explanation,<end_line>
     it's almost as if you were there<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -589,15 +594,18 @@
     <sjis>
       なっ！　なんだと！<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なっ！　なによ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -869,17 +877,21 @@
       どうしたんだ？<end_line>
       なにかあった？<end_line>
     </sjis>
+    <ascii>
+    What's wrong?<end_line>
+    What happened?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしたの？<end_line>
       なにかあった？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's wrong?<end_line>
     What happened?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1047,6 +1059,11 @@
       オレたちじゃ弱すぎるって言うのか！<end_line>
       なんなら勝負してみるか？<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+    So you're saying we're too weak?<end_line>
+    Why don't we show you then?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1054,12 +1071,12 @@
       わたしたちじゃ弱すぎるって言うの？<end_line>
       なんなら勝負してみる？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
     So you're saying we're too weak?<end_line>
     Why don't we show you then?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -1268,15 +1285,19 @@
       いいんじゃないの？<end_line>
       オレたちも戻ろう<end_line>
     </sjis>
+    <ascii>
+    Sounds good to me.<end_line>
+    Let's head back.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       いいんじゃない？<end_line>
       わたしたちも戻ろう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sounds good to me.<end_line>
     Let's head back.<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 06/050_25354380_182e08c.xml
+++ b/Day 06/050_25354380_182e08c.xml
@@ -54,24 +54,29 @@
 	<portrait_l entry="player" eye="surprised" mouth="stressed">
 	<portrait_r entry="murno" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そんなこと気にしなくていいよ<end_line>
 			あの魔晶柱ってやつには何かヒミツが<end_line>
 			かくされてるかもしれないんだろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そんなこと気にしなくていいよ<end_line>
-			あの魔晶柱ってのには、何かヒミツが<end_line>
-			かくされてるかもしれないんでしょ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Don't worry about it.<end_line>
     There might be some kind of secret<end_line>
     behind that Crystal Pillar.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そんなこと気にしなくていいよ<end_line>
+			あの魔晶柱ってのには、何かヒミツが<end_line>
+			かくされてるかもしれないんでしょ？<end_line>
+		</sjis>
+    <ascii>
+    Don't worry about it.<end_line>
+    There might be some kind of secret<end_line>
+    behind that Crystal Pillar.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -107,7 +112,7 @@
 	<portrait_l entry="player" eye="surprised_blush" mouth="tense">
 	<portrait_r entry="murno" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			え！　いや<three_dots><end_line>
 			そんなことないよ<three_dots><end_line>
 		</sjis>
@@ -115,9 +120,9 @@
       Eh! No<three_dots><end_line>
       I'm really not<three_dots><end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			え！　あの<three_dots><end_line>
 			そんなことないよ<three_dots><end_line>
 		</sjis>
@@ -125,7 +130,7 @@
       Eh! Um<three_dots><end_line>
       I'm really not<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -146,23 +151,27 @@
 	<portrait_l entry="player" eye="sad" mouth="neutral">
 	<portrait_r entry="murno" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ホント、まんまと<end_line>
 			だまされちまったよなぁ<end_line>
 			かっこわるいぜ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Anise really fooled us<three_dots><end_line>
+    I'm so lame<three_dots><end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			ホント、まんまと<end_line>
 			だまされちゃったよね<three_dots><end_line>
 			かっこわるいよ<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise really fooled us<three_dots><end_line>
     I'm so lame<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">

--- a/Day 06/051_25355852_182e64c.xml
+++ b/Day 06/051_25355852_182e64c.xml
@@ -179,6 +179,11 @@
       変身してオレを守ってくれてさ<end_line>
       すっげぇカッコよかったぜ<end_line>
     </sjis>
+    <ascii>
+    Yeah, like when you<end_line>
+    transformed to protect me.<end_line>
+    You were super cool.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -186,12 +191,12 @@
       変身してわたしを守ってくれてさ<end_line>
       すっごいカッコよかったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, like when you<end_line>
     transformed to protect me.<end_line>
     You were super cool.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -230,15 +235,18 @@
     <sjis>
       な、なんで泣くんだよ！？<end_line>
     </sjis>
+    <ascii>
+    Wh-why are you crying!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な、なんで泣くの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wh-why are you crying!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -266,17 +274,21 @@
       熱くなったってこと？<end_line>
       もしかしてテレてたのか？<end_line>
     </sjis>
+    <ascii>
+    Overheating?<end_line>
+    Are you embarrassed?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       熱くなったってこと？<end_line>
       もしかしてテレてたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Overheating?<end_line>
     Are you embarrassed?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -304,17 +316,21 @@
       ん？<end_line>
       どうした？<end_line>
     </sjis>
+    <ascii>
+    Hm?<end_line>
+    What's wrong?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん？<end_line>
       どうしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hm?<end_line>
     What's wrong?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -503,6 +519,11 @@
       とられてちゃカッコワルイからな<end_line>
       オレもがんばらないと<end_line>
     </sjis>
+    <ascii>
+    But I can't let you have<end_line>
+    all of the cool bits.<end_line>
+    I've got to work harder.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -510,12 +531,12 @@
       とられてちゃカッコワルイからね<end_line>
       わたしもがんばらないと<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     But I can't let you have<end_line>
     all of the cool bits.<end_line>
     I've got to work harder.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -544,6 +565,11 @@
       でっかいトラに変身してさ<end_line>
       すっげぇカッコよかったぜ<end_line>
     </sjis>
+    <ascii>
+    Yeah!  Like when you<end_line>
+    transformed into a tiger.<end_line>
+    That was awesome.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -551,12 +577,12 @@
       おっきいトラに変身してさ<end_line>
       すっごくカッコよかったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!  Like when you<end_line>
     transformed into a tiger.<end_line>
     That was awesome.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -585,6 +611,11 @@
       忘れてたよ、ごめんごめん<end_line>
       でもよかったな、元に戻れて<end_line>
     </sjis>
+    <ascii>
+    R-right,<end_line>
+    I forgot, sorry.<end_line>
+    That's good though.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -592,12 +623,12 @@
       忘れてたよ、ごめんごめん<end_line>
       でもよかったね、元に戻れて<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     R-right,<end_line>
     I forgot, sorry.<end_line>
     That's good though.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -639,17 +670,21 @@
       単純だけど大切な気持ち？<end_line>
       なんだよそれ？<end_line>
     </sjis>
+    <ascii>
+    Simple, yet important feeling?<end_line>
+    What's that?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       単純だけど大切な気持ち？<end_line>
       なによそれ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Simple, yet important feeling?<end_line>
     What's that?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -678,6 +713,11 @@
       え～<three_dots>？<end_line>
       わかんないよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I did?<end_line>
+    Ehh<three_dots>?<end_line>
+    I don't get it<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -685,12 +725,12 @@
       え～<three_dots>？<end_line>
       わかんないよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I did?<end_line>
     Ehh<three_dots>?<end_line>
     I don't get it<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -757,6 +797,10 @@
       明日の勝負のことを<end_line>
       考えてただけだよ<end_line>
     </sjis>
+    <ascii>
+    Well<three_dots><end_line>
+    I was thinking about tomorrow.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -764,11 +808,11 @@
       明日の勝負のことを<end_line>
       考えてただけだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well<three_dots><end_line>
     I was thinking about tomorrow.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -871,6 +915,11 @@
       変身とかされて助けられちゃな<three_dots><end_line>
       素直にもなるさ<end_line>
     </sjis>
+    <ascii>
+    Well, you were really cool,<end_line>
+    transforming and saving me<three_dots><end_line>
+    Course I'd be honest.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -878,12 +927,12 @@
       変身とかされて助けられたらね<three_dots><end_line>
       素直にもなるよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, you were really cool,<end_line>
     transforming and saving me<three_dots><end_line>
     Course I'd be honest.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -912,6 +961,11 @@
       忘れてたよ、悪い悪い<end_line>
       でもよかったな、元に戻れて<end_line>
     </sjis>
+    <ascii>
+    R-right,<end_line>
+    I forgot, sorry.<end_line>
+    That's good though.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -919,12 +973,12 @@
       忘れてたよ、ごめんごめん<end_line>
       でもよかったね、元に戻れて<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     R-right,<end_line>
     I forgot, sorry.<end_line>
     That's good though.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -951,15 +1005,18 @@
     <sjis>
       あんなことってなんだよ？<end_line>
     </sjis>
+    <ascii>
+    What do you mean?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんなことってなに？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What do you mean?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -984,6 +1041,11 @@
       なんで怒るんだよ<three_dots><end_line>
       <three_dots>ってなんで赤くなってんだ？<end_line>
     </sjis>
+    <ascii>
+    What?<end_line>
+    Why are you angry<three_dots><end_line>
+    <three_dots>Hey, why's your face red?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -991,12 +1053,12 @@
       なんで怒るのよ<three_dots><end_line>
       <three_dots>ってなんで赤くなってるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What?<end_line>
     Why are you angry<three_dots><end_line>
     <three_dots>Hey, why's your face red?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1025,6 +1087,11 @@
       トラムの前に変身したお前と<end_line>
       勝負ってのもいいかもな！<end_line>
     </sjis>
+    <ascii>
+    Oh, a match!?<end_line>
+    It might be nice to fight<end_line>
+    you when you're transformed!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1032,12 +1099,12 @@
       トラムの前に変身したあなたと<end_line>
       勝負ってのもいいかもね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, a match!?<end_line>
     It might be nice to fight<end_line>
     you when you're transformed!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1063,17 +1130,21 @@
       なんだよ<three_dots><end_line>
       ホント、わかんないヤツだな<end_line>
     </sjis>
+    <ascii>
+    What was that<three_dots><end_line>
+    I really don't understand him.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ<three_dots><end_line>
       ホント、わかんない子ね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that<three_dots><end_line>
     I really don't understand him.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1194,6 +1265,11 @@
       とられてちゃカッコワルイからな<end_line>
       オレもがんばらないと<end_line>
     </sjis>
+    <ascii>
+    But I can't let you have<end_line>
+    all of the cool bits.<end_line>
+    I've got to work harder.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1201,12 +1277,12 @@
       とられてちゃカッコワルイからね<end_line>
       わたしもがんばらないと<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     But I can't let you have<end_line>
     all of the cool bits.<end_line>
     I've got to work harder.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1308,6 +1384,11 @@
       忘れてたよ、悪い悪い<end_line>
       でもよかったな、また変身できて<end_line>
     </sjis>
+    <ascii>
+    R-right,<end_line>
+    I forgot, sorry.<end_line>
+    That's great though.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1315,12 +1396,12 @@
       忘れてたよ、ごめんごめん<end_line>
       でもよかったね、また変身できて<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     R-right,<end_line>
     I forgot, sorry.<end_line>
     That's great though.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1361,17 +1442,21 @@
       うーんと<three_dots><end_line>
       オレ、何かしたっけ<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Hmm<three_dots><end_line>
+    Did I do something<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うーんと<three_dots><end_line>
       わたし、何かしたっけ<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hmm<three_dots><end_line>
     Did I do something<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 06/24498732_175d22c.xml
+++ b/Day 06/24498732_175d22c.xml
@@ -12,18 +12,21 @@
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんなんだよ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なんなのよ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I wonder what he wants<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なんなのよ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I wonder what he wants<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -31,24 +34,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			あのおっちゃんに<end_line>
 			オレたちのウデを<end_line>
 			見せつけてやろうぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あのおじさんに<end_line>
-			わたしたちのウデを<end_line>
-			見せつけよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's show off our<end_line>
     real strength to<end_line>
     that old man!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あのおじさんに<end_line>
+			わたしたちのウデを<end_line>
+			見せつけよう！<end_line>
+		</sjis>
+    <ascii>
+    Let's show off our<end_line>
+    real strength to<end_line>
+    that old man!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -84,18 +92,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			魔法使えないんだろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			魔法使えないんでしょ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     those bracelets on, right?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			魔法使えないんでしょ？<end_line>
+		</sjis>
+    <ascii>
+    those bracelets on, right?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -117,18 +128,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			オレたちのウデを見せれば<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしたちのウデを見せれば<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     If we show him what we can do,<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしたちのウデを見せれば<end_line>
+		</sjis>
+    <ascii>
+    If we show him what we can do,<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -150,24 +164,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			あのおっちゃんに<end_line>
 			オレたちのウデを<end_line>
 			見せつけてやろうぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あのおじさんに<end_line>
-			わたしたちのウデを<end_line>
-			見せつけよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's show off our<end_line>
     real strength to<end_line>
     that old man!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あのおじさんに<end_line>
+			わたしたちのウデを<end_line>
+			見せつけよう！<end_line>
+		</sjis>
+    <ascii>
+    Let's show off our<end_line>
+    real strength to<end_line>
+    that old man!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -205,18 +224,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			魔法使えないんだろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			魔法使えないんでしょ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     those bracelets on, right?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			魔法使えないんでしょ？<end_line>
+		</sjis>
+    <ascii>
+    those bracelets on, right?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -238,18 +260,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			オレたちのウデを見せれば<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしたちのウデを見せれば<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     If we show him what we can do,<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしたちのウデを見せれば<end_line>
+		</sjis>
+    <ascii>
+    If we show him what we can do,<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -271,24 +296,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			あのおっちゃんに<end_line>
 			オレたちのウデを<end_line>
 			見せつけてやろうぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あのおじさんに<end_line>
-			わたしたちのウデを<end_line>
-			見せつけよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's show off our<end_line>
     real strength to<end_line>
     that old man!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あのおじさんに<end_line>
+			わたしたちのウデを<end_line>
+			見せつけよう！<end_line>
+		</sjis>
+    <ascii>
+    Let's show off our<end_line>
+    real strength to<end_line>
+    that old man!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -324,18 +354,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			魔法使えないんだろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			魔法使えないんでしょ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     those bracelets on, right?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			魔法使えないんでしょ？<end_line>
+		</sjis>
+    <ascii>
+    those bracelets on, right?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -357,18 +390,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			オレたちのウデを見せれば<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしたちのウデを見せれば<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     If we show him what we can do,<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしたちのウデを見せれば<end_line>
+		</sjis>
+    <ascii>
+    If we show him what we can do,<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -389,24 +425,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			あのおっちゃんに<end_line>
 			オレたちのウデを<end_line>
 			見せつけてやろうぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あのおじさんに<end_line>
-			わたしたちのウデを<end_line>
-			見せつけよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's show off our<end_line>
     real strength to<end_line>
     that old man!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あのおじさんに<end_line>
+			わたしたちのウデを<end_line>
+			見せつけよう！<end_line>
+		</sjis>
+    <ascii>
+    Let's show off our<end_line>
+    real strength to<end_line>
+    that old man!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -439,18 +480,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			魔法使えないんだろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			魔法使えないんでしょ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     those bracelets on, right?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			魔法使えないんでしょ？<end_line>
+		</sjis>
+    <ascii>
+    those bracelets on, right?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -468,18 +512,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			オレたちのウデを見せれば<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしたちのウデを見せれば<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     If we show him what we can do,<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしたちのウデを見せれば<end_line>
+		</sjis>
+    <ascii>
+    If we show him what we can do,<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -514,18 +561,21 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いくつだっけ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いくつだったかな？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     How many were there again?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いくつだったかな？<end_line>
+		</sjis>
+    <ascii>
+    How many were there again?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -561,18 +611,21 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			わ、忘れるわけないだろー？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わ、忘れてたわけじゃないよ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I-I mean, of course not!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わ、忘れてたわけじゃないよ？<end_line>
+		</sjis>
+    <ascii>
+    I-I mean, of course not!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -600,18 +653,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			どれが重かった？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			どれが重かったかな？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Which one is the heaviest?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			どれが重かったかな？<end_line>
+		</sjis>
+    <ascii>
+    Which one is the heaviest?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -651,18 +707,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			なんだった？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なんだったかな？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I wonder what it is?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なんだったかな？<end_line>
+		</sjis>
+    <ascii>
+    I wonder what it is?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -692,21 +751,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 			これは自分自身で答える問題だな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<three_dots><end_line>
-			これは自分自身で答える問題よね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You're right<three_dots><end_line>
     I'll have to think about it.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<three_dots><end_line>
+			これは自分自身で答える問題よね<end_line>
+		</sjis>
+    <ascii>
+    You're right<three_dots><end_line>
+    I'll have to think about it.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -738,18 +801,21 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いくつだっけ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いくつだったかな？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     How many were there again?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いくつだったかな？<end_line>
+		</sjis>
+    <ascii>
+    How many were there again?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -799,18 +865,21 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			わ、忘れるわけないだろー？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わ、忘れてたわけじゃないよ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I-I mean, of course not!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わ、忘れてたわけじゃないよ？<end_line>
+		</sjis>
+    <ascii>
+    I-I mean, of course not!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -838,18 +907,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			どれが重かった？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			どれが重かったかな？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Which one is the heaviest?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			どれが重かったかな？<end_line>
+		</sjis>
+    <ascii>
+    Which one is the heaviest?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -889,18 +961,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			なんだった？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なんだったかな？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I wonder what it is?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なんだったかな？<end_line>
+		</sjis>
+    <ascii>
+    I wonder what it is?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -932,21 +1007,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 			これは自分自身で答える問題だな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<three_dots><end_line>
-			これは自分自身で答える問題よね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You're right<three_dots><end_line>
     I'll have to think about it.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<three_dots><end_line>
+			これは自分自身で答える問題よね<end_line>
+		</sjis>
+    <ascii>
+    You're right<three_dots><end_line>
+    I'll have to think about it.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -978,18 +1057,21 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いくつだっけ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いくつだったかな？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     How many were there again?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いくつだったかな？<end_line>
+		</sjis>
+    <ascii>
+    How many were there again?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1013,24 +1095,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			わかったよ<three_dots><end_line>
 			え～っと、おっちゃんも言ってた通り<end_line>
 			ハンマーを入れると<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わかったわよ<three_dots><end_line>
-			え～っと、おじさんも言ってた通り<end_line>
-			ハンマーを入れると<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I know<three_dots><end_line>
     Umm, so if I include my hammer<end_line>
     like he said<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わかったわよ<three_dots><end_line>
+			え～っと、おじさんも言ってた通り<end_line>
+			ハンマーを入れると<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I know<three_dots><end_line>
+    Umm, so if I include my hammer<end_line>
+    like he said<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1058,18 +1145,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			どれが重かった？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			どれが重かったかな？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Which one is the heaviest?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			どれが重かったかな？<end_line>
+		</sjis>
+    <ascii>
+    Which one is the heaviest?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -1089,24 +1179,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			わかったよ<three_dots><end_line>
 			え～っと、こういう時は見た目の<end_line>
 			大きさから考えてみるかな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わかったわよ<three_dots><end_line>
-			え～っと、こういう時は見た目の<end_line>
-			大きさから考えてみようかな<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I know<three_dots><end_line>
     Umm, maybe I can just look<end_line>
     at them and find out that way<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わかったわよ<three_dots><end_line>
+			え～っと、こういう時は見た目の<end_line>
+			大きさから考えてみようかな<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I know<three_dots><end_line>
+    Umm, maybe I can just look<end_line>
+    at them and find out that way<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -1122,18 +1217,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			なんだった？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なんだったかな？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I wonder what it is?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なんだったかな？<end_line>
+		</sjis>
+    <ascii>
+    I wonder what it is?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -1153,21 +1251,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 			これは自分自身で答える問題だな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<three_dots><end_line>
-			これは自分自身で答える問題よね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You're right<three_dots><end_line>
     This one I have to answer myself.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<three_dots><end_line>
+			これは自分自身で答える問題よね<end_line>
+		</sjis>
+    <ascii>
+    You're right<three_dots><end_line>
+    This one I have to answer myself.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -1197,18 +1299,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			いくつだっけ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いくつだったかな？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     How many were there again?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いくつだったかな？<end_line>
+		</sjis>
+    <ascii>
+    How many were there again?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1241,19 +1346,22 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			わ、忘れるわけないだろー？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    I-I mean, of course not!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			や、やだなぁ<end_line>
 			忘れるわけないでしょー？<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I-I mean, of course not!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1280,18 +1388,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			どれが重かった？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			どれが重かったかな？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Which one is the heaviest?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			どれが重かったかな？<end_line>
+		</sjis>
+    <ascii>
+    Which one is the heaviest?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -1331,18 +1442,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			なんだった？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なんだったかな？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I wonder what it is?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なんだったかな？<end_line>
+		</sjis>
+    <ascii>
+    I wonder what it is?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -1374,21 +1488,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 			これは自分自身で答える問題だな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<three_dots><end_line>
-			これは自分自身で答える問題よね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You're right<three_dots><end_line>
     I'll have to think about it.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<three_dots><end_line>
+			これは自分自身で答える問題よね<end_line>
+		</sjis>
+    <ascii>
+    You're right<three_dots><end_line>
+    I'll have to think about it.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -1406,24 +1524,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			この武器をちゃんと修理して<end_line>
 			鍛冶師だってみとめさせるぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よーし！<end_line>
-			この武器をちゃんと修理して<end_line>
-			鍛冶師だってみとめさせるんだから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Now all that's left is<end_line>
     to repair this weapon!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よーし！<end_line>
+			この武器をちゃんと修理して<end_line>
+			鍛冶師だってみとめさせるんだから！<end_line>
+		</sjis>
+    <ascii>
+    Alright!<end_line>
+    Now all that's left is<end_line>
+    to repair this weapon!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1449,7 +1572,7 @@
 	<sjis>
 		あんましコワイことは<end_line>
 		考えないように！<end_line>
-	</sjis> 
+	</sjis>
   <ascii>
     Please stop thinking<end_line>
     about things like that!<end_line>
@@ -1461,24 +1584,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			この武器をちゃんと修理して<end_line>
 			鍛冶師だってみとめさせるぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よーし！<end_line>
-			この武器をちゃんと修理して<end_line>
-			鍛冶師だってみとめさせるんだから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Now all that's left is<end_line>
     to repair this weapon!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よーし！<end_line>
+			この武器をちゃんと修理して<end_line>
+			鍛冶師だってみとめさせるんだから！<end_line>
+		</sjis>
+    <ascii>
+    Alright!<end_line>
+    Now all that's left is<end_line>
+    to repair this weapon!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1518,24 +1646,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			この武器をちゃんと修理して<end_line>
 			鍛冶師だってみとめさせるぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よーし！<end_line>
-			この武器をちゃんと修理して<end_line>
-			鍛冶師だってみとめさせるんだから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Now all that's left is<end_line>
     to repair this weapon!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よーし！<end_line>
+			この武器をちゃんと修理して<end_line>
+			鍛冶師だってみとめさせるんだから！<end_line>
+		</sjis>
+    <ascii>
+    Alright!<end_line>
+    Now all that's left is<end_line>
+    to repair this weapon!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1572,24 +1705,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			この武器をちゃんと修理して<end_line>
 			鍛冶師だってみとめさせるぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よーし！<end_line>
-			この武器をちゃんと修理して<end_line>
-			鍛冶師だってみとめさせるんだから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Now all that's left is<end_line>
     to repair this weapon!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よーし！<end_line>
+			この武器をちゃんと修理して<end_line>
+			鍛冶師だってみとめさせるんだから！<end_line>
+		</sjis>
+    <ascii>
+    Alright!<end_line>
+    Now all that's left is<end_line>
+    to repair this weapon!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1631,18 +1769,21 @@
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			させるかよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			させるもんか！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I won't let that happen!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			させるもんか！<end_line>
+		</sjis>
+    <ascii>
+    I won't let that happen!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -1674,18 +1815,21 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			急ぐぞ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			急ぐよ、<partner>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's hurry, <partner>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			急ぐよ、<partner>！<end_line>
+		</sjis>
+    <ascii>
+    Let's hurry, <partner>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1735,18 +1879,21 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			急ぐぞ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			急ぐよ、<partner>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's hurry, <partner>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			急ぐよ、<partner>！<end_line>
+		</sjis>
+    <ascii>
+    Let's hurry, <partner>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1793,18 +1940,21 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			急ぐぞ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			急ぐよ、<partner>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's hurry, <partner>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			急ぐよ、<partner>！<end_line>
+		</sjis>
+    <ascii>
+    Let's hurry, <partner>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1828,18 +1978,21 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			まかせとけって！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			まかせといてよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Leave it to me!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			まかせといてよ！<end_line>
+		</sjis>
+    <ascii>
+    Leave it to me!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1859,18 +2012,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			急ぐぞ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			急ぐよ、<partner>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's hurry, <partner>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			急ぐよ、<partner>！<end_line>
+		</sjis>
+    <ascii>
+    Let's hurry, <partner>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">

--- a/Day 06/24502636_175e16c.xml
+++ b/Day 06/24502636_175e16c.xml
@@ -18,18 +18,21 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			急ぐぞ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			急ぐよ、<partner>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's hurry, <partner>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			急ぐよ、<partner>！<end_line>
+		</sjis>
+    <ascii>
+    Let's hurry, <partner>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -65,24 +68,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			でも、装備が心配だな<three_dots><end_line>
 			おっちゃんの工房が使えると<end_line>
 			いいんだけど<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも、装備が心配だね<three_dots><end_line>
-			おじさんの工房が使えると<end_line>
-			いいんだけど<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm kind of worried about my gear<three_dots><end_line>
     It'd be fine if I could use the<end_line>
     old man's workshop, but<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でも、装備が心配だね<three_dots><end_line>
+			おじさんの工房が使えると<end_line>
+			いいんだけど<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I'm kind of worried about my gear<three_dots><end_line>
+    It'd be fine if I could use the<end_line>
+    old man's workshop, but<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -104,18 +112,21 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			急ぐぞ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			急ぐよ、<partner>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's hurry, <partner>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			急ぐよ、<partner>！<end_line>
+		</sjis>
+    <ascii>
+    Let's hurry, <partner>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -151,24 +162,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			でも、装備が心配だな<three_dots><end_line>
 			おっちゃんの工房が使えると<end_line>
 			いいんだけど<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも、装備が心配だね<three_dots><end_line>
-			おじさんの工房が使えると<end_line>
-			いいんだけど<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm kind of worried about my gear<three_dots><end_line>
     It'd be fine if I could use the<end_line>
     old man's workshop, but<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でも、装備が心配だね<three_dots><end_line>
+			おじさんの工房が使えると<end_line>
+			いいんだけど<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I'm kind of worried about my gear<three_dots><end_line>
+    It'd be fine if I could use the<end_line>
+    old man's workshop, but<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -190,18 +206,21 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			急ぐぞ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			急ぐよ、<partner>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's hurry, <partner>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			急ぐよ、<partner>！<end_line>
+		</sjis>
+    <ascii>
+    Let's hurry, <partner>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -225,18 +244,21 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			まかせとけって！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			まかせといてよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Leave it to me!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			まかせといてよ！<end_line>
+		</sjis>
+    <ascii>
+    Leave it to me!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -244,24 +266,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			でも、装備が心配だな<three_dots><end_line>
 			おっちゃんの工房が使えると<end_line>
 			いいんだけど<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも、装備が心配だね<three_dots><end_line>
-			おじさんの工房が使えると<end_line>
-			いいんだけど<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm kind of worried about my gear<three_dots><end_line>
     It'd be fine if I could use the<end_line>
     old man's workshop, but<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でも、装備が心配だね<three_dots><end_line>
+			おじさんの工房が使えると<end_line>
+			いいんだけど<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I'm kind of worried about my gear<three_dots><end_line>
+    It'd be fine if I could use the<end_line>
+    old man's workshop, but<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -281,18 +308,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			急ぐぞ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			急ぐよ、<partner>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's hurry, <partner>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			急ぐよ、<partner>！<end_line>
+		</sjis>
+    <ascii>
+    Let's hurry, <partner>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -325,24 +355,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			でも、装備が心配だな<three_dots><end_line>
 			おっちゃんの工房が使えると<end_line>
 			いいんだけど<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも、装備が心配だね<three_dots><end_line>
-			おじさんの工房が使えると<end_line>
-			いいんだけど<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm kind of worried about my gear<three_dots><end_line>
     It'd be fine if I could use the<end_line>
     old man's workshop, but<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でも、装備が心配だね<three_dots><end_line>
+			おじさんの工房が使えると<end_line>
+			いいんだけど<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I'm kind of worried about my gear<three_dots><end_line>
+    It'd be fine if I could use the<end_line>
+    old man's workshop, but<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -350,21 +385,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			おっちゃんの工房も使えそうだし<end_line>
 			全力でミューノを助けに行くぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			おじさんの工房も使えそうだし<end_line>
-			全力でミューノを助けに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Seems like we can use the workshop.<end_line>
     One step closer to saving Murno!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			おじさんの工房も使えそうだし<end_line>
+			全力でミューノを助けに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Seems like we can use the workshop.<end_line>
+    One step closer to saving Murno!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -388,24 +427,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			わかってる！<end_line>
 			ミューノを召喚獣のエサになんか<end_line>
 			させるもんか！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わかってるって！<end_line>
-			ミューノを召喚獣のエサになんか<end_line>
-			させないから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I said I know!<end_line>
     I won't let this Phantom Dragon<end_line>
     eat Murno!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わかってるって！<end_line>
+			ミューノを召喚獣のエサになんか<end_line>
+			させないから！<end_line>
+		</sjis>
+    <ascii>
+    I said I know!<end_line>
+    I won't let this Phantom Dragon<end_line>
+    eat Murno!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -413,21 +457,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			おっちゃんの工房も使えそうだし<end_line>
 			全力でミューノを助けに行くぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			おじさんの工房も使えそうだし<end_line>
-			全力でミューノを助けに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Seems like we can use the workshop.<end_line>
     One step closer to saving Murno!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			おじさんの工房も使えそうだし<end_line>
+			全力でミューノを助けに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Seems like we can use the workshop.<end_line>
+    One step closer to saving Murno!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -451,24 +499,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			わかってる！<end_line>
 			ミューノを召喚獣のエサになんか<end_line>
 			させるもんか！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わかってるって！<end_line>
-			ミューノを召喚獣のエサになんか<end_line>
-			させないから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I said I know!<end_line>
     I won't let this Phantom Dragon<end_line>
     eat Murno!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わかってるって！<end_line>
+			ミューノを召喚獣のエサになんか<end_line>
+			させないから！<end_line>
+		</sjis>
+    <ascii>
+    I said I know!<end_line>
+    I won't let this Phantom Dragon<end_line>
+    eat Murno!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -476,21 +529,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			おっちゃんの工房も使えそうだし<end_line>
 			全力でミューノを助けに行くぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			おじさんの工房も使えそうだし<end_line>
-			全力でミューノを助けに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Seems like we can use the workshop.<end_line>
     One step closer to saving Murno!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			おじさんの工房も使えそうだし<end_line>
+			全力でミューノを助けに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Seems like we can use the workshop.<end_line>
+    One step closer to saving Murno!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -509,45 +566,54 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			まかせとけって！<end_line>
 			ミューノを召喚獣のエサになんか<end_line>
 			させるもんか！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			まかせといてよ！<end_line>
-			ミューノを召喚獣のエサになんか<end_line>
-			させないから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Of course I can!<end_line>
     I won't let this Phantom Dragon<end_line>
     eat Murno!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			まかせといてよ！<end_line>
+			ミューノを召喚獣のエサになんか<end_line>
+			させないから！<end_line>
+		</sjis>
+    <ascii>
+    Of course I can!<end_line>
+    I won't let this Phantom Dragon<end_line>
+    eat Murno!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			おっちゃんの工房も使えそうだし<end_line>
 			全力でミューノを助けに行くぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			おじさんの工房も使えそうだし<end_line>
-			全力でミューノを助けに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Seems like we can use the workshop.<end_line>
     One step closer to saving Murno!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			おじさんの工房も使えそうだし<end_line>
+			全力でミューノを助けに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Seems like we can use the workshop.<end_line>
+    One step closer to saving Murno!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -569,24 +635,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			わかってる！<end_line>
 			ミューノを召喚獣のエサになんか<end_line>
 			させるもんか！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わかってるって！<end_line>
-			ミューノを召喚獣のエサになんか<end_line>
-			させないから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I said I know!<end_line>
     I won't let this Phantom Dragon<end_line>
     eat Murno!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わかってるって！<end_line>
+			ミューノを召喚獣のエサになんか<end_line>
+			させないから！<end_line>
+		</sjis>
+    <ascii>
+    I said I know!<end_line>
+    I won't let this Phantom Dragon<end_line>
+    eat Murno!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -594,24 +665,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			レクイの水遺跡の一番下にいる<end_line>
 			ヌシってヤツから<end_line>
 			ミューノを助け出すんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レクイの水遺跡の一番下にいる<end_line>
-			ヌシさまって召喚獣から<end_line>
-			ミューノを助け出さなくっちゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Deep within the ruins is<end_line>
     the lair of their master.<end_line>
     We'll find Murno there!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			レクイの水遺跡の一番下にいる<end_line>
+			ヌシさまって召喚獣から<end_line>
+			ミューノを助け出さなくっちゃ！<end_line>
+		</sjis>
+    <ascii>
+    Deep within the ruins is<end_line>
+    the lair of their master.<end_line>
+    We'll find Murno there!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -649,24 +725,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			レクイの水遺跡の一番下にいる<end_line>
 			ヌシってヤツから<end_line>
 			ミューノを助け出すんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レクイの水遺跡の一番下にいる<end_line>
-			ヌシさまって召喚獣から<end_line>
-			ミューノを助け出さなくっちゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Deep within the ruins is<end_line>
     the lair of their master.<end_line>
     We'll find Murno there!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			レクイの水遺跡の一番下にいる<end_line>
+			ヌシさまって召喚獣から<end_line>
+			ミューノを助け出さなくっちゃ！<end_line>
+		</sjis>
+    <ascii>
+    Deep within the ruins is<end_line>
+    the lair of their master.<end_line>
+    We'll find Murno there!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -706,24 +787,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			レクイの水遺跡の一番下にいる<end_line>
 			ヌシってヤツから<end_line>
 			ミューノを助け出すんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レクイの水遺跡の一番下にいる<end_line>
-			ヌシさまって召喚獣から<end_line>
-			ミューノを助け出さなくっちゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Deep within the ruins is<end_line>
     the lair of their master.<end_line>
     We'll find Murno there!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			レクイの水遺跡の一番下にいる<end_line>
+			ヌシさまって召喚獣から<end_line>
+			ミューノを助け出さなくっちゃ！<end_line>
+		</sjis>
+    <ascii>
+    Deep within the ruins is<end_line>
+    the lair of their master.<end_line>
+    We'll find Murno there!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -758,24 +844,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			レクイの水遺跡の一番下にいる<end_line>
 			ヌシってヤツから<end_line>
 			ミューノを助け出すんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レクイの水遺跡の一番下にいる<end_line>
-			ヌシさまって召喚獣から<end_line>
-			ミューノを助け出さなくっちゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Deep within the ruins is<end_line>
     the lair of their master.<end_line>
     We'll find Murno there!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			レクイの水遺跡の一番下にいる<end_line>
+			ヌシさまって召喚獣から<end_line>
+			ミューノを助け出さなくっちゃ！<end_line>
+		</sjis>
+    <ascii>
+    Deep within the ruins is<end_line>
+    the lair of their master.<end_line>
+    We'll find Murno there!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -790,7 +881,7 @@
     This strange sensation<three_dots><end_line>
     I have a bad feeling about this<three_dots><end_line>
     Please be careful.<end_line>
-  </ascii> 
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -811,24 +902,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			レクイの水遺跡の一番下にいる<end_line>
 			ヌシってヤツから<end_line>
 			ミューノを助け出すんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レクイの水遺跡の一番下にいる<end_line>
-			ヌシさまって召喚獣から<end_line>
-			ミューノを助け出さなくっちゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Deep within the ruins is<end_line>
     the lair of their master.<end_line>
     We'll find Murno there!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			レクイの水遺跡の一番下にいる<end_line>
+			ヌシさまって召喚獣から<end_line>
+			ミューノを助け出さなくっちゃ！<end_line>
+		</sjis>
+    <ascii>
+    Deep within the ruins is<end_line>
+    the lair of their master.<end_line>
+    We'll find Murno there!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -852,24 +948,29 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			どんなシカケかわかんないんだから<end_line>
 			どう気をつけていいか<end_line>
 			わかんないけどな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			どんなシカケかわかんないんだから<end_line>
-			どう気をつけていいか<end_line>
-			わかんないけどね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well I don't know how it works,<end_line>
     so how am I supposed<end_line>
     to avoid it!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			どんなシカケかわかんないんだから<end_line>
+			どう気をつけていいか<end_line>
+			わかんないけどね<end_line>
+		</sjis>
+    <ascii>
+    Well I don't know how it works,<end_line>
+    so how am I supposed<end_line>
+    to avoid it!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -877,24 +978,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			レクイの水遺跡の一番下にいる<end_line>
 			ヌシってヤツから<end_line>
 			ミューノを助け出すんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レクイの水遺跡の一番下にいる<end_line>
-			ヌシさまって召喚獣から<end_line>
-			ミューノを助け出さなくっちゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Deep within the ruins is<end_line>
     the lair of their master.<end_line>
     We'll find Murno there!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			レクイの水遺跡の一番下にいる<end_line>
+			ヌシさまって召喚獣から<end_line>
+			ミューノを助け出さなくっちゃ！<end_line>
+		</sjis>
+    <ascii>
+    Deep within the ruins is<end_line>
+    the lair of their master.<end_line>
+    We'll find Murno there!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -910,7 +1016,7 @@
     Whatever caused Tier to<end_line>
     show up may happen again.<end_line>
     Tread carefully.<end_line>
-  </ascii> 
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -918,21 +1024,25 @@
 	<portrait_l entry="player" eye="sad" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			「人じゃない」とか言われても<end_line>
 			どう気をつければいいんだよ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			「人じゃない」とか言われて<end_line>
-			どう気をつければいいのよ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You said that wasn't human so<three_dots><end_line>
     I have no idea what to do<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			「人じゃない」とか言われて<end_line>
+			どう気をつければいいのよ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    You said that wasn't human so<three_dots><end_line>
+    I have no idea what to do<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -956,24 +1066,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			レクイの水遺跡の一番下にいる<end_line>
 			ヌシってヤツから<end_line>
 			ミューノを助け出すんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レクイの水遺跡の一番下にいる<end_line>
-			ヌシさまって召喚獣から<end_line>
-			ミューノを助け出さなくっちゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Deep within the ruins is<end_line>
     the lair of their master.<end_line>
     We'll find Murno there!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			レクイの水遺跡の一番下にいる<end_line>
+			ヌシさまって召喚獣から<end_line>
+			ミューノを助け出さなくっちゃ！<end_line>
+		</sjis>
+    <ascii>
+    Deep within the ruins is<end_line>
+    the lair of their master.<end_line>
+    We'll find Murno there!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -995,21 +1110,25 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			「人じゃない」とか言われても<end_line>
 			どうすりゃいいんだよ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			「人じゃない」とか言われても<end_line>
-			どうすればいいのよ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You said that wasn't human so<three_dots><end_line>
     I have no idea what to do<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			「人じゃない」とか言われても<end_line>
+			どうすればいいのよ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    You said that wasn't human so<three_dots><end_line>
+    I have no idea what to do<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1030,24 +1149,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			レクイの水遺跡の一番下にいる<end_line>
 			ヌシってヤツから<end_line>
 			ミューノを助け出すんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レクイの水遺跡の一番下にいる<end_line>
-			ヌシさまって召喚獣から<end_line>
-			ミューノを助け出さなくっちゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Deep within the ruins is<end_line>
     the lair of their master.<end_line>
     We'll find Murno there!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			レクイの水遺跡の一番下にいる<end_line>
+			ヌシさまって召喚獣から<end_line>
+			ミューノを助け出さなくっちゃ！<end_line>
+		</sjis>
+    <ascii>
+    Deep within the ruins is<end_line>
+    the lair of their master.<end_line>
+    We'll find Murno there!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1069,24 +1193,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			なんだかよくわからないけど<end_line>
 			なんとかなったから大丈夫だよ<end_line>
 			勇気だして行こうぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なんだかよくわからないけど<end_line>
-			なんとかなったから大丈夫だよ<end_line>
-			勇気だして行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I still don't know what it is,<end_line>
     but for now we're doing fine.<end_line>
     We'll face it head on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なんだかよくわからないけど<end_line>
+			なんとかなったから大丈夫だよ<end_line>
+			勇気だして行こう！<end_line>
+		</sjis>
+    <ascii>
+    I still don't know what it is,<end_line>
+    but for now we're doing fine.<end_line>
+    We'll face it head on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1137,21 +1266,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			とにかく<three_dots><end_line>
 			たしかめに行ってみるか<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			とにかく<three_dots><end_line>
-			たしかめに行ってみよう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anyway<three_dots><end_line>
     No choice but to check it out.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			とにかく<three_dots><end_line>
+			たしかめに行ってみよう<end_line>
+		</sjis>
+    <ascii>
+    Anyway<three_dots><end_line>
+    No choice but to check it out.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1246,21 +1379,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			それを聞いてるんだけどな<end_line>
 			とりあえず、行ってみよう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			それを聞いてるんだけどね<end_line>
-			とりあえず、行ってみよう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     That's what I want to know<three_dots><end_line>
     Well, let's check it out.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			それを聞いてるんだけどね<end_line>
+			とりあえず、行ってみよう<end_line>
+		</sjis>
+    <ascii>
+    That's what I want to know<three_dots><end_line>
+    Well, let's check it out.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1268,24 +1405,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			レクイの水遺跡の一番下にいる<end_line>
 			ヌシってヤツから<end_line>
 			ミューノを助け出すんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レクイの水遺跡の一番下にいる<end_line>
-			ヌシさまって召喚獣から<end_line>
-			ミューノを助け出さなくっちゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Deep within the ruins is<end_line>
     the lair of their master.<end_line>
     We'll find Murno there!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			レクイの水遺跡の一番下にいる<end_line>
+			ヌシさまって召喚獣から<end_line>
+			ミューノを助け出さなくっちゃ！<end_line>
+		</sjis>
+    <ascii>
+    Deep within the ruins is<end_line>
+    the lair of their master.<end_line>
+    We'll find Murno there!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1323,24 +1465,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			レクイの水遺跡の一番下にいる<end_line>
 			ヌシってヤツから<end_line>
 			ミューノを助け出すんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レクイの水遺跡の一番下にいる<end_line>
-			ヌシさまって召喚獣から<end_line>
-			ミューノを助け出さなくっちゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Deep within the ruins is<end_line>
     the lair of their master.<end_line>
     We'll find Murno there!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			レクイの水遺跡の一番下にいる<end_line>
+			ヌシさまって召喚獣から<end_line>
+			ミューノを助け出さなくっちゃ！<end_line>
+		</sjis>
+    <ascii>
+    Deep within the ruins is<end_line>
+    the lair of their master.<end_line>
+    We'll find Murno there!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1364,21 +1511,25 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			まだ、何かあるかもしれないな<three_dots><end_line>
 			でも、進まなくちゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			まだ、何かあるかもしれないね<three_dots><end_line>
-			でも、進まなくちゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     That's not all there is to it<three_dots><end_line>
     But we have to keep going!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			まだ、何かあるかもしれないね<three_dots><end_line>
+			でも、進まなくちゃ！<end_line>
+		</sjis>
+    <ascii>
+    That's not all there is to it<three_dots><end_line>
+    But we have to keep going!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1386,24 +1537,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			レクイの水遺跡の一番下にいる<end_line>
 			ヌシってヤツから<end_line>
 			ミューノを助け出すんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レクイの水遺跡の一番下にいる<end_line>
-			ヌシさまって召喚獣から<end_line>
-			ミューノを助け出さなくっちゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Deep within the ruins is<end_line>
     the lair of their master.<end_line>
     We'll find Murno there!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			レクイの水遺跡の一番下にいる<end_line>
+			ヌシさまって召喚獣から<end_line>
+			ミューノを助け出さなくっちゃ！<end_line>
+		</sjis>
+    <ascii>
+    Deep within the ruins is<end_line>
+    the lair of their master.<end_line>
+    We'll find Murno there!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1427,42 +1583,50 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			弱そうなヤツだといいけど<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			弱そうな人だといいけど<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hopefully not someone too strong<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			弱そうな人だといいけど<end_line>
+		</sjis>
+    <ascii>
+    Hopefully not someone too strong<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			レクイの水遺跡の一番下にいる<end_line>
 			ヌシってヤツから<end_line>
 			ミューノを助け出すんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レクイの水遺跡の一番下にいる<end_line>
-			ヌシさまって召喚獣から<end_line>
-			ミューノを助け出さなくっちゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Deep within the ruins is<end_line>
     the lair of their master.<end_line>
     We'll find Murno there!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			レクイの水遺跡の一番下にいる<end_line>
+			ヌシさまって召喚獣から<end_line>
+			ミューノを助け出さなくっちゃ！<end_line>
+		</sjis>
+    <ascii>
+    Deep within the ruins is<end_line>
+    the lair of their master.<end_line>
+    We'll find Murno there!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1477,28 +1641,32 @@
     I am ready for<end_line>
     whoever comes next!<end_line>
     Let's hurry!<end_line>
-  </ascii> 
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな！<end_line>
 			どんとこいってんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね！<end_line>
-			どんとこいって感じ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
     Keep 'em coming!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね！<end_line>
+			どんとこいって感じ！<end_line>
+		</sjis>
+    <ascii>
+    Right!<end_line>
+    Keep 'em coming!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1506,21 +1674,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			もうニセモノはたくさんだ！<end_line>
 			本物のミューノは<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    There's so many fakes!<end_line>
+    The real Murno is<three_dots><end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			もうニセモノはたくさん！<end_line>
 			本物のミューノは<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     There's so many fakes!<end_line>
     The real Murno is<three_dots><end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1558,21 +1730,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			もうニセモノはたくさんだ！<end_line>
 			本物のミューノは<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    There's so many fakes!<end_line>
+    The real Murno is<three_dots><end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			もうニセモノはたくさん！<end_line>
 			本物のミューノは<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     There's so many fakes!<end_line>
     The real Murno is<three_dots><end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1610,21 +1786,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			もうニセモノはたくさんだ！<end_line>
 			本物のミューノは<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    There's so many fakes!<end_line>
+    The real Murno is<three_dots><end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			もうニセモノはたくさん！<end_line>
 			本物のミューノは<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     There's so many fakes!<end_line>
     The real Murno is<three_dots><end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1661,21 +1841,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			もうニセモノはたくさんだ！<end_line>
 			本物のミューノは<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    There's so many fakes!<end_line>
+    The real Murno is<three_dots><end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			もうニセモノはたくさん！<end_line>
 			本物のミューノは<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     There's so many fakes!<end_line>
     The real Murno is<three_dots><end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1690,7 +1874,7 @@
     In the deepest part of the ruins!<end_line>
     We must be quick, or Lady Murno<end_line>
     will be eaten by a Summon Beast!<end_line>
-  </ascii>  
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">

--- a/Day 06/25325180_1826e7c.xml
+++ b/Day 06/25325180_1826e7c.xml
@@ -2,24 +2,29 @@
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			あれ？<end_line>
 			オレ、何してたんだっけ<three_dots>？<end_line>
 			え～っと<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Huh?<end_line>
+    What was I doing again<three_dots>?<end_line>
+    Umm<three_dots><end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			あれ？<end_line>
 			わたし、何してたんだっけ<three_dots>？<end_line>
 			え～っと<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     What was I doing again<three_dots>?<end_line>
     Umm<three_dots><end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -55,18 +60,21 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			大丈夫か？　おい<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			大丈夫？　ねぇ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     but you're okay, right<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			大丈夫？　ねぇ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    but you're okay, right<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -119,20 +127,23 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ<end_line>
 			<partner>だって<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    You forgot too<three_dots>?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			なによ<end_line>
 			<partner>だって<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You forgot too<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -182,22 +193,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ<end_line>
 			<partner>だって、わかんないんじゃ<end_line>
 			ないのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    So you don't know either?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			なによ<end_line>
 			<partner>も、わかんないんじゃ<end_line>
 			ないの？<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So you don't know either?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -237,22 +251,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ<end_line>
 			<partner>だって、わかんないんじゃ<end_line>
 			ないのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    So you don't know either?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			なによ<end_line>
 			<partner>も、わかんないんじゃ<end_line>
 			ないの？<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So you don't know either?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">

--- a/Day 06/25329580_1827fac.xml
+++ b/Day 06/25329580_1827fac.xml
@@ -2,24 +2,29 @@
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			あれ？<end_line>
 			オレ、何してたんだっけ<three_dots>？<end_line>
 			え～っと<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Huh?<end_line>
+    What was I doing again<three_dots>?<end_line>
+    Umm<three_dots><end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			あれ？<end_line>
 			わたし、何してたんだっけ<three_dots>？<end_line>
 			え～っと<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     What was I doing again<three_dots>?<end_line>
     Umm<three_dots><end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -55,18 +60,21 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			大丈夫か？　おい<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			大丈夫？　ねぇ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     but you're okay, right<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			大丈夫？　ねぇ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    but you're okay, right<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -119,20 +127,23 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ<end_line>
 			<partner>だって<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    You forgot too<three_dots>?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			なによ<end_line>
 			<partner>だって<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You forgot too<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -182,22 +193,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ<end_line>
 			<partner>だって、わかんないんじゃ<end_line>
 			ないのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    So you don't know either?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			なによ<end_line>
 			<partner>も、わかんないんじゃ<end_line>
 			ないの？<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So you don't know either?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -237,22 +251,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ<end_line>
 			<partner>だって、わかんないんじゃ<end_line>
 			ないのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    So you don't know either?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			なによ<end_line>
 			<partner>も、わかんないんじゃ<end_line>
 			ないの？<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So you don't know either?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">

--- a/Day 07/001_25360684_182f92c.xml
+++ b/Day 07/001_25360684_182f92c.xml
@@ -3,21 +3,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			いよいよトラムとの勝負だ<end_line>
 			絶対に勝つぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いよいよトラムとの勝負だね<end_line>
-			絶対に勝つよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     It's time for our match with Tram.<end_line>
     I'm definitely going to win!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いよいよトラムとの勝負だね<end_line>
+			絶対に勝つよ！<end_line>
+		</sjis>
+    <ascii>
+    It's time for our match with Tram.<end_line>
+    I'm definitely going to win!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -39,7 +43,7 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、心配してくれるのか？<end_line>
 			ありがとう<end_line>
 			大丈夫だって！<end_line>
@@ -49,9 +53,9 @@
       Thanks.<end_line>
       I'll be fine!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			心配してくれるの？<end_line>
 			ありがとう<end_line>
 			大丈夫だよ！<end_line>
@@ -61,7 +65,7 @@
       Thanks.<end_line>
       I'll be fine!<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -179,18 +183,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="talk">
 	<portrait_r entry="partner" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			お前<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あなた<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あなた<three_dots><end_line>
+		</sjis>
+    <ascii>
+    You<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -228,7 +235,7 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、心配してくれるのか？<end_line>
 			ありがとう<end_line>
 			大丈夫だって！<end_line>
@@ -238,9 +245,9 @@
       Thanks.<end_line>
       I'll be fine!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			心配してくれるの？<end_line>
 			ありがとう<end_line>
 			大丈夫だよ！<end_line>
@@ -250,7 +257,7 @@
       Thanks.<end_line>
       I'll be fine!<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -394,21 +401,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよそれ？<end_line>
 			もしかして心配してくれるのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによそれ？<end_line>
-			もしかして心配してくれるの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What's that supposed to mean?<end_line>
     Are you worried about me?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによそれ？<end_line>
+			もしかして心配してくれるの？<end_line>
+		</sjis>
+    <ascii>
+    What's that supposed to mean?<end_line>
+    Are you worried about me?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -558,7 +569,7 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、心配してくれるのか？<end_line>
 			ありがとう<end_line>
 			大丈夫だって！<end_line>
@@ -568,9 +579,9 @@
       Thanks.<end_line>
       I'll be fine!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			心配してくれるの？<end_line>
 			ありがとう<end_line>
 			大丈夫だよ！<end_line>
@@ -580,7 +591,7 @@
       Thanks.<end_line>
       I'll be fine!<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -618,24 +629,29 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			てなわけで<end_line>
 			そろそろオレは行くけど<end_line>
 			<partner>はどうする？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そんなわけで<end_line>
-			そろそろわたしは行くけど<end_line>
-			<partner>はどうする？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Now then,<end_line>
     it's about time for me to go.<end_line>
     What will you do, <partner>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そんなわけで<end_line>
+			そろそろわたしは行くけど<end_line>
+			<partner>はどうする？<end_line>
+		</sjis>
+    <ascii>
+    Now then,<end_line>
+    it's about time for me to go.<end_line>
+    What will you do, <partner>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -669,18 +685,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			お前<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あなた<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あなた<three_dots><end_line>
+		</sjis>
+    <ascii>
+    You<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -703,18 +722,21 @@
 	<portrait_l entry="player" eye="sad" mouth="neutral">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			そういうことか<three_dots><end_line>
 			わかったよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Oh, that's what you meant<three_dots><end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そういうことね<three_dots><end_line>
 			わかったわよ<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Oh, that's what you meant<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 07/003_25362748_183013c.xml
+++ b/Day 07/003_25362748_183013c.xml
@@ -29,6 +29,11 @@
       絶対勝ってみせるから<end_line>
       安心してな！<end_line>
     </sjis>
+    <ascii>
+    Don't look so worried.<end_line>
+    I'm going to win.<end_line>
+    Leave it to me!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -36,12 +41,12 @@
       絶対勝ってみせるから<end_line>
       まかせてよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't look so worried.<end_line>
     I'm going to win.<end_line>
     Leave it to me!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -254,15 +259,18 @@
     <sjis>
       おっちゃんも来るの？<end_line>
     </sjis>
+    <ascii>
+    You're coming too?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       おじさんも来るの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're coming too?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -542,6 +550,11 @@
       ヌシのいたところだな<end_line>
       わかった！<end_line>
     </sjis>
+    <ascii>
+    The Rekui Water Ruins<three_dots><end_line>
+    That's where your master was, right?<end_line>
+    Got it!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -549,10 +562,10 @@
       ヌシさまのいたところね<end_line>
       わかった！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The Rekui Water Ruins<three_dots><end_line>
     That's where your master was, right?<end_line>
     Got it!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 07/009_25365420_1830bac.xml
+++ b/Day 07/009_25365420_1830bac.xml
@@ -74,6 +74,11 @@
       どうせオレが勝ったら<end_line>
       中を見せてもらえるんだし<end_line>
     </sjis>
+    <ascii>
+    Isn't it fine?<end_line>
+    I mean, once I win, I'm gonna<end_line>
+    have you show us around anyway.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -81,12 +86,12 @@
       どうせわたしが勝ったら<end_line>
       中を見せてくれるんでしょ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Isn't it fine?<end_line>
     I mean, once I win, I'm gonna<end_line>
     have you show us around anyway.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -249,17 +254,21 @@
       まかせとけ<end_line>
       絶対たおしてやる！<end_line>
     </sjis>
+    <ascii>
+    Leave it to me.<end_line>
+    I'm going to win!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       まかせといて<end_line>
       絶対やっつけちゃうから！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Leave it to me.<end_line>
     I'm going to win!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -374,15 +383,18 @@
     <sjis>
       心配すんなって<end_line>
     </sjis>
+    <ascii>
+    Don't worry.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       心配しないで<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't worry.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -473,15 +485,19 @@
       あ<three_dots><end_line>
       お、おう！<end_line>
     </sjis>
+    <ascii>
+    Ah<three_dots><end_line>
+    Y-yeah!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ<three_dots><end_line>
       う、うん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah<three_dots><end_line>
     Y-yeah!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 07/011_25368172_183166c.xml
+++ b/Day 07/011_25368172_183166c.xml
@@ -8,6 +8,11 @@
       なんだよ？<end_line>
       今度は暑いなぁ<end_line>
     </sjis>
+    <ascii>
+    Woah<three_dots>!<end_line>
+    What the<three_dots>?<end_line>
+    It's so hot in here.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -15,12 +20,12 @@
       なによ？<end_line>
       今度は暑いなぁ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Woah<three_dots>!<end_line>
     What the<three_dots>?<end_line>
     It's so hot in here.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -133,17 +138,21 @@
       召喚獣が凶暴になるって<three_dots><end_line>
       <partner>は大丈夫か？<end_line>
     </sjis>
+    <ascii>
+    Summon Beasts going berserk<three_dots><end_line>
+    <partner>, are you okay?<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       召喚獣が凶暴になるって<three_dots><end_line>
       <partner>は大丈夫？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Summon Beasts going berserk<three_dots><end_line>
     <partner>, are you okay?<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -216,17 +225,21 @@
       この遺跡にいる召喚獣は<end_line>
       一体なにを守っているんだ？<end_line>
     </sjis>
+    <ascii>
+    What are the Summon Beasts<end_line>
+    here protecting?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       この遺跡にいる召喚獣って<end_line>
       一体なにを守ってるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What are the Summon Beasts<end_line>
     here protecting?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -249,15 +262,18 @@
     <sjis>
       わかってるよ<end_line>
     </sjis>
+    <ascii>
+    I know.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わかったわよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -281,17 +297,21 @@
       ちょっと待て！<end_line>
       なんでだよ！？<end_line>
     </sjis>
+    <ascii>
+    Hey, wait!<end_line>
+    What's with that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちょっと待って！<end_line>
       なによ、それ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, wait!<end_line>
     What's with that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -327,15 +347,18 @@
     <sjis>
       なんだと！<end_line>
     </sjis>
+    <ascii>
+    What was that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -373,6 +396,11 @@
       必ず裁きの間までたどりついて<end_line>
       絶対に勝ってみせるぜ！<end_line>
     </sjis>
+    <ascii>
+    Alright<three_dots><end_line>
+    I'll make it to the Room of<end_line>
+    Judgment on my own, and beat Tram!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -380,12 +408,12 @@
       必ず裁きの間までたどりついて<end_line>
       絶対に勝ってみせるから！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright<three_dots><end_line>
     I'll make it to the Room of<end_line>
     Judgment on my own, and beat Tram!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -424,17 +452,21 @@
       よし<three_dots>！<end_line>
       じゃ、オレたちも行こうぜ！<end_line>
     </sjis>
+    <ascii>
+    Alright<three_dots>!<end_line>
+    Let's get going!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よ～し！<end_line>
       じゃ、わたしたちも行こっ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright<three_dots>!<end_line>
     Let's get going!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 07/015_25370572_1831fcc.xml
+++ b/Day 07/015_25370572_1831fcc.xml
@@ -95,7 +95,7 @@
   <ascii>
     Many things were decided by<end_line>
     the outcome of matches here.<end_line>
-  </ascii> 
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -184,21 +184,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<portrait_r entry="tram" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			侵入者は負けたら<end_line>
 			溶岩に落とされてたのか<three_dots>？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			侵入者は負けたら<end_line>
-			溶岩に落とされていたの<three_dots>？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Intruders get thrown<end_line>
     into the lava<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			侵入者は負けたら<end_line>
+			溶岩に落とされていたの<three_dots>？<end_line>
+		</sjis>
+    <ascii>
+    Intruders get thrown<end_line>
+    into the lava<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -231,21 +235,25 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			なんだと！？<end_line>
 			オレはコワがってなんかいない！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ！？<end_line>
-			わたしはコワがってなんかないわよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What!?<end_line>
     I'm not scared!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ！？<end_line>
+			わたしはコワがってなんかないわよ！<end_line>
+		</sjis>
+    <ascii>
+    What!?<end_line>
+    I'm not scared!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -314,21 +322,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			そっか<three_dots><end_line>
 			ごめん<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだよね<three_dots><end_line>
-			ごめん<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You're right<three_dots><end_line>
     Sorry.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだよね<three_dots><end_line>
+			ごめん<end_line>
+		</sjis>
+    <ascii>
+    You're right<three_dots><end_line>
+    Sorry.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">

--- a/Day 07/017_25374220_1832e0c.xml
+++ b/Day 07/017_25374220_1832e0c.xml
@@ -17,15 +17,18 @@
     <sjis>
       やったぞ、ミューノ！<end_line>
     </sjis>
+    <ascii>
+    I did it, Murno!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       やったよ、ミューノ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I did it, Murno!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -300,6 +303,11 @@
       まさか、アニスといっしょにいた<end_line>
       召喚獣のことじゃ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Magdrad<three_dots><end_line>
+    Could that be the Summon Beast<end_line>
+    that was with Anise<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -307,12 +315,12 @@
       まさか、アニスといっしょにいた<end_line>
       召喚獣のこと？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Magdrad<three_dots><end_line>
     Could that be the Summon Beast<end_line>
     that was with Anise<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -366,16 +374,19 @@
       それをあの女が<end_line>
       持ち出してたのか？<end_line>
     </sjis>
+    <ascii>
+    And Anise removed them?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       それをあの人が<end_line>
       持ち出したの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And Anise removed them?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -480,15 +491,18 @@
     <sjis>
       なんだと！？<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -591,17 +605,21 @@
       なんだと！？<end_line>
       そんなこと、あるわけないだろ！<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+    As if!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！？<end_line>
       そんなこと、あるわけないでしょ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
     As if!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -707,14 +725,17 @@
       では、気をつけてな<end_line>
       ボウズ！<end_line>
     </sjis>
+    <ascii>
+    Well then, be careful kid!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       では、気をつけてな<end_line>
       じょうちゃん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well then, be careful kid!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 07/019_25377356_1833a4c.xml
+++ b/Day 07/019_25377356_1833a4c.xml
@@ -20,17 +20,21 @@
       迷子になんかなるもんか<end_line>
       な、<partner><end_line>
     </sjis>
+    <ascii>
+    We never get lost,<end_line>
+    right, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       迷子になんかならないわよ<end_line>
       ね、<partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We never get lost,<end_line>
     right, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -93,17 +97,21 @@
       ほーら！<end_line>
       <three_dots>ってオイ！？<end_line>
     </sjis>
+    <ascii>
+    See!<end_line>
+    <three_dots>Wait, what!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ほらね！<end_line>
       <three_dots>ってなんで！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     See!<end_line>
     <three_dots>Wait, what!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -145,15 +153,18 @@
     <sjis>
       何だ！？<end_line>
     </sjis>
+    <ascii>
+    Huh!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       何！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -331,17 +342,21 @@
       それほどまでに<end_line>
       あいつのことを<three_dots><end_line>
     </sjis>
+    <ascii>
+    So Magdrad trusts<end_line>
+    Anise that much<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       それほどまでに<end_line>
       あの人のことを<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So Magdrad trusts<end_line>
     Anise that much<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -609,15 +624,18 @@
     <sjis>
       そうだったのか<three_dots><end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そうだったの<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 07/021_25380268_18345ac.xml
+++ b/Day 07/021_25380268_18345ac.xml
@@ -84,17 +84,21 @@
       マグドラドだ<three_dots><end_line>
       やっぱ、スゲェな<three_dots><end_line>
     </sjis>
+    <ascii>
+    So this is Magdrad<three_dots><end_line>
+    Amazing<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       マグドラドだよね<three_dots><end_line>
       やっぱり、スゴイ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So this is Magdrad<three_dots><end_line>
     Amazing<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -208,17 +212,21 @@
       なんだと！？<end_line>
       そんなワケあるか！<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+    Of course not!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！？<end_line>
       そんなことないわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
     Of course not!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 07/022_25382156_1834d0c.xml
+++ b/Day 07/022_25382156_1834d0c.xml
@@ -90,15 +90,18 @@
     <sjis>
       どういうことだよ？<end_line>
     </sjis>
+    <ascii>
+    Hm?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どういうこと？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hm?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 07/024_25385724_1835afc.xml
+++ b/Day 07/024_25385724_1835afc.xml
@@ -86,15 +86,18 @@
     <sjis>
       あの、オレたちは<three_dots><end_line>
     </sjis>
+    <ascii>
+    Um, what should we<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あの、わたしたちは<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Um, what should we<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -152,17 +155,21 @@
       そうだな！<end_line>
       行こう、ミューノ！<end_line>
     </sjis>
+    <ascii>
+    You're right!<end_line>
+    Let's go, Murno!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そうだね！<end_line>
       行こう、ミューノ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're right!<end_line>
     Let's go, Murno!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -988,15 +995,18 @@
     <sjis>
       わかった！<end_line>
     </sjis>
+    <ascii>
+    Okay!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わかったわ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1263,6 +1273,11 @@
       このまま逃げるなんてできるかよ！<end_line>
       オレにも何か手伝わせてくれよ<end_line>
     </sjis>
+    <ascii>
+    I'm a Craftknight!<end_line>
+    I can't run away like this!<end_line>
+    Let me help with something!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1270,12 +1285,12 @@
       このまま逃げるなんてできないわ！<end_line>
       わたしにも何か手伝わせて<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm a Craftknight!<end_line>
     I can't run away like this!<end_line>
     Let me help with something!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -1365,6 +1380,11 @@
       オレにだって何かできることが<end_line>
       あるはずだろ？<end_line>
     </sjis>
+    <ascii>
+    No!<end_line>
+    There's got to be something <end_line>
+    even we can do, right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1372,12 +1392,12 @@
       わたしにだって何かできることが<end_line>
       あるはずでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No!<end_line>
     There's got to be something <end_line>
     even we can do, right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -1431,17 +1451,21 @@
       牢屋に行けばいいんだな<end_line>
       わかった！<end_line>
     </sjis>
+    <ascii>
+    To the prison then.<end_line>
+    Got it!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       牢屋に行けばいいのね<end_line>
       わかったわ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     To the prison then.<end_line>
     Got it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 07/026_25389484_18369ac.xml
+++ b/Day 07/026_25389484_18369ac.xml
@@ -63,15 +63,18 @@
     <sjis>
       なんだよそれ！<end_line>
     </sjis>
+    <ascii>
+    How could they!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによそれ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How could they!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -243,15 +246,18 @@
     <sjis>
       カギはどこだよ！？<end_line>
     </sjis>
+    <ascii>
+    Is there a key!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       カギはどこにあるの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Is there a key!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -274,13 +280,16 @@
     <sjis>
       わかったよ<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Okay!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わかったわよ<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 07/027_25391036_1836fbc.xml
+++ b/Day 07/027_25391036_1836fbc.xml
@@ -344,6 +344,11 @@
       急ごう！<end_line>
       お前も来い<end_line>
     </sjis>
+    <ascii>
+    We don't have time to argue.<end_line>
+    Let's hurry!<end_line>
+    You're coming too.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -351,12 +356,12 @@
       急ぐわよ！<end_line>
       あなたも来てよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We don't have time to argue.<end_line>
     Let's hurry!<end_line>
     You're coming too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 07/028_25393228_183784c.xml
+++ b/Day 07/028_25393228_183784c.xml
@@ -15,15 +15,18 @@
     <sjis>
       アニスをつれてきたぞ！<end_line>
     </sjis>
+    <ascii>
+    I brought Anise!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       アニスをつれてきたよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I brought Anise!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -45,15 +48,18 @@
     <sjis>
       今度は何だ！？<end_line>
     </sjis>
+    <ascii>
+    What was that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今度は何！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -457,15 +463,18 @@
     <sjis>
       そう<three_dots>なのか<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Is<three_dots>that so<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そう<three_dots>なの<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Is<three_dots>that so<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Day 07/029_25396796_183863c.xml
+++ b/Day 07/029_25396796_183863c.xml
@@ -123,17 +123,21 @@
       あいつ、逃げ出したのか！？<end_line>
       追いかけないと！<end_line>
     </sjis>
+    <ascii>
+    She ran away!?<end_line>
+    We have to find her!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あいつ、逃げ出したの！？<end_line>
       追いかけなきゃ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     She ran away!?<end_line>
     We have to find her!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 07/030_25398700_1838dac.xml
+++ b/Day 07/030_25398700_1838dac.xml
@@ -1,4 +1,3 @@
-#Starts at line 77
 <dialogue>
   <info box="nobox">
   <sjis>
@@ -312,17 +311,21 @@
       とにかくそいつを元に戻せば<end_line>
       全て元通りになるのか？<end_line>
     </sjis>
+    <ascii>
+    So if we put it back,<end_line>
+    will everything return to normal?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       とにかくそいつを元に戻せば<end_line>
       全て元通りになるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So if we put it back,<end_line>
     will everything return to normal?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -361,17 +364,21 @@
       え？<end_line>
       帰ってもいいのか？<end_line>
     </sjis>
+    <ascii>
+    Eh?<end_line>
+    We can leave?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え？<end_line>
       帰ってもいいの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh?<end_line>
     We can leave?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 07/032_25401644_183992c.xml
+++ b/Day 07/032_25401644_183992c.xml
@@ -20,17 +20,21 @@
       なんだ、コレ？<end_line>
       ウロコ？<end_line>
     </sjis>
+    <ascii>
+    What's this?<end_line>
+    A scale?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに、コレ？<end_line>
       ウロコ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's this?<end_line>
     A scale?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -55,6 +59,11 @@
       ありがとう<end_line>
       大事にするよ！<end_line>
     </sjis>
+    <ascii>
+    A charm<three_dots><end_line>
+    Thank you.<end_line>
+    I'll take good care of it!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -62,12 +71,12 @@
       ありがとう<end_line>
       大事にするね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     A charm<three_dots><end_line>
     Thank you.<end_line>
     I'll take good care of it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -91,17 +100,21 @@
       おう！<end_line>
       じゃ、元気で！<end_line>
     </sjis>
+    <ascii>
+    Sure!<end_line>
+    Stay healthy!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん！<end_line>
       じゃ、元気で！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sure!<end_line>
     Stay healthy!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -127,10 +140,6 @@
       Farewell!<end_line>
     </ascii>
   </female>
-  <ascii>
-    You too, old man<three_dots><end_line>
-    Goodbye!<end_line>
-  </ascii>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -307,17 +316,21 @@
       おっちゃん<end_line>
       もしかして、泣いてるのか？<end_line>
     </sjis>
+    <ascii>
+    Wait,<end_line>
+    are you<three_dots> crying?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       おじさん<end_line>
       もしかして、泣いてるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wait,<end_line>
     are you<three_dots> crying?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -343,17 +356,21 @@
       わかったよ！<end_line>
       じゃあ！<end_line>
     </sjis>
+    <ascii>
+    I know!<end_line>
+    Bye!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わかったわよ！<end_line>
       じゃあね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know!<end_line>
     Bye!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -387,15 +404,18 @@
     <sjis>
       やっぱり、息子さんのことを<three_dots><end_line>
     </sjis>
+    <ascii>
+    Like I thought, you're still<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       やっぱり、娘さんのことを<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Like I thought, you're still<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 07/034_25403468_183a04c.xml
+++ b/Day 07/034_25403468_183a04c.xml
@@ -52,6 +52,11 @@
       ミューノの村じゃないのか？<end_line>
       魔石を戻しに行くんだろ？<end_line>
     </sjis>
+    <ascii>
+    Where<three_dots><end_line>
+    Murno's village, right?<end_line>
+    Aren't we returning the Demon Stone?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -59,12 +64,12 @@
       ミューノの村じゃないの？<end_line>
       魔石を戻しに行くんでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Where<three_dots><end_line>
     Murno's village, right?<end_line>
     Aren't we returning the Demon Stone?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -107,6 +112,11 @@
       ミューノの村じゃないのか？<end_line>
       魔石を戻しに行くんだろ？<end_line>
     </sjis>
+    <ascii>
+    Where<three_dots><end_line>
+    Murno's village, right?<end_line>
+    Aren't we returning the Demon Stone?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -114,12 +124,12 @@
       ミューノの村じゃないの？<end_line>
       魔石を戻しに行くんでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Where<three_dots><end_line>
     Murno's village, right?<end_line>
     Aren't we returning the Demon Stone?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -162,6 +172,11 @@
       ミューノの村じゃないのか？<end_line>
       魔石を戻しに行くんだろ？<end_line>
     </sjis>
+    <ascii>
+    What<three_dots><end_line>
+    Murno's village, right?<end_line>
+    Aren't we returning the Demon Stone?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -169,12 +184,12 @@
       ミューノの村じゃないの？<end_line>
       魔石を戻しに行くんでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What<three_dots><end_line>
     Murno's village, right?<end_line>
     Aren't we returning the Demon Stone?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -215,6 +230,11 @@
       ミューノの村じゃないのか？<end_line>
       魔石を戻しに行くんだろ？<end_line>
     </sjis>
+    <ascii>
+    What<three_dots><end_line>
+    Murno's village, right?<end_line>
+    Aren't we returning the Demon Stone?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -222,12 +242,12 @@
       ミューノの村じゃないの？<end_line>
       魔石を戻しに行くんでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What<three_dots><end_line>
     Murno's village, right?<end_line>
     Aren't we returning the Demon Stone?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -365,15 +385,18 @@
     <sjis>
       オレ、なんかヘンなこと言った？<end_line>
     </sjis>
+    <ascii>
+    Did I say something strange?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたし、なんかヘンなこと言った？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Did I say something strange?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -424,15 +447,18 @@
     <sjis>
       そんなにほめるなよ～<end_line>
     </sjis>
+    <ascii>
+    Don't praise me so much~<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなにほめないでよ～<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't praise me so much~<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -481,15 +507,18 @@
     <sjis>
       そんなにほめるなよ～<end_line>
     </sjis>
+    <ascii>
+    Don't praise me so much~<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなにほめないでよ～<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't praise me so much~<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -538,15 +567,18 @@
     <sjis>
       そんなにほめるなよ～<end_line>
     </sjis>
+    <ascii>
+    Don't praise me so much~<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなにほめないでよ～<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't praise me so much~<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -595,15 +627,18 @@
     <sjis>
       そんなにほめるなよ～<end_line>
     </sjis>
+    <ascii>
+    Don't praise me so much~<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなにほめないでよ～<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't praise me so much~<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 07/038_25412396_183c32c.xml
+++ b/Day 07/038_25412396_183c32c.xml
@@ -195,6 +195,10 @@
       この人たちの言ってること<end_line>
       信じてるんですか？<end_line>
     </sjis>
+    <ascii>
+    Do all of you seriously believe<end_line>
+    what <player_nickname> just said?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -202,11 +206,11 @@
       この人たちの言ってること<end_line>
       信じてるんですか？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Do all of you seriously believe<end_line>
     what <player_nickname> just said?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -218,6 +222,10 @@
       オレたちがウソついてるって<end_line>
       言うのかよ！<end_line>
     </sjis>
+    <ascii>
+    What was that!?<end_line>
+    Are you calling me a liar!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -225,11 +233,11 @@
       わたしたちがウソついてるって<end_line>
       言うの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that!?<end_line>
     Are you calling me a liar!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -414,6 +422,10 @@
       オレたちは絶対<end_line>
       ウソなんかついてない！<end_line>
     </sjis>
+    <ascii>
+    But<three_dots>!<end_line>
+    I'm not lying!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -421,11 +433,11 @@
       わたしたちは絶対<end_line>
       ウソなんかついてないわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     But<three_dots>!<end_line>
     I'm not lying!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 07/039_25415004_183cd5c.xml
+++ b/Day 07/039_25415004_183cd5c.xml
@@ -90,15 +90,18 @@
     <sjis>
       お前、何を<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    What are you<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんた、何を<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What are you<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -211,15 +214,18 @@
     <sjis>
       で、どうしたらいいんだろ？<end_line>
     </sjis>
+    <ascii>
+    So, what should we do?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       で、どうしたらいいの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So, what should we do?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 07/041_25416956_183d4fc.xml
+++ b/Day 07/041_25416956_183d4fc.xml
@@ -70,17 +70,21 @@
       ごめん<end_line>
       心配かけたみたいで<end_line>
     </sjis>
+    <ascii>
+    Sorry.<end_line>
+    We've made you worry.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ごめんね<end_line>
       心配かけちゃって<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sorry.<end_line>
     We've made you worry.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 07/043_25418508_183db0c.xml
+++ b/Day 07/043_25418508_183db0c.xml
@@ -161,13 +161,16 @@
     <sjis>
       <three_dots>さっぱりわからん<end_line>
     </sjis>
+    <ascii>
+    <three_dots>I can't tell at all<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>全然わかんないよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots>I can't tell at all<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 07/046_25420316_183e21c.xml
+++ b/Day 07/046_25420316_183e21c.xml
@@ -26,24 +26,29 @@
 	<portrait_l entry="player" eye="sad" mouth="neutral">
 	<portrait_r entry="murno" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			うん<three_dots><end_line>
 			オレも何かしないとって思うんだけど<end_line>
 			どうしていいのかわからなくて<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん<three_dots><end_line>
-			わたしも何かしないとって思うんだけど<end_line>
-			どうしていいのかわからなくて<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah<three_dots><end_line>
     I know I have to do something,<end_line>
     but I don't know what<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん<three_dots><end_line>
+			わたしも何かしないとって思うんだけど<end_line>
+			どうしていいのかわからなくて<end_line>
+		</sjis>
+    <ascii>
+    Yeah<three_dots><end_line>
+    I know I have to do something,<end_line>
+    but I don't know what<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -63,24 +68,29 @@
 	<portrait_l entry="player" eye="serious" mouth="serious">
 	<portrait_r entry="murno" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			たしかにルイーズ村では<end_line>
 			色々あったもんなぁ<three_dots><end_line>
 			幻龍鬼まで召喚したし<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			たしかにルイーズ村では<end_line>
-			色々あったもんね<end_line>
-			幻龍鬼まで召喚したし<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     A lot of stuff did happen while<end_line>
     we were in Louise Village.<end_line>
     I even summoned a dragon!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			たしかにルイーズ村では<end_line>
+			色々あったもんね<end_line>
+			幻龍鬼まで召喚したし<end_line>
+		</sjis>
+    <ascii>
+    A lot of stuff did happen while<end_line>
+    we were in Louise Village.<end_line>
+    I even summoned a dragon!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -205,24 +215,29 @@
 	<portrait_l entry="player" eye="happy" mouth="neutral">
 	<portrait_r entry="murno" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			明日、ちゃんとみんなに説明すれば<end_line>
 			悪いのはアイツらだって<end_line>
 			みんなわかってくれるさ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			明日、ちゃんとみんなに説明すれば<end_line>
-			悪いのはアイツらだって<end_line>
-			みんなわかってくれるよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Once I get the chance to explain,<end_line>
     everyone will understand<end_line>
     that Anise is a villain!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			明日、ちゃんとみんなに説明すれば<end_line>
+			悪いのはアイツらだって<end_line>
+			みんなわかってくれるよ！<end_line>
+		</sjis>
+    <ascii>
+    Once I get the chance to explain,<end_line>
+    everyone will understand<end_line>
+    that Anise is a villain!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -244,23 +259,27 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="murno" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なに言ってるんだよ<end_line>
 			ミューノの言うことならみんな聞くさ<end_line>
 			だって、ミューノだもん<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Of course they will.<end_line>
+    You're Murno!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			なに言ってるの<end_line>
 			ミューノの言うことならみんな聞くよ<end_line>
 			だって、ミューノだもん<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Of course they will.<end_line>
     You're Murno!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">

--- a/Day 07/047_25421900_183e84c.xml
+++ b/Day 07/047_25421900_183e84c.xml
@@ -65,24 +65,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			でもさぁ、アニスたちは今でも<end_line>
 			どこかでミューノを狙ってるんだぜ<end_line>
 			ジッとしてられなくてさ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でもさ、アニスたちは今でも<end_line>
-			どこかでミューノを狙ってるんだよ<end_line>
-			ジッとしてられなくて<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I know, but Anise is still out<end_line>
     somewhere, aiming for Murno.<end_line>
     I can't just sit still<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でもさ、アニスたちは今でも<end_line>
+			どこかでミューノを狙ってるんだよ<end_line>
+			ジッとしてられなくて<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I know, but Anise is still out<end_line>
+    somewhere, aiming for Murno.<end_line>
+    I can't just sit still<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -202,24 +207,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			これからが、本番ってワケだな<three_dots><end_line>
 			初心に返って、気合い入れるか！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よおーし！<end_line>
-			これからが、本番ってワケだね<three_dots><end_line>
-			初心に返って、気合い入れよっか！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     We're finally at the main act<three_dots><end_line>
     For starters, let's get fired up!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よおーし！<end_line>
+			これからが、本番ってワケだね<three_dots><end_line>
+			初心に返って、気合い入れよっか！<end_line>
+		</sjis>
+    <ascii>
+    Alright!<end_line>
+    We're finally at the main act<three_dots><end_line>
+    For starters, let's get fired up!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -231,7 +241,7 @@
 	</sjis>
   <ascii>
     Fired<three_dots> Up?<end_line>
-  </ascii> 
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -239,24 +249,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="surprised" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだよ<end_line>
 			覚えてるだろ？<end_line>
 			最初に叫んだアレだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだよ<end_line>
-			覚えてるでしょ？<end_line>
-			最初に叫んだアレよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yep.<end_line>
     You remember, don't you?<end_line>
     The Craftknight's mantra!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだよ<end_line>
+			覚えてるでしょ？<end_line>
+			最初に叫んだアレよ！<end_line>
+		</sjis>
+    <ascii>
+    Yep.<end_line>
+    You remember, don't you?<end_line>
+    The Craftknight's mantra!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -300,18 +315,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>ってどうしたんだよ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots>ってどうしたの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots>Hey, what's wrong?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots>ってどうしたの？<end_line>
+		</sjis>
+    <ascii>
+    <three_dots>Hey, what's wrong?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -335,24 +353,29 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			だから<end_line>
 			叫ぶと、こう<end_line>
 			ハラの中から<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			だから<end_line>
-			叫ぶと、こう<end_line>
-			おなかの中から<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I told you,<end_line>
     the power comes<end_line>
     from your stomach<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			だから<end_line>
+			叫ぶと、こう<end_line>
+			おなかの中から<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I told you,<end_line>
+    the power comes<end_line>
+    from your stomach<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -404,24 +427,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			でもさぁ、アニスたちは今でも<end_line>
 			どこかでミューノを狙ってるんだぜ<end_line>
 			ジッとしてられなくてさ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でもさ、アニスたちは今でも<end_line>
-			どこかでミューノを狙ってるんだよ<end_line>
-			ジッとしてられなくて<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I know, but Anise is still out<end_line>
     somewhere, aiming for Murno.<end_line>
     I can't just sit still<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でもさ、アニスたちは今でも<end_line>
+			どこかでミューノを狙ってるんだよ<end_line>
+			ジッとしてられなくて<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I know, but Anise is still out<end_line>
+    somewhere, aiming for Murno.<end_line>
+    I can't just sit still<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -539,24 +567,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			これからが、本番ってワケだな<three_dots><end_line>
 			初心に返って、気合い入れるか！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よおーし！<end_line>
-			これからが、本番ってワケだね<three_dots><end_line>
-			初心に返って、気合い入れよっか！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     We're finally at the main act<three_dots><end_line>
     For starters, let's get fired up!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よおーし！<end_line>
+			これからが、本番ってワケだね<three_dots><end_line>
+			初心に返って、気合い入れよっか！<end_line>
+		</sjis>
+    <ascii>
+    Alright!<end_line>
+    We're finally at the main act<three_dots><end_line>
+    For starters, let's get fired up!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -578,24 +611,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			そうだよ<end_line>
 			覚えてるだろ？<end_line>
 			最初に叫んだアレだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだよ<end_line>
-			覚えてるでしょ？<end_line>
-			最初に叫んだアレよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yep.<end_line>
     You remember, don't you?<end_line>
     The Craftknight's mantra!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだよ<end_line>
+			覚えてるでしょ？<end_line>
+			最初に叫んだアレよ！<end_line>
+		</sjis>
+    <ascii>
+    Yep.<end_line>
+    You remember, don't you?<end_line>
+    The Craftknight's mantra!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -639,18 +677,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>ってどうしたんだよ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots>ってどうしたの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots>Hey, what's wrong?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots>ってどうしたの？<end_line>
+		</sjis>
+    <ascii>
+    <three_dots>Hey, what's wrong?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -732,24 +773,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			だけどアニスたちは今でも<end_line>
 			どこかでミューノを狙ってるんだぜ<end_line>
 			ジッとしてられなくてさ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でもアニスたちは今でも<end_line>
-			どこかでミューノを狙ってるんだよ<end_line>
-			ジッとしてられなくて<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I know, but Anise is still out<end_line>
     somewhere, aiming for Murno.<end_line>
     I can't just sit still<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でもアニスたちは今でも<end_line>
+			どこかでミューノを狙ってるんだよ<end_line>
+			ジッとしてられなくて<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I know, but Anise is still out<end_line>
+    somewhere, aiming for Murno.<end_line>
+    I can't just sit still<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -867,24 +913,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なに言ってんだよ<end_line>
 			これからが本番ってことだろ？<end_line>
 			初心に返って、気合い入れるか！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なに言ってるのよ<end_line>
-			これからが本番ってことでしょ？<end_line>
-			初心に返って、気合い入れよっか！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We're just getting started!<end_line>
     It's finally time for the main act!<end_line>
     For starters, let's get fired up!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なに言ってるのよ<end_line>
+			これからが本番ってことでしょ？<end_line>
+			初心に返って、気合い入れよっか！<end_line>
+		</sjis>
+    <ascii>
+    We're just getting started!<end_line>
+    It's finally time for the main act!<end_line>
+    For starters, let's get fired up!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -906,24 +957,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="surprised" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そうだよ<end_line>
 			覚えてるだろ？<end_line>
 			最初に叫んだアレだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだよ<end_line>
-			覚えてるでしょ？<end_line>
-			最初に叫んだアレよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yep.<end_line>
     You remember, don't you?<end_line>
     The Craftknight's mantra!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだよ<end_line>
+			覚えてるでしょ？<end_line>
+			最初に叫んだアレよ！<end_line>
+		</sjis>
+    <ascii>
+    Yep.<end_line>
+    You remember, don't you?<end_line>
+    The Craftknight's mantra!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -967,18 +1023,21 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>ってどうしたんだよ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots>ってどうしたの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots>Hey, what's wrong?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots>ってどうしたの？<end_line>
+		</sjis>
+    <ascii>
+    <three_dots>Hey, what's wrong?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1000,24 +1059,29 @@
 	<portrait_l entry="player" eye="surprised" mouth="stressed">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			え<three_dots>！？<end_line>
 			<partner>がオレにお願いなんて<three_dots><end_line>
 			そんなにイヤなのか<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			え<three_dots>！？<end_line>
-			<partner>がわたしにお願いなんて<three_dots><end_line>
-			そんなにイヤなの<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Eh<three_dots>!?<end_line>
     <partner> is begging me<three_dots><end_line>
     Do you hate it that much<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			え<three_dots>！？<end_line>
+			<partner>がわたしにお願いなんて<three_dots><end_line>
+			そんなにイヤなの<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Eh<three_dots>!?<end_line>
+    <partner> is begging me<three_dots><end_line>
+    Do you hate it that much<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1039,24 +1103,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			でもさぁ、アニスたちは今でも<end_line>
 			どこかでミューノを狙ってるんだぜ<end_line>
 			ジッとしてられなくてさ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でもさ、アニスたちは今でも<end_line>
-			どこかでミューノを狙ってるんだよ<end_line>
-			ジッとしてられなくて<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I know, but Anise is still out<end_line>
     somewhere, aiming for Murno.<end_line>
     I can't just sit still<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でもさ、アニスたちは今でも<end_line>
+			どこかでミューノを狙ってるんだよ<end_line>
+			ジッとしてられなくて<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I know, but Anise is still out<end_line>
+    somewhere, aiming for Murno.<end_line>
+    I can't just sit still<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1166,24 +1235,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			これからが、本番ってワケだな<three_dots><end_line>
 			初心に返って、気合い入れるか！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よおーし！<end_line>
-			これからが、本番ってワケだね<three_dots><end_line>
-			初心に返って、気合い入れよっか！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     We're finally at the main act<three_dots><end_line>
     For starters, let's get fired up!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よおーし！<end_line>
+			これからが、本番ってワケだね<three_dots><end_line>
+			初心に返って、気合い入れよっか！<end_line>
+		</sjis>
+    <ascii>
+    Alright!<end_line>
+    We're finally at the main act<three_dots><end_line>
+    For starters, let's get fired up!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1203,24 +1277,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだよ<end_line>
 			覚えてるだろ？<end_line>
 			最初に叫んだアレだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだよ<end_line>
-			覚えてるでしょ？<end_line>
-			最初に叫んだアレよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yep.<end_line>
     You remember, don't you?<end_line>
     The Craftknight's mantra!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだよ<end_line>
+			覚えてるでしょ？<end_line>
+			最初に叫んだアレよ！<end_line>
+		</sjis>
+    <ascii>
+    Yep.<end_line>
+    You remember, don't you?<end_line>
+    The Craftknight's mantra!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1260,18 +1339,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>ってどうしたんだよ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots>ってどうしたの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots>Hey, what's wrong?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots>ってどうしたの？<end_line>
+		</sjis>
+    <ascii>
+    <three_dots>Hey, what's wrong?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">

--- a/Day 07/048_25425324_183f5ac.xml
+++ b/Day 07/048_25425324_183f5ac.xml
@@ -33,6 +33,11 @@
       元気いっぱいだぜ！<end_line>
       やっぱ親方のシチューは最高だぜ！<end_line>
     </sjis>
+    <ascii>
+    Master's stew has<end_line>
+    got me all fired up!<end_line>
+    It really is the best!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -40,12 +45,12 @@
       元気いっぱいだよ！<end_line>
       やっぱ親方のシチューは最高だね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Master's stew has<end_line>
     got me all fired up!<end_line>
     It really is the best!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -83,6 +88,11 @@
       それにやる気も出てきたから<end_line>
       こうやって見回りを<three_dots><end_line>
     </sjis>
+    <ascii>
+    It's fine, it's for Murno.<end_line>
+    It's thanks to that energy<end_line>
+    I can patrol like this<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -90,12 +100,12 @@
       それにやる気も出てきたから<end_line>
       こうやって見回りを<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's fine, it's for Murno.<end_line>
     It's thanks to that energy<end_line>
     I can patrol like this<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -122,6 +132,11 @@
       あいつら絶対に今も<end_line>
       ミューノのことねらってるぜ！<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+    I'm sure they're<end_line>
+    still going after Murno!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -129,12 +144,12 @@
       あいつら絶対に今も<end_line>
       ミューノのことねらってるよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
     I'm sure they're<end_line>
     still going after Murno!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -160,17 +175,21 @@
       えー<end_line>
       でも、オレだって<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ehhh?<end_line>
+    But, even I<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       えー<end_line>
       でも、わたしだって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ehhh?<end_line>
     But, even I<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -195,15 +214,18 @@
     <sjis>
       ネコといっしょにすんな！<end_line>
     </sjis>
+    <ascii>
+    Don't compare me to a cat!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ネコといっしょにしないでよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't compare me to a cat!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -258,6 +280,11 @@
       そんなこと考えてたら<end_line>
       寝られなくなりそうだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Uu<three_dots><end_line>
+    I feel like I won't be able<end_line>
+    to fall asleep if I do that<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -265,12 +292,12 @@
       そんなこと考えてたら<end_line>
       寝られなくなりそう<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uu<three_dots><end_line>
     I feel like I won't be able<end_line>
     to fall asleep if I do that<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -296,15 +323,19 @@
       うー<three_dots><end_line>
       それはそれで寝られなくなりそうだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ugh<three_dots><end_line>
+    That's just make it worse<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うー<three_dots><end_line>
       それはそれで寝られなくなりそう<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ugh<three_dots><end_line>
     That's just make it worse<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 07/049_25427132_183fcbc.xml
+++ b/Day 07/049_25427132_183fcbc.xml
@@ -32,17 +32,21 @@
       なんだよ、それ！<end_line>
       オレはただ、この辺りの見回りを<three_dots><end_line>
     </sjis>
+    <ascii>
+    What? No!<end_line>
+    I was just patrolling around here<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！<end_line>
       わたしはただ、この辺りの見回りを<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What? No!<end_line>
     I was just patrolling around here<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -96,6 +100,11 @@
       仲間だと思っているのか？<end_line>
       ボスタフさんがそう言ったのか！？<end_line>
     </sjis>
+    <ascii>
+    Do you still think<end_line>
+    they're on our side?<end_line>
+    Did Bostaph say that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -103,12 +112,12 @@
       仲間だと思っているの？<end_line>
       ボスタフさんがそう言ったから！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Do you still think<end_line>
     they're on our side?<end_line>
     Did Bostaph say that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -132,17 +141,21 @@
       なんだよ<three_dots><end_line>
       さっきはあんなに<three_dots><end_line>
     </sjis>
+    <ascii>
+    What's with that<three_dots><end_line>
+    Why haven't you<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ<three_dots><end_line>
       さっきはあんなに<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's with that<three_dots><end_line>
     Why haven't you<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 07/050_25428556_184024c.xml
+++ b/Day 07/050_25428556_184024c.xml
@@ -46,15 +46,18 @@
     <sjis>
       オレもなんかできないかなって<three_dots><end_line>
     </sjis>
+    <ascii>
+    I thought I could do something<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしもなんかできないかなって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I thought I could do something<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -91,17 +94,21 @@
       なんだよ<end_line>
       そんな言い方ないだろ？<end_line>
     </sjis>
+    <ascii>
+    Come on,<end_line>
+    is that really enough?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ<end_line>
       そんな言い方ないでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Come on,<end_line>
     is that really enough?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -169,6 +176,11 @@
       あれはアニキが悪いんじゃないよ！<end_line>
       オレがミューノを支えられてたら<three_dots><end_line>
     </sjis>
+    <ascii>
+    Come on!<end_line>
+    That wasn't your fault!<end_line>
+    If I had supported Murno<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -176,12 +188,12 @@
       あれはアニキが悪いんじゃないよ！<end_line>
       わたしがミューノを支えられてたら<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Come on!<end_line>
     That wasn't your fault!<end_line>
     If I had supported Murno<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -244,17 +256,21 @@
       わ、わかったよ<three_dots><end_line>
       帰るよ<end_line>
     </sjis>
+    <ascii>
+    O-okay, fine<three_dots><end_line>
+    I'm going then.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わ、わかったわよ<three_dots><end_line>
       帰るよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     O-okay, fine<three_dots><end_line>
     I'm going then.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 07/051_25430172_184089c.xml
+++ b/Day 07/051_25430172_184089c.xml
@@ -46,15 +46,18 @@
     <sjis>
       じっとしてらんないよ<end_line>
     </sjis>
+    <ascii>
+    I can't just sit still.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       じっとしてられないよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I can't just sit still.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -145,15 +148,18 @@
     <sjis>
       な、なんだよ！？<end_line>
     </sjis>
+    <ascii>
+    W-what!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な、なによ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     W-what!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 07/24523404_176328c.xml
+++ b/Day 07/24523404_176328c.xml
@@ -4,18 +4,21 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いよいよトラムとの勝負だぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いよいよトラムとの勝負だね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     It's time for our match with Tram.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いよいよトラムとの勝負だね<end_line>
+		</sjis>
+    <ascii>
+    It's time for our match with Tram.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -37,7 +40,7 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			おう！<end_line>
 			行くぜ！<end_line>
 		</sjis>
@@ -45,9 +48,9 @@
       Yeah!<end_line>
       Let's go!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			うん！<end_line>
 			行こう！<end_line>
 		</sjis>
@@ -55,7 +58,7 @@
       I will!<end_line>
       Let's go!<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -63,18 +66,21 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いよいよトラムとの勝負だぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いよいよトラムとの勝負だね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     It's time for our match with Tram.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いよいよトラムとの勝負だね<end_line>
+		</sjis>
+    <ascii>
+    It's time for our match with Tram.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -98,7 +104,7 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			おう！<end_line>
 			誓うぜ！<end_line>
 		</sjis>
@@ -106,17 +112,17 @@
       Yeah!<end_line>
       I swear!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			うん！<end_line>
 			誓うわ！<end_line>
 		</sjis>
-	</female>
     <ascii>
       I will!<end_line>
       I swear!<end_line>
     </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -124,18 +130,21 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いよいよトラムとの勝負だぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いよいよトラムとの勝負だね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     It's time for our match with Tram.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いよいよトラムとの勝負だね<end_line>
+		</sjis>
+    <ascii>
+    It's time for our match with Tram.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -157,39 +166,46 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			はいはい、ミューノのためだろ？<end_line>
 			がんばるよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			はいはい、ミューノのためでしょ？<end_line>
-			がんばるよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     For Murno, right? I know, I know.<end_line>
     I'll do my best.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			はいはい、ミューノのためでしょ？<end_line>
+			がんばるよ<end_line>
+		</sjis>
+    <ascii>
+    For Murno, right? I know, I know.<end_line>
+    I'll do my best.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			いよいよトラムとの勝負だぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いよいよトラムとの勝負だね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     It's time for our match with Tram.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いよいよトラムとの勝負だね<end_line>
+		</sjis>
+    <ascii>
+    It's time for our match with Tram.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -209,7 +225,7 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			おう！<end_line>
 			行くぜ！<end_line>
 		</sjis>
@@ -217,17 +233,17 @@
       Yeah!<end_line>
       Let's go!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			うん！<end_line>
 			行こう！<end_line>
 		</sjis>
-	</female>
     <ascii>
       I will!<end_line>
       Let's go!<end_line>
     </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -235,24 +251,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			トラムとの勝負の準備を調えて<end_line>
 			遺跡前の広場に行こう<end_line>
 			みんな待ってるぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			トラムとの勝負の準備を調えて<end_line>
-			遺跡前の広場に行こう<end_line>
-			みんな待ってるよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Everyone's waiting at the<end_line>
     plaza in front of the ruins.<end_line>
     I have to make sure I'm ready.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			トラムとの勝負の準備を調えて<end_line>
+			遺跡前の広場に行こう<end_line>
+			みんな待ってるよ<end_line>
+		</sjis>
+    <ascii>
+    Everyone's waiting at the<end_line>
+    plaza in front of the ruins.<end_line>
+    I have to make sure I'm ready.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -276,21 +297,25 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いきおいで決まった勝負だ<end_line>
 			細かいことは気にするな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いきおいで決まった勝負だよ<end_line>
-			細かいことは気にしちゃダメ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, that was decided for us.<end_line>
     Nothing we can do about it now!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いきおいで決まった勝負だよ<end_line>
+			細かいことは気にしちゃダメ！<end_line>
+		</sjis>
+    <ascii>
+    Well, that was decided for us.<end_line>
+    Nothing we can do about it now!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -298,24 +323,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			トラムとの勝負の準備を調えて<end_line>
 			遺跡前の広場に行こう<end_line>
 			みんな待ってるぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			トラムとの勝負の準備を調えて<end_line>
-			遺跡前の広場に行こう<end_line>
-			みんな待ってるよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Everyone's waiting at the<end_line>
     plaza in front of the ruins.<end_line>
     I have to make sure I'm ready.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			トラムとの勝負の準備を調えて<end_line>
+			遺跡前の広場に行こう<end_line>
+			みんな待ってるよ<end_line>
+		</sjis>
+    <ascii>
+    Everyone's waiting at the<end_line>
+    plaza in front of the ruins.<end_line>
+    I have to make sure I'm ready.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -339,21 +369,25 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			いきおいで決まった勝負だ<end_line>
 			細かいことは気にするな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いきおいで決まった勝負だよ<end_line>
-			細かいことは気にしちゃダメ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, that was decided for us.<end_line>
     Nothing we can do about it now!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いきおいで決まった勝負だよ<end_line>
+			細かいことは気にしちゃダメ！<end_line>
+		</sjis>
+    <ascii>
+    Well, that was decided for us.<end_line>
+    Nothing we can do about it now!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -361,24 +395,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			トラムとの勝負の準備を調えて<end_line>
 			遺跡前の広場に行こう<end_line>
 			みんな待ってるぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			トラムとの勝負の準備を調えて<end_line>
-			遺跡前の広場に行こう<end_line>
-			みんな待ってるよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Everyone's waiting at the<end_line>
     plaza in front of the ruins.<end_line>
     I have to make sure I'm ready.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			トラムとの勝負の準備を調えて<end_line>
+			遺跡前の広場に行こう<end_line>
+			みんな待ってるよ<end_line>
+		</sjis>
+    <ascii>
+    Everyone's waiting at the<end_line>
+    plaza in front of the ruins.<end_line>
+    I have to make sure I'm ready.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -402,45 +441,54 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			いきおいで決まった勝負だ<end_line>
 			細かいことは気にするな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いきおいで決まった勝負だよ<end_line>
-			細かいことは気にしちゃダメ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, that was decided for us.<end_line>
     Nothing we can do about it now!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いきおいで決まった勝負だよ<end_line>
+			細かいことは気にしちゃダメ！<end_line>
+		</sjis>
+    <ascii>
+    Well, that was decided for us.<end_line>
+    Nothing we can do about it now!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			トラムとの勝負の準備を調えて<end_line>
 			遺跡前の広場に行こう<end_line>
 			みんな待ってるぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			トラムとの勝負の準備を調えて<end_line>
-			遺跡前の広場に行こう<end_line>
-			みんな待ってるよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Everyone's waiting at the<end_line>
     plaza in front of the ruins.<end_line>
     I have to make sure I'm ready.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			トラムとの勝負の準備を調えて<end_line>
+			遺跡前の広場に行こう<end_line>
+			みんな待ってるよ<end_line>
+		</sjis>
+    <ascii>
+    Everyone's waiting at the<end_line>
+    plaza in front of the ruins.<end_line>
+    I have to make sure I'm ready.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -462,21 +510,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			いきおいで決まった勝負だ<end_line>
 			細かいことは気にするな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いきおいで決まった勝負だよ<end_line>
-			細かいことは気にしちゃダメ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, that was decided for us.<end_line>
     Nothing we can do about it now!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いきおいで決まった勝負だよ<end_line>
+			細かいことは気にしちゃダメ！<end_line>
+		</sjis>
+    <ascii>
+    Well, that was decided for us.<end_line>
+    Nothing we can do about it now!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -512,18 +564,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<portrait_r entry="partner" eye="surprised" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			お、おう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    R-right.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			う、うん<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     R-right.<end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -559,18 +614,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			お、おう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    R-right.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			う、うん<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     R-right.<end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -606,21 +664,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<portrait_r entry="partner" eye="special" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノのことになると<end_line>
 			やっぱちがうなぁ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノのことになると<end_line>
-			やっぱちがうなぁ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     He really is different<end_line>
     when it comes to Murno<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノのことになると<end_line>
+			やっぱちがうなぁ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    He really is different<end_line>
+    when it comes to Murno<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -653,18 +715,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			お、おう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    R-right.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			う、うん<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     R-right.<end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -672,24 +737,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			裁きの間まで行かなきゃならないけど<end_line>
 			グマグの炎遺跡ってすごく暑いぞ<end_line>
 			<partner>、大丈夫か？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			裁きの間まで行かなきゃならないけど<end_line>
-			グマグの炎遺跡ってすごく暑いよ<end_line>
-			<partner>、大丈夫？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Do we really have to go in there?<end_line>
     Those ruins are ridiculously hot<three_dots><end_line>
     <partner>, how are you doing?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			裁きの間まで行かなきゃならないけど<end_line>
+			グマグの炎遺跡ってすごく暑いよ<end_line>
+			<partner>、大丈夫？<end_line>
+		</sjis>
+    <ascii>
+    Do we really have to go in there?<end_line>
+    Those ruins are ridiculously hot<three_dots><end_line>
+    <partner>, how are you doing?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -739,24 +809,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			裁きの間まで行かなきゃならないけど<end_line>
 			グマグの炎遺跡ってすごく暑いぞ<end_line>
 			<partner>、大丈夫か？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			裁きの間まで行かなきゃならないけど<end_line>
-			グマグの炎遺跡ってすごく暑いよ<end_line>
-			<partner>、大丈夫？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Do we really have to go in there?<end_line>
     Those ruins are ridiculously hot<three_dots><end_line>
     <partner>, how are you doing?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			裁きの間まで行かなきゃならないけど<end_line>
+			グマグの炎遺跡ってすごく暑いよ<end_line>
+			<partner>、大丈夫？<end_line>
+		</sjis>
+    <ascii>
+    Do we really have to go in there?<end_line>
+    Those ruins are ridiculously hot<three_dots><end_line>
+    <partner>, how are you doing?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -780,24 +855,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			へぇ、スゴイな<end_line>
 			<partner>ってモサモサしてるから<end_line>
 			暑いのには弱いかと思った<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			へぇ、スゴイね<end_line>
-			<partner>ってモサモサしてるから<end_line>
-			暑いのには弱いかと思った<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Huh, that's cool.<end_line>
     You're really hairy,<end_line>
     so I thought you'd be weak to heat.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			へぇ、スゴイね<end_line>
+			<partner>ってモサモサしてるから<end_line>
+			暑いのには弱いかと思った<end_line>
+		</sjis>
+    <ascii>
+    Huh, that's cool.<end_line>
+    You're really hairy,<end_line>
+    so I thought you'd be weak to heat.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -817,24 +897,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			裁きの間まで行かなきゃならないけど<end_line>
 			グマグの炎遺跡ってすごく暑いぞ<end_line>
 			<partner>、大丈夫か？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			裁きの間まで行かなきゃならないけど<end_line>
-			グマグの炎遺跡ってすごく暑いよ<end_line>
-			<partner>、大丈夫？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Do we really have to go in there?<end_line>
     Those ruins are ridiculously hot<three_dots><end_line>
     <partner>, how are you doing?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			裁きの間まで行かなきゃならないけど<end_line>
+			グマグの炎遺跡ってすごく暑いよ<end_line>
+			<partner>、大丈夫？<end_line>
+		</sjis>
+    <ascii>
+    Do we really have to go in there?<end_line>
+    Those ruins are ridiculously hot<three_dots><end_line>
+    <partner>, how are you doing?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -858,21 +943,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="stressed">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ちょっと、<partner><three_dots>？<end_line>
 			お前、ホント大丈夫か？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ちょっと、<partner><three_dots>？<end_line>
-			あなた、ホントに大丈夫？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Umm, <partner><three_dots>?<end_line>
     Are you okay?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ちょっと、<partner><three_dots>？<end_line>
+			あなた、ホントに大丈夫？<end_line>
+		</sjis>
+    <ascii>
+    Umm, <partner><three_dots>?<end_line>
+    Are you okay?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -909,24 +998,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			裁きの間まで行かなきゃならないけど<end_line>
 			グマグの炎遺跡ってすごく暑いぞ<end_line>
 			<partner>、大丈夫か？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			裁きの間まで行かなきゃならないけど<end_line>
-			グマグの炎遺跡ってすごく暑いよ<end_line>
-			<partner>、大丈夫？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Do we really have to go in there?<end_line>
     Those ruins are ridiculously hot<three_dots><end_line>
     <partner>, how are you doing?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			裁きの間まで行かなきゃならないけど<end_line>
+			グマグの炎遺跡ってすごく暑いよ<end_line>
+			<partner>、大丈夫？<end_line>
+		</sjis>
+    <ascii>
+    Do we really have to go in there?<end_line>
+    Those ruins are ridiculously hot<three_dots><end_line>
+    <partner>, how are you doing?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -984,24 +1078,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いよいよトラムと１対１の勝負だ！<end_line>
 			最強の武器をひとつ<end_line>
 			バッチリ装備して行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いよいよトラムと１対１の勝負だ！<end_line>
-			最強の武器をひとつ<end_line>
-			シッカリ装備して行かなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Time for my one on one with Tram!<end_line>
     Gotta make sure I've got<end_line>
     my best weapon ready to go!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いよいよトラムと１対１の勝負だ！<end_line>
+			最強の武器をひとつ<end_line>
+			シッカリ装備して行かなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    Time for my one on one with Tram!<end_line>
+    Gotta make sure I've got<end_line>
+    my best weapon ready to go!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1023,24 +1122,29 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			おう！<end_line>
 			<partner>が応援してくれるんだ<end_line>
 			絶対に勝つぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん！<end_line>
-			<partner>が応援してくれるんだ<end_line>
-			絶対に勝つよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
     With you cheering me on,<end_line>
     I'm sure to win!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん！<end_line>
+			<partner>が応援してくれるんだ<end_line>
+			絶対に勝つよ！<end_line>
+		</sjis>
+    <ascii>
+    Yeah!<end_line>
+    With you cheering me on,<end_line>
+    I'm sure to win!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1048,24 +1152,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いよいよトラムと１対１の勝負だ！<end_line>
 			最強の武器をひとつ<end_line>
 			バッチリ装備して行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いよいよトラムと１対１の勝負だ！<end_line>
-			最強の武器をひとつ<end_line>
-			シッカリ装備して行かなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Time for my one on one with Tram!<end_line>
     Gotta make sure I've got<end_line>
     my best weapon ready to go!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いよいよトラムと１対１の勝負だ！<end_line>
+			最強の武器をひとつ<end_line>
+			シッカリ装備して行かなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    Time for my one on one with Tram!<end_line>
+    Gotta make sure I've got<end_line>
+    my best weapon ready to go!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1089,24 +1198,29 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			おう！<end_line>
 			<partner>が応援してくれるんだ<end_line>
 			絶対に勝つぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん！<end_line>
-			<partner>が応援してくれるんだ<end_line>
-			絶対に勝つよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
     With you cheering me on,<end_line>
     I'm sure to win!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん！<end_line>
+			<partner>が応援してくれるんだ<end_line>
+			絶対に勝つよ！<end_line>
+		</sjis>
+    <ascii>
+    Yeah!<end_line>
+    With you cheering me on,<end_line>
+    I'm sure to win!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1114,24 +1228,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いよいよトラムと１対１の勝負だ！<end_line>
 			最強の武器をひとつ<end_line>
 			バッチリ装備して行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いよいよトラムと１対１の勝負だ！<end_line>
-			最強の武器をひとつ<end_line>
-			シッカリ装備して行かなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Time for my one on one with Tram!<end_line>
     Gotta make sure I've got<end_line>
     my best weapon ready to go!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いよいよトラムと１対１の勝負だ！<end_line>
+			最強の武器をひとつ<end_line>
+			シッカリ装備して行かなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    Time for my one on one with Tram!<end_line>
+    Gotta make sure I've got<end_line>
+    my best weapon ready to go!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1167,48 +1286,58 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			言ってることはブッソウだけど<end_line>
 			オレを心配してくれていると<end_line>
 			思いたい！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			言ってることはブッソウだけど<end_line>
-			わたしを心配してくれていると<end_line>
-			思いたい！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What you're saying is disturbing,<end_line>
     so I'll just take it as your<end_line>
     way of worrying about me!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			言ってることはブッソウだけど<end_line>
+			わたしを心配してくれていると<end_line>
+			思いたい！<end_line>
+		</sjis>
+    <ascii>
+    What you're saying is disturbing,<end_line>
+    so I'll just take it as your<end_line>
+    way of worrying about me!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			いよいよトラムと１対１の勝負だ！<end_line>
 			最強の武器をひとつ<end_line>
 			バッチリ装備して行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いよいよトラムと１対１の勝負だ！<end_line>
-			最強の武器をひとつ<end_line>
-			シッカリ装備して行かなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Time for my one on one with Tram!<end_line>
     Gotta make sure I've got<end_line>
     my best weapon ready to go!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いよいよトラムと１対１の勝負だ！<end_line>
+			最強の武器をひとつ<end_line>
+			シッカリ装備して行かなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    Time for my one on one with Tram!<end_line>
+    Gotta make sure I've got<end_line>
+    my best weapon ready to go!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1230,21 +1359,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			あ、うん<end_line>
 			ありがとう、わかったよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あ、うん<end_line>
-			ありがとう、わかった<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ah, right.<end_line>
     Thanks, I got it.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あ、うん<end_line>
+			ありがとう、わかった<end_line>
+		</sjis>
+    <ascii>
+    Ah, right.<end_line>
+    Thanks, I got it.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1268,24 +1401,29 @@
 	<portrait_l entry="player" eye="sad" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			いいけどさ、よく考えたら<end_line>
 			オレが行っても魔晶柱を調べるのに<end_line>
 			ジャマになったりしないかな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いいけどさ、よく考えたら<end_line>
-			わたしが行っても魔晶柱を調べるのに<end_line>
-			ジャマになったりしないかな<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm all for it, but really,<end_line>
     won't we just be getting<end_line>
     in the way if we do<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いいけどさ、よく考えたら<end_line>
+			わたしが行っても魔晶柱を調べるのに<end_line>
+			ジャマになったりしないかな<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I'm all for it, but really,<end_line>
+    won't we just be getting<end_line>
+    in the way if we do<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1335,24 +1473,29 @@
 	<portrait_l entry="player" eye="sad" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			いいけどさ、よく考えたら<end_line>
 			オレが行っても魔晶柱を調べるのに<end_line>
 			ジャマになったりしないかな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いいけどさ、よく考えたら<end_line>
-			わたしが行っても魔晶柱を調べるのに<end_line>
-			ジャマになったりしないかな<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm all for it, but really,<end_line>
     won't we just be getting<end_line>
     in the way if we do<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いいけどさ、よく考えたら<end_line>
+			わたしが行っても魔晶柱を調べるのに<end_line>
+			ジャマになったりしないかな<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I'm all for it, but really,<end_line>
+    won't we just be getting<end_line>
+    in the way if we do<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1376,7 +1519,7 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そんなことあるか！<end_line>
 			行くぞ！<end_line>
 		</sjis>
@@ -1384,9 +1527,9 @@
       O-of course not!<end_line>
       Let's go!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			なに言ってるのよ！<end_line>
 			もう、行くわよ！<end_line>
 		</sjis>
@@ -1394,7 +1537,7 @@
       What's that mean!?<end_line>
       Ugh, let's just go!<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1418,24 +1561,29 @@
 	<portrait_l entry="player" eye="sad" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			でもさ、よく考えたら<end_line>
 			オレが行っても魔晶柱を調べるのに<end_line>
 			ジャマになったりしないかな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも、よく考えたら<end_line>
-			わたしが行っても魔晶柱を調べるのに<end_line>
-			ジャマになったりしないかな<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Now that I think about it,<end_line>
     won't we just be getting<end_line>
     in the way if we do<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でも、よく考えたら<end_line>
+			わたしが行っても魔晶柱を調べるのに<end_line>
+			ジャマになったりしないかな<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Now that I think about it,<end_line>
+    won't we just be getting<end_line>
+    in the way if we do<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1483,24 +1631,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			いいけどさ、よく考えたら<end_line>
 			オレが行っても魔晶柱を調べるのに<end_line>
 			ジャマになったりしないかな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いいけどさ、よく考えたら<end_line>
-			わたしが行っても魔晶柱を調べるのに<end_line>
-			ジャマになったりしないかな<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm all for it, but really,<end_line>
     won't we just be getting<end_line>
     in the way if we do<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いいけどさ、よく考えたら<end_line>
+			わたしが行っても魔晶柱を調べるのに<end_line>
+			ジャマになったりしないかな<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I'm all for it, but really,<end_line>
+    won't we just be getting<end_line>
+    in the way if we do<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1522,7 +1675,7 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			うっわ！<end_line>
 			ヒデェ！<end_line>
 		</sjis>
@@ -1530,9 +1683,9 @@
       Uwah!<end_line>
       That hurts!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			なにそれ！<end_line>
 			ひっどーい！<end_line>
 		</sjis>
@@ -1540,7 +1693,7 @@
       What!?<end_line>
       You're terrible!<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1548,24 +1701,29 @@
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間たちって<end_line>
 			本当にヒドイことを<end_line>
 			やってたんだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間たちって<end_line>
-			本当にヒドイことを<end_line>
-			やってたんだね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise and her goons<end_line>
     are really terrible<end_line>
     aren't they<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間たちって<end_line>
+			本当にヒドイことを<end_line>
+			やってたんだね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Anise and her goons<end_line>
+    are really terrible<end_line>
+    aren't they<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1589,24 +1747,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 			今はとにかく遺跡の奥の<end_line>
 			魔晶柱を調べに行こう<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Right<three_dots><end_line>
+    For now we still need to find<end_line>
+    the Crystal Pillar in the ruins.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<three_dots><end_line>
 			今はとにかく遺跡の奥の<end_line>
 			魔晶柱を調べに行こう<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
     For now we still need to find<end_line>
     the Crystal Pillar in the ruins.<end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1614,24 +1777,29 @@
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間たちって<end_line>
 			本当にヒドイことを<end_line>
 			やってたんだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間たちって<end_line>
-			本当にヒドイことを<end_line>
-			やってたんだね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise and her goons<end_line>
     are really terrible<end_line>
     aren't they<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間たちって<end_line>
+			本当にヒドイことを<end_line>
+			やってたんだね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Anise and her goons<end_line>
+    are really terrible<end_line>
+    aren't they<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1655,24 +1823,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 			今はとにかく遺跡の奥の<end_line>
 			魔晶柱を調べに行こう<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Right<three_dots><end_line>
+    For now we still need to find<end_line>
+    the Crystal Pillar in the ruins.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<three_dots><end_line>
 			今はとにかく遺跡の奥の<end_line>
 			魔晶柱を調べに行こう<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
     For now we still need to find<end_line>
     the Crystal Pillar in the ruins.<end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1680,24 +1853,29 @@
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間たちって<end_line>
 			本当にヒドイことを<end_line>
 			やってたんだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間たちって<end_line>
-			本当にヒドイことを<end_line>
-			やってたんだね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise and her goons<end_line>
     are really terrible<end_line>
     aren't they<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間たちって<end_line>
+			本当にヒドイことを<end_line>
+			やってたんだね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Anise and her goons<end_line>
+    are really terrible<end_line>
+    aren't they<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1721,48 +1899,58 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 			今はとにかく遺跡の奥の<end_line>
 			魔晶柱を調べに行こう<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Right<three_dots><end_line>
+    For now we still need to find<end_line>
+    the Crystal Pillar in the ruins.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<three_dots><end_line>
 			今はとにかく遺跡の奥の<end_line>
 			魔晶柱を調べに行こう<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
     For now we still need to find<end_line>
     the Crystal Pillar in the ruins.<end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間たちって<end_line>
 			本当にヒドイことを<end_line>
 			やってたんだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間たちって<end_line>
-			本当にヒドイことを<end_line>
-			やってたんだね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise and her goons<end_line>
     are really terrible<end_line>
     aren't they<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間たちって<end_line>
+			本当にヒドイことを<end_line>
+			やってたんだね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Anise and her goons<end_line>
+    are really terrible<end_line>
+    aren't they<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1784,22 +1972,27 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 			今はとにかく遺跡の奥の<end_line>
 			魔晶柱を調べに行こう<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Right<three_dots><end_line>
+    For now we still need to find<end_line>
+    the Crystal Pillar in the ruins.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<three_dots><end_line>
 			今はとにかく遺跡の奥の<end_line>
 			魔晶柱を調べに行こう<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
     For now we still need to find<end_line>
     the Crystal Pillar in the ruins.<end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>

--- a/Day 07/24528348_17645dc.xml
+++ b/Day 07/24528348_17645dc.xml
@@ -161,21 +161,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスを連れてくるように<end_line>
 			牢屋の番人に伝えなきゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスを連れてくるように<end_line>
-			牢屋の番人さんに伝えなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I need to convince the<end_line>
     jailer to let Anise out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスを連れてくるように<end_line>
+			牢屋の番人さんに伝えなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    I need to convince the<end_line>
+    jailer to let Anise out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -213,18 +217,21 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			やるしかないんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やるしかないでしょ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We have to try!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やるしかないでしょ！<end_line>
+		</sjis>
+    <ascii>
+    We have to try!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -232,21 +239,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスを連れてくるように<end_line>
 			牢屋の番人に伝えなきゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスを連れてくるように<end_line>
-			牢屋の番人さんに伝えなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I need to convince the<end_line>
     jailer to let Anise out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスを連れてくるように<end_line>
+			牢屋の番人さんに伝えなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    I need to convince the<end_line>
+    jailer to let Anise out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -284,18 +295,21 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			やるしかないんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やるしかないでしょ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We have to try!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やるしかないでしょ！<end_line>
+		</sjis>
+    <ascii>
+    We have to try!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -303,21 +317,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスを連れてくるように<end_line>
 			牢屋の番人に伝えなきゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスを連れてくるように<end_line>
-			牢屋の番人さんに伝えなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I need to convince the<end_line>
     jailer to let Anise out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスを連れてくるように<end_line>
+			牢屋の番人さんに伝えなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    I need to convince the<end_line>
+    jailer to let Anise out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -355,39 +373,46 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			やるしかないんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やるしかないでしょ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We have to try!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やるしかないでしょ！<end_line>
+		</sjis>
+    <ascii>
+    We have to try!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			アニスを連れてくるように<end_line>
 			牢屋の番人に伝えなきゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスを連れてくるように<end_line>
-			牢屋の番人さんに伝えなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I need to convince the<end_line>
     jailer to let Anise out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスを連れてくるように<end_line>
+			牢屋の番人さんに伝えなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    I need to convince the<end_line>
+    jailer to let Anise out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -422,18 +447,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			やるしかないんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やるしかないでしょ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We have to try!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やるしかないでしょ！<end_line>
+		</sjis>
+    <ascii>
+    We have to try!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -628,21 +656,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			トラムたちが村の出口で待ってる<end_line>
 			とりあえず、帰ろう<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			トラムたちが村の出口で待ってるよ<end_line>
-			とりあえず、帰ろう<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Tram and the others are waiting<end_line>
     for us at the gate<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			トラムたちが村の出口で待ってるよ<end_line>
+			とりあえず、帰ろう<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Tram and the others are waiting<end_line>
+    for us at the gate<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -686,7 +718,7 @@
   <ascii>
     Finally.<end_line>
     I'm sick of this place.<end_line>
-  </ascii> 
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -709,18 +741,21 @@
 	<portrait_l entry="player" eye="sad" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスも逃がしちゃったしな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスも逃がしちゃったしね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise ran away<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスも逃がしちゃったしね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Anise ran away<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -755,24 +790,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			親方に怒られるのはイヤだけど<end_line>
 			とにかくプロスバンの町に戻るしか<end_line>
 			ないみたいだ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			親方に怒られるのはイヤだけど<end_line>
-			とにかくプロスバンの町に戻るしか<end_line>
-			ないみたい<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I don't really want to have<end_line>
     Master scold me, but we have to<end_line>
     go back to Prosban eventually<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			親方に怒られるのはイヤだけど<end_line>
+			とにかくプロスバンの町に戻るしか<end_line>
+			ないみたい<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I don't really want to have<end_line>
+    Master scold me, but we have to<end_line>
+    go back to Prosban eventually<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -865,21 +905,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			誰かがオレをさがしてるみたいだ<end_line>
 			誰だろう<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			誰かがわたしをさがしてるみたい<end_line>
-			誰だろう<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I heard someone looking for me.<end_line>
     I wonder who it is<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			誰かがわたしをさがしてるみたい<end_line>
+			誰だろう<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I heard someone looking for me.<end_line>
+    I wonder who it is<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">

--- a/Day 07/25410412_183bb6c.xml
+++ b/Day 07/25410412_183bb6c.xml
@@ -92,7 +92,7 @@
 	<portrait_l entry="player" eye="surprised_blush" mouth="tense">
 	<portrait_r entry="tier" eye="happy_blush" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			うわ<three_dots>！？<end_line>
 			ちょっと、なんだよ！？<end_line>
 		</sjis>
@@ -100,9 +100,9 @@
       Woah<three_dots>!?<end_line>
       Hey, what's wrong!?<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			きゃ<three_dots>！？<end_line>
 			ちょっと、なによ！？<end_line>
 		</sjis>
@@ -110,7 +110,7 @@
       Kya<three_dots>!?<end_line>
       Hey, what's wrong!?<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -198,21 +198,25 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="tier" eye="surprised" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			ホント<three_dots><end_line>
 			カンベンしてくれよ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ホントにもう<three_dots><end_line>
-			カンベンしてよね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hah<three_dots><end_line>
     Gimme a break<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ホントにもう<three_dots><end_line>
+			カンベンしてよね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Hah<three_dots><end_line>
+    Gimme a break<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">

--- a/Day 08/002_24563292_176ce5c.xml
+++ b/Day 08/002_24563292_176ce5c.xml
@@ -10,15 +10,18 @@
     <sjis>
       がんばってね！　おにーちゃん<end_line>
     </sjis>
+    <ascii>
+    Good luck, <player_nickname>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       がんばってね！　おねーちゃん<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Good luck, <player_nickname>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Day 08/003_25434172_184183c.xml
+++ b/Day 08/003_25434172_184183c.xml
@@ -20,17 +20,21 @@
       うん<end_line>
       もう大丈夫だぜ！<end_line>
     </sjis>
+    <ascii>
+    Yeah.<end_line>
+    I'm alright now!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん<end_line>
       もう大丈夫だよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah.<end_line>
     I'm alright now!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 08/004_24549180_176973c.xml
+++ b/Day 08/004_24549180_176973c.xml
@@ -1,10 +1,10 @@
 <location>
-	<sjis>
+  <sjis>
 		プロスバンの町<end_line>
 	</sjis>
 </location>
 <location>
-	<sjis>
+  <sjis>
 		プロスバンの町　北門前工房通り<end_line>
 	</sjis>
 </location>
@@ -12,24 +12,29 @@
 	<info box="simple">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ねらわれてるミューノをつれて<end_line>
 			あまりウロウロしない方がいいな<three_dots><end_line>
 			とにかく工房に行こう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ねらわれてるミューノをつれて<end_line>
-			あまりウロウロしない方がいいよね<three_dots><end_line>
-			とにかく工房に行こう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I shouldn't wander around while<end_line>
     Murno is still in danger<three_dots><end_line>
     Let's head to the workshop.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ねらわれてるミューノをつれて<end_line>
+			あまりウロウロしない方がいいよね<three_dots><end_line>
+			とにかく工房に行こう<end_line>
+		</sjis>
+    <ascii>
+    I shouldn't wander around while<end_line>
+    Murno is still in danger<three_dots><end_line>
+    Let's head to the workshop.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">

--- a/Day 08/005_25436204_184202c.xml
+++ b/Day 08/005_25436204_184202c.xml
@@ -16,21 +16,21 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="vee" eye="serious" mouth="neutral">
 	<option>
-		<sjis>
+    <sjis>
 			もちろん準備できたよ<end_line>
 		</sjis>
     <ascii>
       I'm ready.<end_line>
     </ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			もうちょっと待ってよ<end_line>
 		</sjis>
     <ascii>
       Not yet.<end_line>
     </ascii>
-	</option>
+  </option>
 </choice>
 <dialogue>
 	<info box="right">
@@ -251,21 +251,21 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="vee" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			おう！<end_line>
 		</sjis>
     <ascii>
       Yeah!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			はい！<end_line>
 		</sjis>
     <ascii>
       Yes!<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -281,18 +281,21 @@
 	<info box="right">
 	<portrait_r entry="player" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、あれ<three_dots>？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、あれ<three_dots>？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What's with him<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、あれ<three_dots>？<end_line>
+		</sjis>
+    <ascii>
+    What's with him<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -312,21 +315,21 @@
 	<portrait_l entry="vee" eye="decided" mouth="tense">
 	<portrait_r entry="player" eye="surprised" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			あ、わかったよ<end_line>
 		</sjis>
     <ascii>
       Ah, right.<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			あ、はーい<end_line>
 		</sjis>
     <ascii>
       Ah, coming.<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">

--- a/Day 08/008_24559260_176be9c.xml
+++ b/Day 08/008_24559260_176be9c.xml
@@ -17,6 +17,11 @@
       あまりウロウロしない方がいいな<three_dots><end_line>
       とにかく工房に行こう<end_line>
     </sjis>
+    <ascii>
+    I shouldn't wander around while<end_line>
+    Murno is still in danger<three_dots><end_line>
+    Let's head to the workshop.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -24,12 +29,12 @@
       あまりウロウロしない方がいいよね<three_dots><end_line>
       とにかく工房に行こう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I shouldn't wander around while<end_line>
     Murno is still in danger<three_dots><end_line>
     Let's head to the workshop.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Day 08/009_25441660_184357c.xml
+++ b/Day 08/009_25441660_184357c.xml
@@ -239,17 +239,21 @@
       スゲェ！　だからアカバネか<three_dots><end_line>
       なんかカッコイイ<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Amazing! So that's why its "Red"<three_dots><end_line>
+    That's kinda cool<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       スゴイ！　だからアカバネか<three_dots><end_line>
       なんかカッコイイ<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Amazing! So that's why its "Red"<three_dots><end_line>
     That's kinda cool<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -525,17 +529,21 @@
       な！<end_line>
       オレだって！<end_line>
     </sjis>
+    <ascii>
+    Wha!<end_line>
+    Even I!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な！<end_line>
       わたしだって！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wha!<end_line>
     Even I!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -555,15 +563,18 @@
     <sjis>
       なんだよ、もう<three_dots><end_line>
     </sjis>
+    <ascii>
+    What the hell<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、もう<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What the hell<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 08/012_24557836_176b90c.xml
+++ b/Day 08/012_24557836_176b90c.xml
@@ -17,6 +17,11 @@
       あまりウロウロしない方がいいな<three_dots><end_line>
       とにかく工房に行こう<end_line>
     </sjis>
+    <ascii>
+    I shouldn't wander around while<end_line>
+    Murno is still in danger<three_dots><end_line>
+    Let's head to the workshop.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -24,12 +29,12 @@
       あまりウロウロしない方がいいよね<three_dots><end_line>
       とにかく工房に行こう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I shouldn't wander around while<end_line>
     Murno is still in danger<three_dots><end_line>
     Let's head to the workshop.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Day 08/017_24554524_176ac1c.xml
+++ b/Day 08/017_24554524_176ac1c.xml
@@ -17,6 +17,11 @@
       あまりウロウロしない方がいいな<three_dots><end_line>
       とにかく工房に行こう<end_line>
     </sjis>
+    <ascii>
+    I shouldn't wander around while<end_line>
+    Murno is still in danger<three_dots><end_line>
+    Let's head to the workshop.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -24,12 +29,12 @@
       あまりウロウロしない方がいいよね<three_dots><end_line>
       とにかく工房に行こう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I shouldn't wander around while<end_line>
     Murno is still in danger<three_dots><end_line>
     Let's head to the workshop.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Day 08/025_25444332_1843fec.xml
+++ b/Day 08/025_25444332_1843fec.xml
@@ -29,6 +29,10 @@
       ちょっと出かけてくるんで<end_line>
       ミューノのことたのみます！<end_line>
     </sjis>
+    <ascii>
+    We'll be going out for a bit.<end_line>
+    Please take care of Murno!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -36,11 +40,11 @@
       ちょっと出かけてくるんで<end_line>
       ミューノのことたのみます！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We'll be going out for a bit.<end_line>
     Please take care of Murno!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -107,17 +111,21 @@
       <three_dots>なんか、通じ合ってるみたいだ<end_line>
       少しくやしい<three_dots><end_line>
     </sjis>
+    <ascii>
+    <three_dots>They get along well.<end_line>
+    It's a bit frustrating<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>なんか、通じ合ってるみたい<end_line>
       少しくやしい<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots>They get along well.<end_line>
     It's a bit frustrating<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -176,17 +184,21 @@
       <three_dots><end_line>
       ダメだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    <three_dots><end_line>
+    I can't do it<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots><end_line>
       ダメかぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots><end_line>
     I can't do it<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -249,15 +261,18 @@
     <sjis>
       ダメか<three_dots><end_line>
     </sjis>
+    <ascii>
+    No good<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ダメかぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No good<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -320,15 +335,18 @@
     <sjis>
       ダメか<three_dots><end_line>
     </sjis>
+    <ascii>
+    No good<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ダメかぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No good<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -391,15 +409,18 @@
     <sjis>
       ダメか<three_dots><end_line>
     </sjis>
+    <ascii>
+    No good<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ダメかぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No good<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -448,6 +469,10 @@
       アニスたちのかくれ場所を<end_line>
       さがしに行くぞ！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Time to look for Anise!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -455,9 +480,9 @@
       アニスたちのかくれ場所を<end_line>
       さがしに行こう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Time to look for Anise!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 08/026_25445996_184466c.xml
+++ b/Day 08/026_25445996_184466c.xml
@@ -118,6 +118,10 @@
       情報通って？<end_line>
       はじめて聞いたぞ<end_line>
     </sjis>
+    <ascii>
+    You're an informant?<end_line>
+    Haven't heard that before.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -125,11 +129,11 @@
       情報通って？<end_line>
       はじめて聞いたよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're an informant?<end_line>
     Haven't heard that before.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -261,6 +265,11 @@
       他に手がかりもないしな～<three_dots><end_line>
       とりあえず行ってみるか<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Hmm, is that so<three_dots><end_line>
+    Well, we've got no other leads<three_dots><end_line>
+    Shall we take a look<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -268,12 +277,12 @@
       他に手がかりもないしな～<three_dots><end_line>
       とりあえず行ってみようか<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hmm, is that so<three_dots><end_line>
     Well, we've got no other leads<three_dots><end_line>
     Shall we take a look<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -465,15 +474,18 @@
     <sjis>
       気をつけてな<end_line>
     </sjis>
+    <ascii>
+    Take care.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       気をつけてね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Take care.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 08/047_25448444_1844ffc.xml
+++ b/Day 08/047_25448444_1844ffc.xml
@@ -7,6 +7,11 @@
       レミィ<end_line>
       何してんだよ？<end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    Lemmy?<end_line>
+    What are you doing here?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -14,12 +19,12 @@
       レミィ<end_line>
       何してるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     Lemmy?<end_line>
     What are you doing here?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -42,6 +47,11 @@
       ここにはアカバネって<end_line>
       コワイはぐれがすんでるって話だぜ<end_line>
     </sjis>
+    <ascii>
+    You didn't know?<end_line>
+    They say a scary Stray named<end_line>
+    Red Wing lives here.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -49,12 +59,12 @@
       ここにはアカバネって<end_line>
       コワイはぐれがすんでるって話だよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You didn't know?<end_line>
     They say a scary Stray named<end_line>
     Red Wing lives here.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -183,6 +193,11 @@
       わざわざアブナイとこで<end_line>
       鍛えてたのか<end_line>
     </sjis>
+    <ascii>
+    Oh! That's great!<end_line>
+    Deliberately training in<end_line>
+    such a dangerous place.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -190,12 +205,12 @@
       わざわざアブナイとこで<end_line>
       鍛えてたんだ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh! That's great!<end_line>
     Deliberately training in<end_line>
     such a dangerous place.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -218,6 +233,11 @@
       ずっと怒ってるのかよ<three_dots><end_line>
       ホント感じ悪いなぁ<end_line>
     </sjis>
+    <ascii>
+    What's wrong with him?<end_line>
+    Is he always that angry?<end_line>
+    He gives me a bad feeling.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -225,12 +245,12 @@
       ずっと怒ってるの？<end_line>
       ホント感じ悪いなぁ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's wrong with him?<end_line>
     Is he always that angry?<end_line>
     He gives me a bad feeling.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 08/050_25450092_184566c.xml
+++ b/Day 08/050_25450092_184566c.xml
@@ -163,17 +163,21 @@
       やっぱ<end_line>
       たおすしかないか<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    All we can do<end_line>
+    is take them out<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       やっぱ<end_line>
       たおすしかないの<three_dots>！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     All we can do<end_line>
     is take them out<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -184,17 +188,21 @@
       なんだ？<end_line>
       見張る気ないのか？<end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    Why's it leaving?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに？<end_line>
       見張る気ないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     Why's it leaving?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 08/051_25457420_184730c.xml
+++ b/Day 08/051_25457420_184730c.xml
@@ -20,17 +20,21 @@
       どうしたんだ、<partner>？<end_line>
       なんかあったのか？<end_line>
     </sjis>
+    <ascii>
+    What is it, <partner>?<end_line>
+    Is something there?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしたの、<partner>？<end_line>
       なんかあったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is it, <partner>?<end_line>
     Is something there?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -91,17 +95,21 @@
       どうしたんだ、<partner>？<end_line>
       なんかあったのか？<end_line>
     </sjis>
+    <ascii>
+    What is it, <partner>?<end_line>
+    Is something there?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしたの、<partner>？<end_line>
       なんかあったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is it, <partner>?<end_line>
     Is something there?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -129,17 +137,21 @@
       誰もいないぞ<end_line>
       気のせいじゃないか？<end_line>
     </sjis>
+    <ascii>
+    There's no one there.<end_line>
+    Isn't it just your imagination?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       誰もいないよ<end_line>
       気のせいじゃない？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There's no one there.<end_line>
     Isn't it just your imagination?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -177,17 +189,21 @@
       どうしたんだ、<partner>？<end_line>
       なんかあったのか？<end_line>
     </sjis>
+    <ascii>
+    What is it, <partner>?<end_line>
+    Is something there?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしたの、<partner>？<end_line>
       なんかあったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is it, <partner>?<end_line>
     Is something there?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -213,17 +229,21 @@
       誰もいないぞ<end_line>
       気のせいじゃないか？<end_line>
     </sjis>
+    <ascii>
+    There's no one there.<end_line>
+    Isn't it just your imagination?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       誰もいないよ<end_line>
       気のせいじゃない？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There's no one there.<end_line>
     Isn't it just your imagination?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -263,17 +283,21 @@
       どうしたんだ、<partner>？<end_line>
       なんかあったのか？<end_line>
     </sjis>
+    <ascii>
+    What is it, <partner>?<end_line>
+    Is something there?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしたの、<partner>？<end_line>
       なんかあったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is it, <partner>?<end_line>
     Is something there?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -300,17 +324,21 @@
       誰もいないぞ<end_line>
       気のせいじゃないか？<end_line>
     </sjis>
+    <ascii>
+    There's no one there.<end_line>
+    Isn't it just your imagination?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       誰もいないよ<end_line>
       気のせいじゃない？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There's no one there.<end_line>
     Isn't it just your imagination?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 08/052_25458748_184783c.xml
+++ b/Day 08/052_25458748_184783c.xml
@@ -18,17 +18,21 @@
       くっ<three_dots><end_line>
       キ<three_dots>キサマら<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Ugh<three_dots><end_line>
+    Y<three_dots>You guys<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       う<three_dots><end_line>
       あ<three_dots>あんたたち<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ugh<three_dots><end_line>
     Y<three_dots>You guys<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -267,13 +271,16 @@
     <sjis>
       くそっ！<end_line>
     </sjis>
+    <ascii>
+    Crap!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       このっ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Crap!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 08/053_25460412_1847ebc.xml
+++ b/Day 08/053_25460412_1847ebc.xml
@@ -67,6 +67,11 @@
       はなせ！<end_line>
       はなせって！！<end_line>
     </sjis>
+    <ascii>
+    What are you doing!?<end_line>
+    Let go!<end_line>
+    Let me go!!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -74,12 +79,12 @@
       はなして！<end_line>
       はなしてよ！！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What are you doing!?<end_line>
     Let go!<end_line>
     Let me go!!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -151,7 +156,7 @@
       You, Summon Beast, quiet down.<end_line>
       If you don't,<end_line>
       the girl's neck will<three_dots><end_line>
-    </ascii> 
+    </ascii>
   </female>
 </dialogue>
 <dialogue>
@@ -201,6 +206,11 @@
       はなせ！<end_line>
       気色悪い！<end_line>
     </sjis>
+    <ascii>
+    Why you! Stop!<end_line>
+    Let me go!<end_line>
+    You're disgusting!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -208,12 +218,12 @@
       はなして！<end_line>
       気色悪い！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Why you! Stop!<end_line>
     Let me go!<end_line>
     You're disgusting!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -235,17 +245,21 @@
       い、いて<three_dots><end_line>
       いてててて！<end_line>
     </sjis>
+    <ascii>
+    O, ow<three_dots><end_line>
+    Owowowow!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       い、いた<three_dots><end_line>
       いたたたた！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     O, ow<three_dots><end_line>
     Owowowow!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -267,15 +281,18 @@
     <sjis>
       いぃってぇえ！<end_line>
     </sjis>
+    <ascii>
+    Owww!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       いぃったぁい！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Owww!<end_line>
   </ascii>
+  </female>
 </bigtext>
 <dialogue>
   <info box="right">
@@ -328,17 +345,21 @@
       な、なんだと！<end_line>
       ダレがお前なんかに<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Wh, what!?<end_line>
+    Like I'd let you<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な、なによ！<end_line>
       ダレがあんたなんかに<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wh, what!?<end_line>
     Like I'd let you<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 08/054_25846812_18a641c.xml
+++ b/Day 08/054_25846812_18a641c.xml
@@ -25,15 +25,18 @@
     <sjis>
       レミィを助けに行くぞ！<end_line>
     </sjis>
+    <ascii>
+    Let's go save Lemmy!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       レミィを助けに行くよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Let's go save Lemmy!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Day 08/055_25463036_18488fc.xml
+++ b/Day 08/055_25463036_18488fc.xml
@@ -14,7 +14,7 @@
 	<info box="right">
 	<portrait_r entry="guilan" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			お目覚めかしら<end_line>
 			ボウヤ<three_dots>？<end_line>
 		</sjis>
@@ -22,9 +22,9 @@
       Are you awake,<end_line>
       boy<three_dots>?<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			お目覚めかしら<end_line>
 			おじょうちゃん<three_dots>？<end_line>
 		</sjis>
@@ -32,7 +32,7 @@
       Are you awake,<end_line>
       little lady<three_dots>?<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -49,48 +49,58 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			どこだ<three_dots>、ここ<three_dots><end_line>
 			いたっ<three_dots><end_line>
 			なんだ<three_dots>これ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			どこ<three_dots>、ここ<three_dots><end_line>
-			いたっ<three_dots><end_line>
-			なに<three_dots>これ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Where<three_dots>, am<three_dots><end_line>
     Ow<three_dots><end_line>
     What's<three_dots>this?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			どこ<three_dots>、ここ<three_dots><end_line>
+			いたっ<three_dots><end_line>
+			なに<three_dots>これ？<end_line>
+		</sjis>
+    <ascii>
+    Where<three_dots>, am<three_dots><end_line>
+    Ow<three_dots><end_line>
+    What's<three_dots>this?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="guilan" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			う<three_dots><end_line>
 			<partner>は<three_dots>？<end_line>
 			キサマら<partner>をドコに！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			う<three_dots><end_line>
-			<partner>は<three_dots>？<end_line>
-			あんたたち<partner>をドコに！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ugh<three_dots><end_line>
     <partner><three_dots>?<end_line>
     Where's <partner>!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			う<three_dots><end_line>
+			<partner>は<three_dots>？<end_line>
+			あんたたち<partner>をドコに！？<end_line>
+		</sjis>
+    <ascii>
+    Ugh<three_dots><end_line>
+    <partner><three_dots>?<end_line>
+    Where's <partner>!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -190,7 +200,7 @@
 	<portrait_l entry="player" eye="surprised" mouth="serious">
 	<portrait_r entry="guilan" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			あら？<end_line>
 			ボウヤ、コワイの？<end_line>
 			カワイイわね<end_line>
@@ -200,9 +210,9 @@
       Is the little boy scared?<end_line>
       How cute.<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			あら？<end_line>
 			おじょうちゃん、コワイの？<end_line>
 			カワイイわね<end_line>
@@ -212,28 +222,32 @@
       Is the little lady scared?<end_line>
       How cute.<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="guilan" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだと<three_dots><end_line>
 			ダレがコワイかよ<three_dots>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なんですって<three_dots><end_line>
-			ダレがコワイもんか<three_dots>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Shut up<three_dots><end_line>
     Of course I'm not<three_dots>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なんですって<three_dots><end_line>
+			ダレがコワイもんか<three_dots>！<end_line>
+		</sjis>
+    <ascii>
+    Shut up<three_dots><end_line>
+    Of course I'm not<three_dots>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -290,24 +304,29 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots><end_line>
 			<partner>は<three_dots><end_line>
 			ドコだ<three_dots>？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots><end_line>
-			<partner>は<three_dots><end_line>
-			ドコ<three_dots>？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots><end_line>
     <partner><three_dots><end_line>
     Where<three_dots>？<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots><end_line>
+			<partner>は<three_dots><end_line>
+			ドコ<three_dots>？<end_line>
+		</sjis>
+    <ascii>
+    <three_dots><end_line>
+    <partner><three_dots><end_line>
+    Where<three_dots>？<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -353,21 +372,25 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="guilan" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			く<three_dots>そ<three_dots><end_line>
 			ゆるさねえ、ぞ<three_dots>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そん<three_dots>な<three_dots><end_line>
-			ゆるさない、わよ<three_dots>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Damn<three_dots>you<three_dots><end_line>
     Unforgivable<three_dots>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そん<three_dots>な<three_dots><end_line>
+			ゆるさない、わよ<three_dots>！<end_line>
+		</sjis>
+    <ascii>
+    Damn<three_dots>you<three_dots><end_line>
+    Unforgivable<three_dots>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -722,24 +745,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="anise" eye="special" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			目的<three_dots>？<end_line>
 			お前、ゴヴァンの魔石を手に入れて<end_line>
 			一体なにをするつもりなんだ<three_dots>？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			目的<three_dots>？<end_line>
-			あんた、ゴヴァンの魔石を手に入れて<end_line>
-			一体なにをするつもりなの<three_dots>？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Voijin<three_dots>?<end_line>
     Once you have the Demon Stone,<end_line>
     just what are you planning to<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			目的<three_dots>？<end_line>
+			あんた、ゴヴァンの魔石を手に入れて<end_line>
+			一体なにをするつもりなの<three_dots>？<end_line>
+		</sjis>
+    <ascii>
+    Voijin<three_dots>?<end_line>
+    Once you have the Demon Stone,<end_line>
+    just what are you planning to<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -776,21 +804,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="anise" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			召喚獣から解放<three_dots>？<end_line>
 			なんだよ、それ<three_dots>？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			召喚獣から解放<three_dots>？<end_line>
-			なによ、それ<three_dots>？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Free us from Summon Beasts<three_dots>?<end_line>
     What do you mean<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			召喚獣から解放<three_dots>？<end_line>
+			なによ、それ<three_dots>？<end_line>
+		</sjis>
+    <ascii>
+    Free us from Summon Beasts<three_dots>?<end_line>
+    What do you mean<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -860,18 +892,21 @@
 	<info box="left">
 	<portrait_l entry="player" eye="surprised" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			な<three_dots>、なんだ！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			な<three_dots>、なによ！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Wha<three_dots>, what the!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			な<three_dots>、なによ！？<end_line>
+		</sjis>
+    <ascii>
+    Wha<three_dots>, what the!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">

--- a/Day 08/056_25467372_18499ec.xml
+++ b/Day 08/056_25467372_18499ec.xml
@@ -101,17 +101,21 @@
       お前<three_dots>？<end_line>
       どうして<three_dots><end_line>
     </sjis>
+    <ascii>
+    You<three_dots>?<end_line>
+    Why<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんた<three_dots>？<end_line>
       どうして<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You<three_dots>?<end_line>
     Why<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -241,6 +245,11 @@
       でも、オレ、ハンマーを<three_dots><end_line>
       あそこに<three_dots>、オレの武器も<three_dots><end_line>
     </sjis>
+    <ascii>
+    Thanks, but my hammer<three_dots><end_line>
+    And my weapons<three_dots><end_line>
+    I can't leave them behind.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -248,12 +257,12 @@
       でも、わたし、ハンマーを<three_dots><end_line>
       あそこに<three_dots>、わたしの武器も<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Thanks, but my hammer<three_dots><end_line>
     And my weapons<three_dots><end_line>
     I can't leave them behind.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -308,17 +317,21 @@
       ダメだ<three_dots>！<end_line>
       <partner>が<three_dots><end_line>
     </sjis>
+    <ascii>
+    No<three_dots>!<end_line>
+    <partner> is<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ダメ<three_dots>！<end_line>
       <partner>が<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No<three_dots>!<end_line>
     <partner> is<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -344,16 +357,19 @@
       <partner>をおいて<end_line>
       逃げるなんてできるもんか！<end_line>
     </sjis>
+    <ascii>
+    I can't leave <partner> behind!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner>をおいて<end_line>
       逃げるなんてできないよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I can't leave <partner> behind!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -379,17 +395,21 @@
       なっ！？<end_line>
       お前<three_dots><end_line>
     </sjis>
+    <ascii>
+    Wha!?<end_line>
+    You<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なっ！？<end_line>
       あんた<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wha!?<end_line>
     You<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 08/057_25470140_184a4bc.xml
+++ b/Day 08/057_25470140_184a4bc.xml
@@ -7,17 +7,21 @@
       <partner><end_line>
       大丈夫か！？<end_line>
     </sjis>
+    <ascii>
+    <partner>!<end_line>
+    Are you okay!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner><end_line>
       大丈夫！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner>!<end_line>
     Are you okay!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -92,17 +96,21 @@
       ヒデェことしやがる<three_dots>！<end_line>
       待ってろ！　すぐ外してやるから！<end_line>
     </sjis>
+    <ascii>
+    How could they<three_dots>!<end_line>
+    Just wait! I'll get it off!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なんてヒドイことを<three_dots>！<end_line>
       待ってて！　すぐ外してあげるから！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How could they<three_dots>!<end_line>
     Just wait! I'll get it off!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -179,6 +187,11 @@
       アイツ、ひとりでアカバネと<three_dots>！<end_line>
       とにかく出るぞ！<end_line>
     </sjis>
+    <ascii>
+    Lemmy came to save us.<end_line>
+    He's facing Red Wing alone<three_dots>!<end_line>
+    We have to leave!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -186,10 +199,10 @@
       あいつ、ひとりでアカバネと<three_dots>！<end_line>
       とにかく出るよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Lemmy came to save us.<end_line>
     He's facing Red Wing alone<three_dots>!<end_line>
     We have to leave!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 08/058_25471724_184aaec.xml
+++ b/Day 08/058_25471724_184aaec.xml
@@ -16,17 +16,21 @@
       なんだ<three_dots>？<end_line>
       レミィ<three_dots><end_line>
     </sjis>
+    <ascii>
+    What was that<three_dots>?<end_line>
+    Lemmy<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに<three_dots>？<end_line>
       レミィ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that<three_dots>?<end_line>
     Lemmy<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -306,6 +310,11 @@
       今逃げるなんて<three_dots><end_line>
       そんなカッコ悪いことできるか<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    I can't do it<three_dots><end_line>
+    Running at a time like this<three_dots><end_line>
+    Like I could be so pathetic<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -313,12 +322,12 @@
       今逃げるなんて<three_dots><end_line>
       そんなカッコ悪いことしちゃ<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I can't do it<three_dots><end_line>
     Running at a time like this<three_dots><end_line>
     Like I could be so pathetic<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -388,15 +397,18 @@
     <sjis>
       決まってるだろ？<end_line>
     </sjis>
+    <ascii>
+    Isn't it obvious?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       決まってるでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Isn't it obvious?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -405,16 +417,19 @@
       レミィをひとりにしておくワケには<end_line>
       いかないぜ！<end_line>
     </sjis>
+    <ascii>
+    I won't abandon Lemmy!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       レミィをひとりにしておくワケには<end_line>
       いかないよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I won't abandon Lemmy!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 08/060_25474060_184b40c.xml
+++ b/Day 08/060_25474060_184b40c.xml
@@ -52,17 +52,21 @@
       すげぇ！<end_line>
       ひとりでか！？<end_line>
     </sjis>
+    <ascii>
+    Amazing!<end_line>
+    By yourself!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       すごい！<end_line>
       ひとりで！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Amazing!<end_line>
     By yourself!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -140,17 +144,21 @@
       お前<three_dots>！<end_line>
       大丈夫か！？<end_line>
     </sjis>
+    <ascii>
+    Lemmy<three_dots>!<end_line>
+    Are you okay!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちょっと<three_dots>！<end_line>
       大丈夫！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Lemmy<three_dots>!<end_line>
     Are you okay!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="simple" effect="big">

--- a/Day 08/061_25475484_184b99c.xml
+++ b/Day 08/061_25475484_184b99c.xml
@@ -77,6 +77,11 @@
       お前が先に戦ってくれたおかげて<end_line>
       たおせたみたいなもんだからな<end_line>
     </sjis>
+    <ascii>
+    Don't worry about that.<end_line>
+    We only won because you<end_line>
+    weakened it for us.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -84,12 +89,12 @@
       あなたが先に戦ってくれたおかげで<end_line>
       たおせたみたいなもんだからさ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't worry about that.<end_line>
     We only won because you<end_line>
     weakened it for us.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -174,6 +179,11 @@
       オレと、<partner>と<end_line>
       お前の<three_dots><end_line>
     </sjis>
+    <ascii>
+    So let's say we all helped<end_line>
+    defeat Red Wing.<end_line>
+    Me, <partner>, and you, together<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -181,12 +191,12 @@
       わたしと、<partner>と<end_line>
       あなたの<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So let's say we all helped<end_line>
     defeat Red Wing.<end_line>
     Me, <partner>, and you, together<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -221,17 +231,21 @@
       おーい！<end_line>
       こっちだー！<end_line>
     </sjis>
+    <ascii>
+    Heeey!<end_line>
+    Over here!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       おーい！<end_line>
       こっちだよー！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Heeey!<end_line>
     Over here!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="simple" effect="big">
@@ -713,17 +727,21 @@
       ち、ちょっと待て！<end_line>
       は、母って<three_dots>！？<end_line>
     </sjis>
+    <ascii>
+    Hey, wait!<end_line>
+    M-mother<three_dots>!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ち、ちょっと待って！<end_line>
       は、母って<three_dots>！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, wait!<end_line>
     M-mother<three_dots>!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 08/063_25480908_184cecc.xml
+++ b/Day 08/063_25480908_184cecc.xml
@@ -16,17 +16,21 @@
       そんなわけ、あるもんか<three_dots><end_line>
       絶対に<three_dots><end_line>
     </sjis>
+    <ascii>
+    That's impossible<three_dots><end_line>
+    I'm sure<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなこと、あるわけないよ<three_dots><end_line>
       絶対に<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's impossible<three_dots><end_line>
     I'm sure<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 08/064_25481708_184d1ec.xml
+++ b/Day 08/064_25481708_184d1ec.xml
@@ -43,6 +43,11 @@
       ボスタフさんもアニスたちを捕まえるの<end_line>
       手伝ってくれるみたいだし<end_line>
     </sjis>
+    <ascii>
+    That's good to hear.<end_line>
+    It seems Bostaph is going to<end_line>
+    help capture Anise as well.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -50,12 +55,12 @@
       ボスタフさんもアニスたちを捕まえるの<end_line>
       手伝ってくれるみたいだし<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's good to hear.<end_line>
     It seems Bostaph is going to<end_line>
     help capture Anise as well.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -81,6 +86,11 @@
       結構ヒドイ目にあわされてるんだ<end_line>
       もうひとごとじゃないよ<end_line>
     </sjis>
+    <ascii>
+    It's fine! Those guys have<end_line>
+    been a pain for all of us.<end_line>
+    It's our problem too.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -88,12 +98,12 @@
       結構ヒドイ目にあわされてるんだから<end_line>
       もうひとごとじゃないよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's fine! Those guys have<end_line>
     been a pain for all of us.<end_line>
     It's our problem too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 08/065_25483164_184d79c.xml
+++ b/Day 08/065_25483164_184d79c.xml
@@ -66,6 +66,11 @@
       ヒドイ目にあったもんなぁ<three_dots><end_line>
       <partner>も大丈夫か？<end_line>
     </sjis>
+    <ascii>
+    True, lots of things<end_line>
+    happened today<three_dots><end_line>
+    How are you feeling, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -73,12 +78,12 @@
       ヒドイ目にあったもんね<three_dots><end_line>
       <partner>も大丈夫？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     True, lots of things<end_line>
     happened today<three_dots><end_line>
     How are you feeling, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -203,15 +208,18 @@
     <sjis>
       アニスのヤツが言ったことも<three_dots><end_line>
     </sjis>
+    <ascii>
+    What Anise said<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       アニスが言ったことも<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What Anise said<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -235,17 +243,21 @@
       あ、いや<three_dots><end_line>
       別にいいんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah, no<three_dots><end_line>
+    It's nothing<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、ううん<three_dots><end_line>
       別にいいよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, no<three_dots><end_line>
     It's nothing<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -345,6 +357,11 @@
       ヒドイ目にあったもんなぁ<three_dots><end_line>
       <partner>も大丈夫か？<end_line>
     </sjis>
+    <ascii>
+    True, lots of things<end_line>
+    happened today<three_dots><end_line>
+    How are you feeling, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -352,12 +369,12 @@
       ヒドイ目にあったもんね<three_dots><end_line>
       <partner>も大丈夫？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     True, lots of things<end_line>
     happened today<three_dots><end_line>
     How are you feeling, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -500,15 +517,18 @@
     <sjis>
       アニスのヤツが言ったことも<three_dots><end_line>
     </sjis>
+    <ascii>
+    What Anise said<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       アニスが言ったことも<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What Anise said<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -532,17 +552,21 @@
       あ、いや<three_dots><end_line>
       別にいいんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah, no<three_dots><end_line>
+    It's nothing<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、ううん<three_dots><end_line>
       別にいいの<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, no<three_dots><end_line>
     It's nothing<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -641,6 +665,11 @@
       大丈夫なのかよ<end_line>
       結構ヒドイ目にあったんだろ？<end_line>
     </sjis>
+    <ascii>
+    Right back at you, <partner>.<end_line>
+    How are you feeling?<end_line>
+    Today's been pretty rough, right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -648,12 +677,12 @@
       大丈夫なの？<end_line>
       結構ヒドイ目にあったんでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Right back at you, <partner>.<end_line>
     How are you feeling?<end_line>
     Today's been pretty rough, right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -849,17 +878,21 @@
       あ、いや<three_dots><end_line>
       別にいいんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah, no<three_dots><end_line>
+    It's nothing<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、ううん<three_dots><end_line>
       別にいいの<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, no<three_dots><end_line>
     It's nothing<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -956,6 +989,11 @@
       ヒドイ目にあったもんなぁ<three_dots><end_line>
       <partner>も大丈夫か？<end_line>
     </sjis>
+    <ascii>
+    True, lots of things<end_line>
+    happened today<three_dots><end_line>
+    Are you okay, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -963,12 +1001,12 @@
       ヒドイ目にあったもんね<three_dots><end_line>
       <partner>も大丈夫？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     True, lots of things<end_line>
     happened today<three_dots><end_line>
     Are you okay, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1168,17 +1206,21 @@
       あ、いや<three_dots><end_line>
       別にいいんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah, no<three_dots><end_line>
+    It's nothing<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、ううん<three_dots><end_line>
       別にいいんだよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, no<three_dots><end_line>
     It's nothing<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 08/066_25486556_184e4dc.xml
+++ b/Day 08/066_25486556_184e4dc.xml
@@ -238,17 +238,21 @@
       そっか<three_dots>、そうだよね<three_dots><end_line>
       ならいいんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I see<three_dots>, of course<three_dots><end_line>
+    That's fine then<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっか<three_dots>、そうだよね<three_dots><end_line>
       ならいいの<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots>, of course<three_dots><end_line>
     That's fine then<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 08/067_25488300_184ebac.xml
+++ b/Day 08/067_25488300_184ebac.xml
@@ -70,17 +70,21 @@
       今日はありがとな<end_line>
       お前のおかげで助かったぜ<end_line>
     </sjis>
+    <ascii>
+    Thanks for today.<end_line>
+    You were a big help.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今日はありがとね<end_line>
       おかげで助かったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Thanks for today.<end_line>
     You were a big help.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -103,6 +107,10 @@
       あの時、アニスたちに<end_line>
       やられてたかもしれなかったんだぜ<end_line>
     </sjis>
+    <ascii>
+    Really, if you hadn't shown up,<end_line>
+    it might have been over for me<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -110,11 +118,11 @@
       あの時、アニスたちに<end_line>
       やられてたかもしれなかったんだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Really, if you hadn't shown up,<end_line>
     it might have been over for me<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -140,6 +148,10 @@
       アカバネだってオレたちだけだったら<end_line>
       勝てたかどうか、わかんないし<end_line>
     </sjis>
+    <ascii>
+    And with Red Wing. I don't know if<end_line>
+    we could have won without you.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -147,11 +159,11 @@
       わたしたちだけだったら<end_line>
       勝てたかどうか、わからないし<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And with Red Wing. I don't know if<end_line>
     we could have won without you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -173,17 +185,21 @@
       それにボスタフさんだって<end_line>
       お前がいたから<three_dots><end_line>
     </sjis>
+    <ascii>
+    And with Bostaph.<end_line>
+    Since you were there<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       それにボスタフさんを<end_line>
       説得できたのだって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And with Bostaph.<end_line>
     Since you were there<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -205,17 +221,21 @@
       は<three_dots>？<end_line>
       どうぞ<end_line>
     </sjis>
+    <ascii>
+    Eh<three_dots>?<end_line>
+    Go ahead.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え<three_dots>？<end_line>
       どうぞ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh<three_dots>?<end_line>
     Go ahead.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -240,6 +260,11 @@
       助けられたのはオレたちの方だろ？<end_line>
       オレの話、聞いてたのか？<end_line>
     </sjis>
+    <ascii>
+    About what?<end_line>
+    You were the one who saved us.<end_line>
+    Were you listening?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -247,12 +272,12 @@
       わたしたちの方でしょ？<end_line>
       わたしの話、聞いてた？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     About what?<end_line>
     You were the one who saved us.<end_line>
     Were you listening?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -279,6 +304,11 @@
       お前にもわかってもらえて<end_line>
       ホント良かったよ！<end_line>
     </sjis>
+    <ascii>
+    Ah, right!<end_line>
+    I'm really happy<end_line>
+    that you understand now!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -286,12 +316,12 @@
       わかってもらえて<end_line>
       ホント良かったよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, right!<end_line>
     I'm really happy<end_line>
     that you understand now!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -316,6 +346,11 @@
       これからはもう少し<end_line>
       オレの言うことを信じるんだな<end_line>
     </sjis>
+    <ascii>
+    I see.<end_line>
+    I hope you'll be able to<end_line>
+    trust me a bit more after this.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -323,12 +358,12 @@
       これからはもう少し<end_line>
       わたしの言うことを信じるのね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see.<end_line>
     I hope you'll be able to<end_line>
     trust me a bit more after this.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -353,6 +388,11 @@
       素直じゃないなぁ<end_line>
       お前はいつもそんなんだから<three_dots><end_line>
     </sjis>
+    <ascii>
+    Consider it!?<end_line>
+    You aren't honest at all, huh.<end_line>
+    Because you're always like that<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -360,12 +400,12 @@
       素直じゃないなぁ<end_line>
       あんたはいつもそんなんだから<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Consider it!?<end_line>
     You aren't honest at all, huh.<end_line>
     Because you're always like that<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 08/068_25490060_184f28c.xml
+++ b/Day 08/068_25490060_184f28c.xml
@@ -160,6 +160,11 @@
       弱らせてくれたから勝てたんだよ<end_line>
       くやしいけど、あいつはスゴイよ<end_line>
     </sjis>
+    <ascii>
+    Even that's because Lemmy<end_line>
+    was able to weaken it.<end_line>
+    I hate to admit it, but he's great.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -167,12 +172,12 @@
       弱らせてくれたから勝てたんだ<three_dots><end_line>
       くやしいけど、あいつはスゴイよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Even that's because Lemmy<end_line>
     was able to weaken it.<end_line>
     I hate to admit it, but he's great.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 08/069_25491564_184f86c.xml
+++ b/Day 08/069_25491564_184f86c.xml
@@ -125,15 +125,18 @@
     <sjis>
       その言い方はやめろ！<end_line>
     </sjis>
+    <ascii>
+    Stop talking like that!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       その言い方はやめて！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Stop talking like that!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 08/24587596_1772d4c.xml
+++ b/Day 08/24587596_1772d4c.xml
@@ -4,24 +4,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			今日は話し合いだ<end_line>
 			金の派閥に行かなきゃ<end_line>
 			がんばるぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今日は話し合いだよ<end_line>
-			金の派閥に行かなきゃ<end_line>
-			がんばるぞ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Today's the day for our<end_line>
     meeting at the Gold Council.<end_line>
     I'll do my best!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今日は話し合いだよ<end_line>
+			金の派閥に行かなきゃ<end_line>
+			がんばるぞ！<end_line>
+		</sjis>
+    <ascii>
+    Today's the day for our<end_line>
+    meeting at the Gold Council.<end_line>
+    I'll do my best!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -41,21 +46,25 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			<partner>はたよりに<end_line>
 			ならないみたいだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<partner>はたよりに<end_line>
-			ならないみたい<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Looks like I can't<end_line>
     rely on <partner> this time.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<partner>はたよりに<end_line>
+			ならないみたい<end_line>
+		</sjis>
+    <ascii>
+    Looks like I can't<end_line>
+    rely on <partner> this time.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -63,24 +72,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			今日は話し合いだ<end_line>
 			金の派閥に行かなきゃ<end_line>
 			がんばるぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今日は話し合いだよ<end_line>
-			金の派閥に行かなきゃ<end_line>
-			がんばるぞ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Today's the day for our<end_line>
     meeting at the Gold Council.<end_line>
     I'll do my best!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今日は話し合いだよ<end_line>
+			金の派閥に行かなきゃ<end_line>
+			がんばるぞ！<end_line>
+		</sjis>
+    <ascii>
+    Today's the day for our<end_line>
+    meeting at the Gold Council.<end_line>
+    I'll do my best!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -134,24 +148,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			今日は話し合いだ<end_line>
 			金の派閥に行かなきゃ<end_line>
 			がんばるぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今日は話し合いだよ<end_line>
-			金の派閥に行かなきゃ<end_line>
-			がんばるぞ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Today's the day for our<end_line>
     meeting at the Gold Council.<end_line>
     I'll do my best!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今日は話し合いだよ<end_line>
+			金の派閥に行かなきゃ<end_line>
+			がんばるぞ！<end_line>
+		</sjis>
+    <ascii>
+    Today's the day for our<end_line>
+    meeting at the Gold Council.<end_line>
+    I'll do my best!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -173,42 +192,50 @@
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、それ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ！<end_line>
+		</sjis>
+    <ascii>
+    Hey!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			今日は話し合いだ<end_line>
 			金の派閥に行かなきゃ<end_line>
 			がんばるぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今日は話し合いだよ<end_line>
-			金の派閥に行かなきゃ<end_line>
-			がんばるぞ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Today's the day for our<end_line>
     meeting at the Gold Council.<end_line>
     I'll do my best!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今日は話し合いだよ<end_line>
+			金の派閥に行かなきゃ<end_line>
+			がんばるぞ！<end_line>
+		</sjis>
+    <ascii>
+    Today's the day for our<end_line>
+    meeting at the Gold Council.<end_line>
+    I'll do my best!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -230,18 +257,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			なんかズレてないか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なんかズレてない？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Isn't that beside the point?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なんかズレてない？<end_line>
+		</sjis>
+    <ascii>
+    Isn't that beside the point?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -249,24 +279,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			今日は話し合いだ<end_line>
 			金の派閥に行かなきゃ<end_line>
 			がんばるぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今日は話し合いだよ<end_line>
-			金の派閥に行かなきゃ<end_line>
-			がんばるぞ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Today's the day for our<end_line>
     meeting at the Gold Council.<end_line>
     I'll do my best!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今日は話し合いだよ<end_line>
+			金の派閥に行かなきゃ<end_line>
+			がんばるぞ！<end_line>
+		</sjis>
+    <ascii>
+    Today's the day for our<end_line>
+    meeting at the Gold Council.<end_line>
+    I'll do my best!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -286,21 +321,25 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			<partner>はたよりに<end_line>
 			ならないみたいだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<partner>はたよりに<end_line>
-			ならないみたい<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Looks like I can't<end_line>
     rely on <partner> this time.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<partner>はたよりに<end_line>
+			ならないみたい<end_line>
+		</sjis>
+    <ascii>
+    Looks like I can't<end_line>
+    rely on <partner> this time.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -308,24 +347,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			今日は話し合いだ<end_line>
 			金の派閥に行かなきゃ<end_line>
 			がんばるぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今日は話し合いだよ<end_line>
-			金の派閥に行かなきゃ<end_line>
-			がんばるぞ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Today's the day for our<end_line>
     meeting at the Gold Council.<end_line>
     I'll do my best!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今日は話し合いだよ<end_line>
+			金の派閥に行かなきゃ<end_line>
+			がんばるぞ！<end_line>
+		</sjis>
+    <ascii>
+    Today's the day for our<end_line>
+    meeting at the Gold Council.<end_line>
+    I'll do my best!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -379,24 +423,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			今日は話し合いだ<end_line>
 			金の派閥に行かなきゃ<end_line>
 			がんばるぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今日は話し合いだよ<end_line>
-			金の派閥に行かなきゃ<end_line>
-			がんばるぞ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Today's the day for our<end_line>
     meeting at the Gold Council.<end_line>
     I'll do my best!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今日は話し合いだよ<end_line>
+			金の派閥に行かなきゃ<end_line>
+			がんばるぞ！<end_line>
+		</sjis>
+    <ascii>
+    Today's the day for our<end_line>
+    meeting at the Gold Council.<end_line>
+    I'll do my best!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -418,42 +467,50 @@
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、それ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ！<end_line>
+		</sjis>
+    <ascii>
+    Hey!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			今日は話し合いだ<end_line>
 			金の派閥に行かなきゃ<end_line>
 			がんばるぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今日は話し合いだよ<end_line>
-			金の派閥に行かなきゃ<end_line>
-			がんばるぞ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Today's the day for our<end_line>
     meeting at the Gold Council.<end_line>
     I'll do my best!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今日は話し合いだよ<end_line>
+			金の派閥に行かなきゃ<end_line>
+			がんばるぞ！<end_line>
+		</sjis>
+    <ascii>
+    Today's the day for our<end_line>
+    meeting at the Gold Council.<end_line>
+    I'll do my best!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -475,18 +532,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			なんかズレてないか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なんかズレてない？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Isn't that beside the point?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なんかズレてない？<end_line>
+		</sjis>
+    <ascii>
+    Isn't that beside the point?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -520,24 +580,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="murno" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なに言ってるんだ<end_line>
 			ミューノは魔石を守るんだろ？<end_line>
 			立派に役に立ってるよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なに言ってるの<end_line>
-			ミューノは魔石を守ってるし<end_line>
-			立派に役に立ってるって！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You're not! You're protecting<end_line>
     the Demon Stone, right?<end_line>
     That's really important!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なに言ってるの<end_line>
+			ミューノは魔石を守ってるし<end_line>
+			立派に役に立ってるって！<end_line>
+		</sjis>
+    <ascii>
+    You're not! You're protecting<end_line>
+    the Demon Stone, right?<end_line>
+    That's really important!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">

--- a/Day 08/24589212_177339c.xml
+++ b/Day 08/24589212_177339c.xml
@@ -36,24 +36,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			うん！<end_line>
 			どんな手がかりも<end_line>
 			見落とさないぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん！<end_line>
-			どんな手がかりも<end_line>
-			見落とさないんだから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
     Keep your eyes peeled!<end_line>
     We can't miss a thing!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん！<end_line>
+			どんな手がかりも<end_line>
+			見落とさないんだから！<end_line>
+		</sjis>
+    <ascii>
+    Right!<end_line>
+    Keep your eyes peeled!<end_line>
+    We can't miss a thing!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -93,24 +98,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			うん！<end_line>
 			どんな手がかりも<end_line>
 			見落とさないぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん！<end_line>
-			どんな手がかりも<end_line>
-			見落とさないんだから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
     Keep your eyes peeled!<end_line>
     We can't miss a thing!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん！<end_line>
+			どんな手がかりも<end_line>
+			見落とさないんだから！<end_line>
+		</sjis>
+    <ascii>
+    Right!<end_line>
+    Keep your eyes peeled!<end_line>
+    We can't miss a thing!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -150,24 +160,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			うん！<end_line>
 			どんな手がかりも<end_line>
 			見落とさないぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん！<end_line>
-			どんな手がかりも<end_line>
-			見落とさないんだから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
     Keep your eyes peeled!<end_line>
     We can't miss a thing!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん！<end_line>
+			どんな手がかりも<end_line>
+			見落とさないんだから！<end_line>
+		</sjis>
+    <ascii>
+    Right!<end_line>
+    Keep your eyes peeled!<end_line>
+    We can't miss a thing!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -204,24 +219,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			うん！<end_line>
 			どんな手がかりも<end_line>
 			見落とさないぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん！<end_line>
-			どんな手がかりも<end_line>
-			見落とさないんだから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
     Keep your eyes peeled!<end_line>
     We can't miss a thing!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん！<end_line>
+			どんな手がかりも<end_line>
+			見落とさないんだから！<end_line>
+		</sjis>
+    <ascii>
+    Right!<end_line>
+    Keep your eyes peeled!<end_line>
+    We can't miss a thing!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -229,24 +249,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスたちはスレンジ採掘場の<end_line>
 			どこかにいるみたいだ<end_line>
 			さがしに行こう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスたちはスレンジ採掘場の<end_line>
-			どこかにいるみたいだよ<end_line>
-			さがしに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise seems to be hiding<end_line>
     somewhere in Slenj Mine.<end_line>
     Let's check it out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスたちはスレンジ採掘場の<end_line>
+			どこかにいるみたいだよ<end_line>
+			さがしに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Anise seems to be hiding<end_line>
+    somewhere in Slenj Mine.<end_line>
+    Let's check it out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -282,24 +307,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスたちはスレンジ採掘場の<end_line>
 			どこかにいるみたいだ<end_line>
 			さがしに行こう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスたちはスレンジ採掘場の<end_line>
-			どこかにいるみたいだよ<end_line>
-			さがしに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise seems to be hiding<end_line>
     somewhere in Slenj Mine.<end_line>
     Let's check it out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスたちはスレンジ採掘場の<end_line>
+			どこかにいるみたいだよ<end_line>
+			さがしに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Anise seems to be hiding<end_line>
+    somewhere in Slenj Mine.<end_line>
+    Let's check it out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -363,24 +393,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスたちはスレンジ採掘場の<end_line>
 			どこかにいるみたいだ<end_line>
 			さがしに行こう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスたちはスレンジ採掘場の<end_line>
-			どこかにいるみたいだよ<end_line>
-			さがしに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise seems to be hiding<end_line>
     somewhere in Slenj Mine.<end_line>
     Let's check it out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスたちはスレンジ採掘場の<end_line>
+			どこかにいるみたいだよ<end_line>
+			さがしに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Anise seems to be hiding<end_line>
+    somewhere in Slenj Mine.<end_line>
+    Let's check it out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -415,24 +450,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			アニスたちはスレンジ採掘場の<end_line>
 			どこかにいるみたいだ<end_line>
 			さがしに行こう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスたちはスレンジ採掘場の<end_line>
-			どこかにいるみたいだよ<end_line>
-			さがしに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise seems to be hiding<end_line>
     somewhere in Slenj Mine.<end_line>
     Let's check it out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスたちはスレンジ採掘場の<end_line>
+			どこかにいるみたいだよ<end_line>
+			さがしに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Anise seems to be hiding<end_line>
+    somewhere in Slenj Mine.<end_line>
+    Let's check it out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -466,24 +506,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスたちはスレンジ採掘場の<end_line>
 			どこかにいるみたいだ<end_line>
 			さがしに行こう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスたちはスレンジ採掘場の<end_line>
-			どこかにいるみたいだよ<end_line>
-			さがしに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise seems to be hiding<end_line>
     somewhere in Slenj Mine.<end_line>
     Let's check it out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスたちはスレンジ採掘場の<end_line>
+			どこかにいるみたいだよ<end_line>
+			さがしに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Anise seems to be hiding<end_line>
+    somewhere in Slenj Mine.<end_line>
+    Let's check it out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -519,24 +564,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスたちはスレンジ採掘場の<end_line>
 			どこかにいるみたいだ<end_line>
 			さがしに行こう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスたちはスレンジ採掘場の<end_line>
-			どこかにいるみたいだよ<end_line>
-			さがしに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise seems to be hiding<end_line>
     somewhere in Slenj Mine.<end_line>
     Let's check it out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスたちはスレンジ採掘場の<end_line>
+			どこかにいるみたいだよ<end_line>
+			さがしに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Anise seems to be hiding<end_line>
+    somewhere in Slenj Mine.<end_line>
+    Let's check it out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -600,24 +650,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスたちはスレンジ採掘場の<end_line>
 			どこかにいるみたいだ<end_line>
 			さがしに行こう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスたちはスレンジ採掘場の<end_line>
-			どこかにいるみたいだよ<end_line>
-			さがしに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise seems to be hiding<end_line>
     somewhere in Slenj Mine.<end_line>
     Let's check it out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスたちはスレンジ採掘場の<end_line>
+			どこかにいるみたいだよ<end_line>
+			さがしに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Anise seems to be hiding<end_line>
+    somewhere in Slenj Mine.<end_line>
+    Let's check it out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -652,24 +707,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			アニスたちはスレンジ採掘場の<end_line>
 			どこかにいるみたいだ<end_line>
 			さがしに行こう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスたちはスレンジ採掘場の<end_line>
-			どこかにいるみたいだよ<end_line>
-			さがしに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise seems to be hiding<end_line>
     somewhere in Slenj Mine.<end_line>
     Let's check it out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスたちはスレンジ採掘場の<end_line>
+			どこかにいるみたいだよ<end_line>
+			さがしに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Anise seems to be hiding<end_line>
+    somewhere in Slenj Mine.<end_line>
+    Let's check it out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -703,24 +763,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -742,21 +807,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			気をつけないと<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-			気をつけないと<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right.<end_line>
     I'll have to watch out<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+			気をつけないと<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Right.<end_line>
+    I'll have to watch out<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -764,24 +833,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -805,21 +879,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			シンチョウに行こう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-			シンチョウに行こう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right.<end_line>
     I'll be careful.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+			シンチョウに行こう<end_line>
+		</sjis>
+    <ascii>
+    Right.<end_line>
+    I'll be careful.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -827,24 +905,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -881,24 +964,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -920,21 +1008,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			シンチョウに行こう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-			シンチョウに行こう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right.<end_line>
     I'll be careful.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+			シンチョウに行こう<end_line>
+		</sjis>
+    <ascii>
+    Right.<end_line>
+    I'll be careful.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -942,24 +1034,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -997,24 +1094,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1038,24 +1140,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 			とにかくもう少し<end_line>
 			行ってみよう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<three_dots><end_line>
-			とにかくもう少し<end_line>
-			行ってみよう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
     Nothing we can do now.<end_line>
     Moving on<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<three_dots><end_line>
+			とにかくもう少し<end_line>
+			行ってみよう<end_line>
+		</sjis>
+    <ascii>
+    Right<three_dots><end_line>
+    Nothing we can do now.<end_line>
+    Moving on<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1063,24 +1170,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1129,24 +1241,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1168,24 +1285,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			がんばれ、<partner><end_line>
 			とにかくもう少し<end_line>
 			行ってみよう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			がんばって、<partner><end_line>
-			とにかくもう少し<end_line>
-			行ってみよう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     It'll be fine, <partner>!<end_line>
     Anyways, let's keep<end_line>
     going further in.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			がんばって、<partner><end_line>
+			とにかくもう少し<end_line>
+			行ってみよう<end_line>
+		</sjis>
+    <ascii>
+    It'll be fine, <partner>!<end_line>
+    Anyways, let's keep<end_line>
+    going further in.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1193,24 +1315,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1248,24 +1375,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1287,21 +1419,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			念には念を、だろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだな<end_line>
-			念には念を、でしょ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right.<end_line>
     Safety first, right?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだな<end_line>
+			念には念を、でしょ？<end_line>
+		</sjis>
+    <ascii>
+    Right.<end_line>
+    Safety first, right?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1323,24 +1459,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1362,21 +1503,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			ちょ<three_dots>っ！<end_line>
 			おどかすなよな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ちょっと<three_dots>！<end_line>
-			おどかさないでよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey<three_dots>!<end_line>
     Don't scare me like that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ちょっと<three_dots>！<end_line>
+			おどかさないでよ！<end_line>
+		</sjis>
+    <ascii>
+    Hey<three_dots>!<end_line>
+    Don't scare me like that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1392,24 +1537,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1454,45 +1604,54 @@
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>っ！<end_line>
 			まずは<partner>を<end_line>
 			助けにいかなきゃ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots>もうっ！<end_line>
-			まずは<partner>を<end_line>
-			助けにいかなきゃ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots>Ugh!<end_line>
     I have to save<end_line>
     <partner> first!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots>もうっ！<end_line>
+			まずは<partner>を<end_line>
+			助けにいかなきゃ<end_line>
+		</sjis>
+    <ascii>
+    <three_dots>Ugh!<end_line>
+    I have to save<end_line>
+    <partner> first!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			大丈夫か、<partner>？<end_line>
 			とにかくここから出よう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			大丈夫、<partner>？<end_line>
-			とにかくここから出よう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Are you okay, <partner>?<end_line>
     Let's get out of here!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			大丈夫、<partner>？<end_line>
+			とにかくここから出よう！<end_line>
+		</sjis>
+    <ascii>
+    Are you okay, <partner>?<end_line>
+    Let's get out of here!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1548,21 +1707,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			待ってろレミィ<end_line>
 			今行くからな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			待っててレミィ<end_line>
-			今行くから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hold on, Lemmy!<end_line>
     We'll be there soon!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			待っててレミィ<end_line>
+			今行くから！<end_line>
+		</sjis>
+    <ascii>
+    Hold on, Lemmy!<end_line>
+    We'll be there soon!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1584,21 +1747,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			待ってろレミィ<end_line>
 			今行くからな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			待っててレミィ<end_line>
-			今行くから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hold on, Lemmy!<end_line>
     We'll be there soon!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			待っててレミィ<end_line>
+			今行くから！<end_line>
+		</sjis>
+    <ascii>
+    Hold on, Lemmy!<end_line>
+    We'll be there soon!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1620,21 +1787,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			待ってろレミィ<end_line>
 			今行くからな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			待っててレミィ<end_line>
-			今行くから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hold on, Lemmy!<end_line>
     We'll be there soon!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			待っててレミィ<end_line>
+			今行くから！<end_line>
+		</sjis>
+    <ascii>
+    Hold on, Lemmy!<end_line>
+    We'll be there soon!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1655,21 +1826,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			待ってろレミィ<end_line>
 			今行くからな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			待っててレミィ<end_line>
-			今行くから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hold on, Lemmy!<end_line>
     We'll be there soon!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			待っててレミィ<end_line>
+			今行くから！<end_line>
+		</sjis>
+    <ascii>
+    Hold on, Lemmy!<end_line>
+    We'll be there soon!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">

--- a/Day 09/001_25493836_185014c.xml
+++ b/Day 09/001_25493836_185014c.xml
@@ -1,4 +1,3 @@
-#line 90
 <dialogue>
   <info box="left">
   <portrait_l entry="player" eye="decided" mouth="neutral">
@@ -9,6 +8,11 @@
       今日こそアニスたちを<end_line>
       とっつかまえてやるぜ！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Today is the day<end_line>
+    we catch Anise!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -16,12 +20,12 @@
       今日こそアニスたちを<end_line>
       捕まえてやるんだから！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Today is the day<end_line>
     we catch Anise!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -80,6 +84,11 @@
       アニスたちに捕まったときのこと<end_line>
       怒ってるのか？<end_line>
     </sjis>
+    <ascii>
+    What?<end_line>
+    Are you still angry about<end_line>
+    the time we were captured?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -87,12 +96,12 @@
       アニスたちに捕まったときのこと<end_line>
       怒ってるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What?<end_line>
     Are you still angry about<end_line>
     the time we were captured?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -120,6 +129,11 @@
       ま、とにかく落ちついて<end_line>
       行こうぜ<end_line>
     </sjis>
+    <ascii>
+    Really?<end_line>
+    Well, either way, calm down.<end_line>
+    Let's go.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -127,12 +141,12 @@
       ま、とにかく落ちついて<end_line>
       行こう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Really?<end_line>
     Well, either way, calm down.<end_line>
     Let's go.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -160,17 +174,21 @@
       ハラが立つのはわかるけどさ<end_line>
       あんまりムチャなことするなよ<end_line>
     </sjis>
+    <ascii>
+    I know you're angry,<end_line>
+    but don't go too crazy.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ハラが立つのはわかるけどさ<end_line>
       あんまりムチャなことしないでよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know you're angry,<end_line>
     but don't go too crazy.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -230,6 +248,11 @@
       ムチャはするなよな<end_line>
       落ちついて行こうぜ<end_line>
     </sjis>
+    <ascii>
+    Please, I'm begging you.<end_line>
+    Don't take this too far.<end_line>
+    Let's all calm down.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -237,12 +260,12 @@
       ムチャはしないでよ<end_line>
       落ちついて行こう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Please, I'm begging you.<end_line>
     Don't take this too far.<end_line>
     Let's all calm down.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -270,17 +293,21 @@
       ハラが立つのはわかるけどさ<end_line>
       あんまりムチャなことするなよ<end_line>
     </sjis>
+    <ascii>
+    I know you're angry,<end_line>
+    but don't go too crazy.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ハラが立つのはわかるけどさ<end_line>
       あんまりムチャなことしないでよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know you're angry,<end_line>
     but don't go too crazy.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -308,17 +335,21 @@
       だからムチャすんなって！<end_line>
       自警団の人もいるんだからさ<end_line>
     </sjis>
+    <ascii>
+    That's why I'm telling you!<end_line>
+    The Vigilante Corps will be there.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       だからムチャしないでって！<end_line>
       自警団の人もいるんだからさ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's why I'm telling you!<end_line>
     The Vigilante Corps will be there.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -344,6 +375,11 @@
       人手が多い方がいいんだから<end_line>
       ガマンしろよ<end_line>
     </sjis>
+    <ascii>
+    What, you don't want to?<end_line>
+    The more people helping, the better.<end_line>
+    Deal with it.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -351,12 +387,12 @@
       人手が多い方がいいんだから<end_line>
       ガマンしてよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What, you don't want to?<end_line>
     The more people helping, the better.<end_line>
     Deal with it.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -383,6 +419,11 @@
       ムチャはするなよな<end_line>
       落ちついて行こうぜ<end_line>
     </sjis>
+    <ascii>
+    Please, I'm begging you.<end_line>
+    Don't take this too far.<end_line>
+    Let's all calm down.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -390,12 +431,12 @@
       ムチャはしないでよ<end_line>
       落ちついて行こう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Please, I'm begging you.<end_line>
     Don't take this too far.<end_line>
     Let's all calm down.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -423,17 +464,21 @@
       ハラが立つのはわかるけどさ<end_line>
       あんまりムチャなことするなよ<end_line>
     </sjis>
+    <ascii>
+    I know you're angry,<end_line>
+    but don't go too crazy.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ハラが立つのはわかるけどさ<end_line>
       あんまりムチャなことしないでよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know you're angry,<end_line>
     but don't go too crazy.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -463,7 +508,7 @@
     Of course not!<end_line>
     We have to be able to hand them<end_line>
     over to the Vigilante Corps.<end_line>
-  </ascii> 
+  </ascii>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -490,6 +535,11 @@
       ムチャはするなよな<end_line>
       落ちついて行こうぜ<end_line>
     </sjis>
+    <ascii>
+    Please, I'm begging you.<end_line>
+    Don't take this too far.<end_line>
+    Let's all calm down.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -497,10 +547,10 @@
       ムチャはしないでよ<end_line>
       落ちついて行こう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Please, I'm begging you.<end_line>
     Don't take this too far.<end_line>
     Let's all calm down.<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 09/002_25495772_18508dc.xml
+++ b/Day 09/002_25495772_18508dc.xml
@@ -80,15 +80,19 @@
       まったく！<end_line>
       こんな時に！<end_line>
     </sjis>
+    <ascii>
+    Oh, come on!<end_line>
+    What terrible timing!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       もう！<end_line>
       こんな時に！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, come on!<end_line>
     What terrible timing!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 09/004_25496796_1850cdc.xml
+++ b/Day 09/004_25496796_1850cdc.xml
@@ -125,17 +125,21 @@
       ならないわね<three_dots>って<end_line>
       お前も来るつもりなのか？<end_line>
     </sjis>
+    <ascii>
+    Right<three_dots> wait,<end_line>
+    you're helping too?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ならないわね<three_dots>って<end_line>
       あなたも来るつもりなの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Right<three_dots> wait,<end_line>
     you're helping too?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 09/041_25502780_185243c.xml
+++ b/Day 09/041_25502780_185243c.xml
@@ -65,17 +65,21 @@
       オ、オレ！？<end_line>
       オレ何もしてないぞ！<end_line>
     </sjis>
+    <ascii>
+    M-me!?<end_line>
+    I didn't do anything!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わ、わたし！？<end_line>
       わたし何もしてないよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     M-me!?<end_line>
     I didn't do anything!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 09/042_25503788_185282c.xml
+++ b/Day 09/042_25503788_185282c.xml
@@ -75,13 +75,16 @@
     <sjis>
       行くぞ！<end_line>
     </sjis>
+    <ascii>
+    Here we go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       行くよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Here we go!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 09/043_25504748_1852bec.xml
+++ b/Day 09/043_25504748_1852bec.xml
@@ -20,17 +20,21 @@
       平気平気<end_line>
       楽勝だぜ！<end_line>
     </sjis>
+    <ascii>
+    No worries.<end_line>
+    That was almost too easy!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       平気平気<end_line>
       楽勝だよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No worries.<end_line>
     That was almost too easy!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -54,16 +58,19 @@
       で、さっきのアニスの仲間<end_line>
       どこ行ったんだ？<end_line>
     </sjis>
+    <ascii>
+    So, where did Anise's buddies go?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       で、さっきのアニスの仲間<end_line>
       どこ行ったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So, where did Anise's buddies go?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -100,17 +107,21 @@
       エリエまで<end_line>
       どうしたんだ！？<end_line>
     </sjis>
+    <ascii>
+    Elieze!?<end_line>
+    What's going on!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       エリエまで<end_line>
       どうしたの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Elieze!?<end_line>
     What's going on!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -376,16 +387,19 @@
       ミューノの方はオレたちに<end_line>
       まかせてくれ！<end_line>
     </sjis>
+    <ascii>
+    Leave Murno to us!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ミューノの方はわたしたちに<end_line>
       まかせて！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Leave Murno to us!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -521,17 +535,21 @@
       あ、そうか<end_line>
       それがいいよ！<end_line>
     </sjis>
+    <ascii>
+    Ah, right,<end_line>
+    that sounds good!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、そっか<end_line>
       それがいいよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, right,<end_line>
     that sounds good!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -584,17 +602,21 @@
       よっし！<end_line>
       オレたちも行こう！<end_line>
     </sjis>
+    <ascii>
+    Okay!<end_line>
+    Let's get moving!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       わたしたちも行こう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay!<end_line>
     Let's get moving!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 09/044_25508284_18539bc.xml
+++ b/Day 09/044_25508284_18539bc.xml
@@ -18,16 +18,19 @@
       アイツらの手がかりが<end_line>
       見つかったのか？<end_line>
     </sjis>
+    <ascii>
+    Find any clues?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       アイツらの手がかりが<end_line>
       見つかったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Find any clues?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -51,17 +54,21 @@
       なんだって<three_dots><end_line>
       まさか、あいつひとりで？<end_line>
     </sjis>
+    <ascii>
+    Zakk<three_dots><end_line>
+    You mean, alone?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんな<three_dots><end_line>
       まさか、ザックひとりで？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Zakk<three_dots><end_line>
     You mean, alone?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -141,15 +148,19 @@
       わかった！<end_line>
       急ごう！<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+    Let's hurry!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん！<end_line>
       急ごう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
     Let's hurry!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 09/045_25509484_1853e6c.xml
+++ b/Day 09/045_25509484_1853e6c.xml
@@ -7,17 +7,21 @@
       ザック！？<end_line>
       お前、どうしたんだ！？<end_line>
     </sjis>
+    <ascii>
+    Zakk!?<end_line>
+    Hey, what happened!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ザック！？<end_line>
       あなた、どうしたの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Zakk!?<end_line>
     Hey, what happened!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -192,6 +196,11 @@
       じゃあティエはザックをつれて<end_line>
       町にかえれ<end_line>
     </sjis>
+    <ascii>
+    Got it<three_dots><end_line>
+    Okay Tier, take Zakk<end_line>
+    and return to town.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -199,12 +208,12 @@
       じゃあティエはザックをつれて<end_line>
       町に戻ってて<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Got it<three_dots><end_line>
     Okay Tier, take Zakk<end_line>
     and return to town.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -227,6 +236,10 @@
       だからティエ、お前は<end_line>
       ザックをたのむ、な<end_line>
     </sjis>
+    <ascii>
+    We'll take care of the rest!<end_line>
+    So Tier, you watch over Zakk, okay?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -234,11 +247,11 @@
       だからティエ、あなたは<end_line>
       ザックをおねがい、ね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We'll take care of the rest!<end_line>
     So Tier, you watch over Zakk, okay?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -263,13 +276,16 @@
     <sjis>
       おう！<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 09/046_25511132_18544dc.xml
+++ b/Day 09/046_25511132_18544dc.xml
@@ -19,17 +19,21 @@
       待っていたのか？<end_line>
       オレたちを<three_dots><end_line>
     </sjis>
+    <ascii>
+    Waiting?<end_line>
+    For us<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       待っていたの？<end_line>
       わたしたちを<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Waiting?<end_line>
     For us<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -149,6 +153,11 @@
       ミューノを助ける方が大事なんだ<end_line>
       あんたには付き合ってられないよ<end_line>
     </sjis>
+    <ascii>
+    Sorry, but right now, saving Murno<end_line>
+    is more important. We don't have<end_line>
+    time to play with you.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -156,12 +165,12 @@
       ミューノを助ける方が大事なの<end_line>
       あんたに付き合ってるヒマはないよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sorry, but right now, saving Murno<end_line>
     is more important. We don't have<end_line>
     time to play with you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -172,17 +181,21 @@
       なんだと、こぞう<three_dots><end_line>
       なめるなよ！<end_line>
     </sjis>
+    <ascii>
+    The fuck, you brat<three_dots><end_line>
+    Don't underestimate me!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なんだと、きさま<three_dots><end_line>
       なめるなよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The fuck, you brat<three_dots><end_line>
     Don't underestimate me!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -209,6 +222,11 @@
       じゃあ、お前をぶったおして<end_line>
       ミューノのとこまで案内してもらうぜ<end_line>
     </sjis>
+    <ascii>
+    Alright, fine!<end_line>
+    You'll tell us where she is,<end_line>
+    after I beat the crap out of you.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -216,12 +234,12 @@
       それじゃあ、あんたをたおして<end_line>
       ミューノのとこまで案内してもらうわ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright, fine!<end_line>
     You'll tell us where she is,<end_line>
     after I beat the crap out of you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -248,6 +266,11 @@
       お前にはまだ聞きたいことが<end_line>
       あるんだ！<end_line>
     </sjis>
+    <ascii>
+    Oh, shut up!<end_line>
+    I still have things<end_line>
+    I want to ask you!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -255,12 +278,12 @@
       あんたにはまだ聞きたいことが<end_line>
       あるのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, shut up!<end_line>
     I still have things<end_line>
     I want to ask you!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -284,16 +307,19 @@
       ザックにケガさせたのは<end_line>
       お前か？<end_line>
     </sjis>
+    <ascii>
+    Are you the one who hurt Zakk?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ザックにケガさせたのって<end_line>
       あんた？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Are you the one who hurt Zakk?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -316,13 +342,16 @@
     <sjis>
       手加減しねぇってことだ！<end_line>
     </sjis>
+    <ascii>
+    Then I won't hold back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       手加減しないってことよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Then I won't hold back!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 09/047_25512972_1854c0c.xml
+++ b/Day 09/047_25512972_1854c0c.xml
@@ -8,6 +8,10 @@
       ミューノのところに<end_line>
       案内してもらうぞ！<end_line>
     </sjis>
+    <ascii>
+    Now,<end_line>
+    take me to where Murno is!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -15,11 +19,11 @@
       ミューノのところに<end_line>
       案内してもらうわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Now,<end_line>
     take me to where Murno is!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -83,17 +87,21 @@
       ちょっと<three_dots><end_line>
       なんなんだよ、コイツ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Woah<three_dots><end_line>
+    What's up with him<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちょっと<three_dots><end_line>
       なんなのよ、コイツ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Woah<three_dots><end_line>
     What's up with him<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -169,17 +177,21 @@
       ちょ、ちょっと<three_dots>！<end_line>
       オレ<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    W-wait<three_dots>!<end_line>
+    I<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちょ、ちょっと<three_dots>！<end_line>
       わたし<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     W-wait<three_dots>!<end_line>
     I<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -438,15 +450,18 @@
     <sjis>
       オ、オレたちも行こう！<end_line>
     </sjis>
+    <ascii>
+    L-let's go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わ、わたしたちも行こう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     L-let's go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 09/049_25516108_185584c.xml
+++ b/Day 09/049_25516108_185584c.xml
@@ -139,15 +139,18 @@
     <sjis>
       なんだと！<end_line>
     </sjis>
+    <ascii>
+    What was that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -383,6 +386,11 @@
       でも、あのギランってヤツは<end_line>
       オレにまかせて欲しいんだ<end_line>
     </sjis>
+    <ascii>
+    Sorry, Brother<three_dots><end_line>
+    But, I want you to leave<end_line>
+    that Gillan guy to me.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -390,12 +398,12 @@
       でも、あのギランって人は<end_line>
       わたしにまかせて欲しいんだ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sorry, Brother<three_dots><end_line>
     But, I want you to leave<end_line>
     that Gillan guy to me.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -446,6 +454,11 @@
       教わってないと思うんだ<end_line>
       それをアイツに証明したくて<three_dots><end_line>
     </sjis>
+    <ascii>
+    I want to prove it to them<three_dots><end_line>
+    That Master has never taught<end_line>
+    me anything wrong.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -453,12 +466,12 @@
       教わってないと思うんだ<end_line>
       それをアイツに証明したくて<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I want to prove it to them<three_dots><end_line>
     That Master has never taught<end_line>
     me anything wrong.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 09/050_25518780_18562bc.xml
+++ b/Day 09/050_25518780_18562bc.xml
@@ -77,17 +77,21 @@
       さあ<end_line>
       親方にあやまれよ！<end_line>
     </sjis>
+    <ascii>
+    Go on,<end_line>
+    apologize to Master!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       さあ<end_line>
       親方にあやまってよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Go on,<end_line>
     apologize to Master!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -420,15 +424,18 @@
     <sjis>
       お、オレたちも急ごう<end_line>
     </sjis>
+    <ascii>
+    We should get going too.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしたちも急ごう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We should get going too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 09/051_25521372_1856cdc.xml
+++ b/Day 09/051_25521372_1856cdc.xml
@@ -6,17 +6,21 @@
       見つけたぞ、アニス！<end_line>
       ミューノを返せ！<end_line>
     </sjis>
+    <ascii>
+    Found you, Anise!<end_line>
+    Let Murno go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       見つけたわよ、アニス！<end_line>
       ミューノを返して！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Found you, Anise!<end_line>
     Let Murno go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -168,6 +172,11 @@
       ミューノを返せって<end_line>
       言ってンだろ！？<end_line>
     </sjis>
+    <ascii>
+    Wait!<end_line>
+    I told you to return Murno,<end_line>
+    didn't I!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -175,12 +184,12 @@
       ミューノを返してって<end_line>
       言ってるでしょ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wait!<end_line>
     I told you to return Murno,<end_line>
     didn't I!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -340,17 +349,21 @@
       待て<three_dots><end_line>
       ミューノを返せ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Wait<three_dots><end_line>
+    Let Murno go<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       待って<three_dots><end_line>
       ミューノを返して<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wait<three_dots><end_line>
     Let Murno go<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -477,15 +490,18 @@
     <sjis>
       き<three_dots>、きっさま<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Y<three_dots> You<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ<three_dots>、あんたっ<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Y<three_dots> You<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 09/052_25524476_18578fc.xml
+++ b/Day 09/052_25524476_18578fc.xml
@@ -76,17 +76,21 @@
       お前<three_dots><end_line>
       今、なにをした！？<end_line>
     </sjis>
+    <ascii>
+    Why you<three_dots><end_line>
+    What did you do!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんた<three_dots><end_line>
       今、なにをしたの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Why you<three_dots><end_line>
     What did you do!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -206,17 +210,21 @@
       アニスはオレが捕まえるから<end_line>
       親方たちは逃げたヤツらを！<end_line>
     </sjis>
+    <ascii>
+    I'll catch Anise,<end_line>
+    Master, go after the runners!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       アニスはわたしが捕まえるから<end_line>
       親方たちは逃げたふたりを！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'll catch Anise,<end_line>
     Master, go after the runners!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -506,17 +514,21 @@
       <partner><three_dots><end_line>
       いけるな？<end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots><end_line>
+    Can you do it?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner><three_dots><end_line>
       いけるね？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots><end_line>
     Can you do it?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -576,6 +588,10 @@
       お前はオレたちが<end_line>
       ぶっとばす！！！！！<end_line>
     </sjis>
+    <ascii>
+    Alright, prepare yourself!<end_line>
+    We're gonna destroy you!!!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -583,11 +599,11 @@
       あんたはわたしたちが<end_line>
       ぶっとばす！！！！！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright, prepare yourself!<end_line>
     We're gonna destroy you!!!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="right" effect="big">

--- a/Day 09/053_25528492_18588ac.xml
+++ b/Day 09/053_25528492_18588ac.xml
@@ -7,17 +7,21 @@
       さあ<end_line>
       おとなしくしろ！<end_line>
     </sjis>
+    <ascii>
+    Now,<end_line>
+    still still!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       さあ<end_line>
       おとなしくするのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Now,<end_line>
     still still!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -115,6 +119,11 @@
       これで終わりだな<end_line>
       さあ、お前も<three_dots><end_line>
     </sjis>
+    <ascii>
+    This is the end<end_line>
+    of your schemes.<end_line>
+    Come, you too<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -122,12 +131,12 @@
       これで終わりね<end_line>
       さあ、あんたも<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This is the end<end_line>
     of your schemes.<end_line>
     Come, you too<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -307,17 +316,21 @@
       てめぇ！<end_line>
       何してんだ！<end_line>
     </sjis>
+    <ascii>
+    You!<end_line>
+    What are you doing!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんたっ！<end_line>
       何するのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You!<end_line>
     What are you doing!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">

--- a/Day 09/054_25531292_185939c.xml
+++ b/Day 09/054_25531292_185939c.xml
@@ -57,6 +57,11 @@
       これ以上やる気なら<end_line>
       オレは、こいつを<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    The match is already over.<end_line>
+    If you still want to fight,<end_line>
+    I'll be the one<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -64,12 +69,12 @@
       これ以上やる気なら<end_line>
       わたしは、こいつを<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The match is already over.<end_line>
     If you still want to fight,<end_line>
     I'll be the one<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -211,17 +216,21 @@
       ふう<end_line>
       やったな、<partner><end_line>
     </sjis>
+    <ascii>
+    Phew.<end_line>
+    We did it, <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ふう<end_line>
       やったね、<partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Phew.<end_line>
     We did it, <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -497,6 +506,11 @@
       みんながいてくれたおかげだよ<end_line>
       レミィもありがとな<end_line>
     </sjis>
+    <ascii>
+    It's thanks to everyone that<end_line>
+    we've been able to come this far.<end_line>
+    Thank you too, Lemmy.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -504,12 +518,12 @@
       みんながいてくれたおかげだよ<end_line>
       レミィもありがとね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's thanks to everyone that<end_line>
     we've been able to come this far.<end_line>
     Thank you too, Lemmy.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -664,6 +678,11 @@
       じゃ、あとひとふんばり<end_line>
       がんばろうぜ！<end_line>
     </sjis>
+    <ascii>
+    Ah, right.<end_line>
+    Then, for this last part,<end_line>
+    let's do our best!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -671,12 +690,12 @@
       じゃ、あとひとふんばり<end_line>
       がんばろう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, right.<end_line>
     Then, for this last part,<end_line>
     let's do our best!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -686,15 +705,18 @@
     <sjis>
       な、ミューノ！<end_line>
     </sjis>
+    <ascii>
+    Right, Murno?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ね、ミューノ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Right, Murno?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -728,6 +750,11 @@
       ど、どうして<three_dots>！？<end_line>
       オレ、なんか悪いこと言った！？<end_line>
     </sjis>
+    <ascii>
+    Eh!?<end_line>
+    Wh-why<three_dots>!?<end_line>
+    Did I say something wrong!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -735,12 +762,12 @@
       ど、どうして<three_dots>！？<end_line>
       わたし、なんか悪いこと言った！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh!?<end_line>
     Wh-why<three_dots>!?<end_line>
     Did I say something wrong!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Day 09/057_25536988_185a9dc.xml
+++ b/Day 09/057_25536988_185a9dc.xml
@@ -57,6 +57,11 @@
       じゃあ、お父さんが元気になって<end_line>
       村に戻れるのも、もうすぐだ<end_line>
     </sjis>
+    <ascii>
+    I see, that's great.<end_line>
+    So it won't be long until<end_line>
+    you can go back to your village.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -64,12 +69,12 @@
       じゃあ、お父さんが元気になって<end_line>
       村に戻れるのも、もうすぐだね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see, that's great.<end_line>
     So it won't be long until<end_line>
     you can go back to your village.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -96,6 +101,11 @@
       魔石を戻すまでは<end_line>
       終わっていないんだぜ<end_line>
     </sjis>
+    <ascii>
+    It's not over yet.<end_line>
+    Until we return the Demon Stone,<end_line>
+    this isn't over.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -103,12 +113,12 @@
       魔石を戻すまでは<end_line>
       終わっていないんだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's not over yet.<end_line>
     Until we return the Demon Stone,<end_line>
     this isn't over.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -159,6 +169,11 @@
       オレが行きたいんだ<end_line>
       ダメだって言われてもついていくぞ<end_line>
     </sjis>
+    <ascii>
+    Sorry, Murno.<end_line>
+    I'm going with you.<end_line>
+    Even if you tell me not to.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -166,12 +181,12 @@
       わたしが行きたいんだ<end_line>
       ダメだって言われてもついていくから<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sorry, Murno.<end_line>
     I'm going with you.<end_line>
     Even if you tell me not to.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -198,6 +213,11 @@
       ミューノと出会って色々あったなぁ<end_line>
       これまであっという間だったよ<end_line>
     </sjis>
+    <ascii>
+    Still<three_dots> Ever since we met,<end_line>
+    It's been quite a ride.<end_line>
+    Everything went by so fast.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -205,12 +225,12 @@
       ミューノと出会って色々あったね<end_line>
       これまであっという間だったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Still<three_dots> Ever since we met,<end_line>
     It's been quite a ride.<end_line>
     Everything went by so fast.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -353,6 +373,11 @@
       そんなのお安いご用さ<three_dots><end_line>
       <three_dots>って待てよ<end_line>
     </sjis>
+    <ascii>
+    Eh! Is that it?<end_line>
+    That's an easy reque<three_dots><end_line>
+    <three_dots>Hey, wait.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -360,12 +385,12 @@
       そんなのお安いご用よ<three_dots><end_line>
       <three_dots>ってちょっと待って<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh! Is that it?<end_line>
     That's an easy reque<three_dots><end_line>
     <three_dots>Hey, wait.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -446,6 +471,11 @@
       いいに決まってるじゃないか！<end_line>
       じゃ、明日いっしょに作ろう！<end_line>
     </sjis>
+    <ascii>
+    Okay okay, I was joking!<end_line>
+    Of course it's okay!<end_line>
+    Let's do it tomorrow!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -453,12 +483,12 @@
       いいに決まってるじゃないの！<end_line>
       じゃ、明日いっしょに作ろうね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay okay, I was joking!<end_line>
     Of course it's okay!<end_line>
     Let's do it tomorrow!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 09/058_25539052_185b1ec.xml
+++ b/Day 09/058_25539052_185b1ec.xml
@@ -1,4 +1,3 @@
-#400
 <dialogue>
   <partner name="run-dor">
   <info box="nobox">
@@ -65,6 +64,11 @@
       あとはゴヴァンの魔石を戻せば<end_line>
       おしまいだな<three_dots><end_line>
     </sjis>
+    <ascii>
+    We've captured Anise,<end_line>
+    so once we return the Demon Stone,<end_line>
+    it'll be over<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -72,12 +76,12 @@
       あとはゴヴァンの魔石を戻せば<end_line>
       おしまいだね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We've captured Anise,<end_line>
     so once we return the Demon Stone,<end_line>
     it'll be over<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -103,17 +107,21 @@
       そっか<three_dots><end_line>
       よかったな、ミューノ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    Murno must be happy<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっか<three_dots><end_line>
       よかったね、ミューノ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     Murno must be happy<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -135,6 +143,11 @@
       お前と会ってから<end_line>
       いろんなことがあったな<three_dots><end_line>
     </sjis>
+    <ascii>
+    You know<three_dots><end_line>
+    Since I met you,<end_line>
+    all sorts of things have happened<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -142,12 +155,12 @@
       あなたと会ってから<end_line>
       いろんなことがあったね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You know<three_dots><end_line>
     Since I met you,<end_line>
     all sorts of things have happened<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -176,6 +189,10 @@
       鍛冶師のパートナーは<end_line>
       面白かったか？<end_line>
     </sjis>
+    <ascii>
+    How was it?<end_line>
+    Did you find it interesting?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -183,11 +200,11 @@
       鍛冶師のパートナーは<end_line>
       面白かった？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How was it?<end_line>
     Did you find it interesting?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -247,6 +264,11 @@
       <partner>の仕事はすごく正確だし<end_line>
       良い職人になれると思うけどな<end_line>
     </sjis>
+    <ascii>
+    Hmm<three_dots><end_line>
+    Your work is always so precise.<end_line>
+    I think you'd make a great smith.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -254,12 +276,12 @@
       <partner>の仕事はすごく正確だし<end_line>
       良い職人になれると思うけど<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hmm<three_dots><end_line>
     Your work is always so precise.<end_line>
     I think you'd make a great smith.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -318,6 +340,11 @@
       自分ではよくわからないんだけど<end_line>
       そうなのかな？<end_line>
     </sjis>
+    <ascii>
+    Hmm<three_dots><end_line>
+    I don't really get it myself,<end_line>
+    is that how it is?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -325,12 +352,12 @@
       自分ではよくわからないんだけど<end_line>
       そうなのかな？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hmm<three_dots><end_line>
     I don't really get it myself,<end_line>
     is that how it is?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -359,6 +386,10 @@
       <partner>にだって<end_line>
       魂はあるさ！<end_line>
     </sjis>
+    <ascii>
+    That's not true!<end_line>
+    You have a soul too, <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -366,11 +397,11 @@
       <partner>にだって<end_line>
       魂はあるよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's not true!<end_line>
     You have a soul too, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -395,6 +426,11 @@
       たまに<partner>だって怒ったり<end_line>
       するときがあるじゃないか！<end_line>
     </sjis>
+    <ascii>
+    Well<three_dots> I don't know, but<end_line>
+    sometimes, even you get angry<end_line>
+    about things, <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -402,12 +438,12 @@
       たまに<partner>だって怒ったり<end_line>
       するときがあるじゃない！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well<three_dots> I don't know, but<end_line>
     sometimes, even you get angry<end_line>
     about things, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -434,6 +470,11 @@
       そういう<partner>だから<end_line>
       オレたちは今までパートナーとして<end_line>
     </sjis>
+    <ascii>
+    I don't think that's true.<end_line>
+    It's because you do have emotions,<end_line>
+    that we've been able to get here,<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -441,12 +482,12 @@
       そういう<partner>だから<end_line>
       わたしたちは今までパートナーとして<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I don't think that's true.<end_line>
     It's because you do have emotions,<end_line>
     that we've been able to get here,<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -511,6 +552,11 @@
       あとはゴヴァンの魔石を戻せば<end_line>
       おしまいだな<three_dots><end_line>
     </sjis>
+    <ascii>
+    We've captured Anise,<end_line>
+    so once we return the Demon Stone,<end_line>
+    it'll be over<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -518,12 +564,12 @@
       あとはゴヴァンの魔石を戻せば<end_line>
       おしまいだね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We've captured Anise,<end_line>
     so once we return the Demon Stone,<end_line>
     it'll be over<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 #6
 <dialogue>
@@ -552,17 +598,21 @@
       そっか<three_dots><end_line>
       よかったな、ミューノ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    Murno must be happy<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっか<three_dots><end_line>
       よかったね、ミューノ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     Murno must be happy<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -591,6 +641,11 @@
       それにしても、お前と会ってから<end_line>
       いろんなことがあったな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Thanks, <partner><three_dots><end_line>
+    You know, since I met you,<end_line>
+    all sorts of things have happened<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -598,12 +653,12 @@
       それにしても、あなたと会ってから<end_line>
       いろんなことがあったね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Thanks, <partner><three_dots><end_line>
     You know, since I met you,<end_line>
     all sorts of things have happened<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -632,6 +687,10 @@
       鍛冶師のパートナーは<end_line>
       面白かったか？<end_line>
     </sjis>
+    <ascii>
+    How was it?<end_line>
+    Did you find it interesting?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -639,11 +698,11 @@
       鍛冶師のパートナーは<end_line>
       面白かった？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How was it?<end_line>
     Did you find it interesting?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -687,6 +746,11 @@
       オレだってお前と会ってから<end_line>
       毎日ドキドキすることばっかだったぜ<end_line>
     </sjis>
+    <ascii>
+    I feel the same way.<end_line>
+    Ever since we met, every day<end_line>
+    has been full of excitement.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -694,12 +758,12 @@
       わたしだってあなたと会ってから<end_line>
       毎日ドキドキすることばっかだったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I feel the same way.<end_line>
     Ever since we met, every day<end_line>
     has been full of excitement.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -743,6 +807,11 @@
       いつか<partner>用の武器も<end_line>
       作ってやるからな<end_line>
     </sjis>
+    <ascii>
+    Yeah, I will!<end_line>
+    One day, I'll make a weapon<end_line>
+    for you to use.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -750,12 +819,12 @@
       いつか<partner>用の武器も<end_line>
       作ってあげるからね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, I will!<end_line>
     One day, I'll make a weapon<end_line>
     for you to use.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -784,6 +853,11 @@
       魔石を戻しに行く前に<end_line>
       なんかやり残したこととかないのか？<end_line>
     </sjis>
+    <ascii>
+    That reminds me, <partner>.<end_line>
+    Before we return the Demon Stone,<end_line>
+    is there anything you'd like to do?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -791,12 +865,12 @@
       魔石を戻しに行く前に<end_line>
       なんかやり残したこととかないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That reminds me, <partner>.<end_line>
     Before we return the Demon Stone,<end_line>
     is there anything you'd like to do?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -832,17 +906,21 @@
       そ、そうなのか<three_dots><end_line>
       なんかさびしいなぁ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I-is that so<three_dots><end_line>
+    That makes me feel kinda lonely<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そ、そうなんだ<three_dots><end_line>
       なんかさびしいなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I-is that so<three_dots><end_line>
     That makes me feel kinda lonely<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -883,6 +961,11 @@
       あとはゴヴァンの魔石を戻せば<end_line>
       おしまいだな<three_dots><end_line>
     </sjis>
+    <ascii>
+    We've captured Anise,<end_line>
+    so once we return the Demon Stone,<end_line>
+    it'll be over<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -890,12 +973,12 @@
       あとはゴヴァンの魔石を戻せば<end_line>
       おしまいだね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We've captured Anise,<end_line>
     so once we return the Demon Stone,<end_line>
     it'll be over<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -923,17 +1006,21 @@
       そっか<three_dots><end_line>
       よかったな、ミューノ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    Murno must be happy<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっか<three_dots><end_line>
       よかったね、ミューノ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     Murno must be happy<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -958,6 +1045,11 @@
       お前と会ってから<end_line>
       いろんなことがあったな<three_dots><end_line>
     </sjis>
+    <ascii>
+    You know<three_dots><end_line>
+    Since I met you,<end_line>
+    all sorts of things have happened<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -965,12 +1057,12 @@
       あなたと会ってから<end_line>
       いろんなことがあったね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You know<three_dots><end_line>
     Since I met you,<end_line>
     all sorts of things have happened<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -999,6 +1091,10 @@
       鍛冶師のパートナーは<three_dots><end_line>
       やっぱイヤだったか？<end_line>
     </sjis>
+    <ascii>
+    How was it?<end_line>
+    Did you hate it after all?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1006,11 +1102,11 @@
       鍛冶師のパートナーって<three_dots><end_line>
       やっぱイヤだった？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How was it?<end_line>
     Did you hate it after all?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1039,6 +1135,11 @@
       そんなにつらかったのか<end_line>
       悪かったな<three_dots><end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    It must have been tough.<end_line>
+    Sorry<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1046,12 +1147,12 @@
       そんなにつらかったんだ<end_line>
       悪かったね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     It must have been tough.<end_line>
     Sorry<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1079,17 +1180,21 @@
       もう<three_dots><end_line>
       なんなんだよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Geez<three_dots><end_line>
+    What's with you<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       もう<three_dots><end_line>
       なんなのよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Geez<three_dots><end_line>
     What's with you<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1129,17 +1234,21 @@
       たしかにお前といると<end_line>
       問題ばっか起きたからな<end_line>
     </sjis>
+    <ascii>
+    It's true, problems seem to<end_line>
+    come up when I'm with you.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       たしかにあなたといると<end_line>
       問題ばっか起きたからね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's true, problems seem to<end_line>
     come up when I'm with you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1246,6 +1355,11 @@
       魔石を戻しに行く前に<end_line>
       なんかやり残したこととかないのか？<end_line>
     </sjis>
+    <ascii>
+    That reminds me, <partner>.<end_line>
+    Before we return the Demon Stone,<end_line>
+    is there anything you'd like to do?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1253,12 +1367,12 @@
       魔石を戻しに行く前に<end_line>
       なんかやり残したこととかないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That reminds me, <partner>.<end_line>
     Before we return the Demon Stone,<end_line>
     is there anything you'd like to do?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1294,17 +1408,21 @@
       そ、そうなのか<three_dots><end_line>
       なんかさびしいなぁ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I-is that so<three_dots><end_line>
+    That makes me feel kinda lonely<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そ、そうなんだ<three_dots><end_line>
       なんかさびしいなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I-is that so<three_dots><end_line>
     That makes me feel kinda lonely<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1341,6 +1459,11 @@
       あとはゴヴァンの魔石を戻せば<end_line>
       おしまいだな<three_dots><end_line>
     </sjis>
+    <ascii>
+    We've captured Anise,<end_line>
+    so once we return the Demon Stone,<end_line>
+    it'll be over<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1348,12 +1471,12 @@
       あとはゴヴァンの魔石を戻せば<end_line>
       おしまいだね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We've captured Anise,<end_line>
     so once we return the Demon Stone,<end_line>
     it'll be over<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1379,17 +1502,21 @@
       そっか<three_dots><end_line>
       よかったな、ミューノ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    Murno must be happy<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっか<three_dots><end_line>
       よかったね、ミューノ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     Murno must be happy<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1416,6 +1543,11 @@
       それにしても、お前と会ってから<end_line>
       いろんなことがあったな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Yeah<three_dots><end_line>
+    You know, since I met you,<end_line>
+    all sorts of things have happened<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1423,12 +1555,12 @@
       それにしても、あなたと会ってから<end_line>
       いろんなことがあったね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah<three_dots><end_line>
     You know, since I met you,<end_line>
     all sorts of things have happened<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1481,17 +1613,21 @@
       あはは<three_dots><end_line>
       そっか<three_dots>、ごめんな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ahaha<three_dots><end_line>
+    I see<three_dots> Sorry<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あはは<three_dots><end_line>
       そっか<three_dots>、ごめんね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ahaha<three_dots><end_line>
     I see<three_dots> Sorry<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1583,6 +1719,11 @@
       いつか<partner>用の武器も<end_line>
       作ってやるからな<end_line>
     </sjis>
+    <ascii>
+    Yeah, leave it to me!<end_line>
+    One day, I'll make a weapon<end_line>
+    for you to use, <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1590,12 +1731,12 @@
       いつか<partner>用の武器も<end_line>
       作ってあげるからね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, leave it to me!<end_line>
     One day, I'll make a weapon<end_line>
     for you to use, <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1620,6 +1761,11 @@
       魔石を戻しに行く前に<end_line>
       なんかやり残したこととかないのか？<end_line>
     </sjis>
+    <ascii>
+    That reminds me, <partner>.<end_line>
+    Before we return the Demon Stone,<end_line>
+    is there anything you'd like to do?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1627,12 +1773,12 @@
       魔石を戻しに行く前に<end_line>
       なんかやり残したこととかないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That reminds me, <partner>.<end_line>
     Before we return the Demon Stone,<end_line>
     is there anything you'd like to do?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1667,17 +1813,21 @@
       そ、そうなのか<three_dots><end_line>
       なんかさびしいなぁ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I-is that so<three_dots><end_line>
+    That makes me feel kinda lonely<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そ、そうなんだ<three_dots><end_line>
       なんかさびしいなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I-is that so<three_dots><end_line>
     That makes me feel kinda lonely<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 09/059_25543452_185c31c.xml
+++ b/Day 09/059_25543452_185c31c.xml
@@ -5,15 +5,18 @@
     <sjis>
       お、ヒーロー発見！<end_line>
     </sjis>
+    <ascii>
+    Oh, there's our hero!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       お、ヒロイン発見！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, there's our hero!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -60,6 +63,11 @@
       そんなにオレのこと、ほめるなんて<end_line>
       なんだか気持ち悪いよ<end_line>
     </sjis>
+    <ascii>
+    Wait<three_dots> What's wrong, Master?<end_line>
+    It's kind of creepy for you to<end_line>
+    praise me so much.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -67,12 +75,12 @@
       そんなにわたしのこと、ほめるなんて<end_line>
       なんだか気持ち悪いよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wait<three_dots> What's wrong, Master?<end_line>
     It's kind of creepy for you to<end_line>
     praise me so much.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -127,6 +135,11 @@
       悪い男になったんだい<end_line>
       <player_nickname><three_dots><end_line>
     </sjis>
+    <ascii>
+    Since when have you been<end_line>
+    such a horrible person?<end_line>
+    <player_nickname><three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -134,12 +147,12 @@
       ヒドイ女になったんだい<end_line>
       <player_nickname><three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Since when have you been<end_line>
     such a horrible person?<end_line>
     <player_nickname><three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -149,15 +162,18 @@
     <sjis>
       なんだよ、それ<three_dots><end_line>
     </sjis>
+    <ascii>
+    What the<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What the<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 09/060_25545292_185ca4c.xml
+++ b/Day 09/060_25545292_185ca4c.xml
@@ -17,17 +17,21 @@
       ホントお前はいっつも<end_line>
       いいとこに現れるよな<end_line>
     </sjis>
+    <ascii>
+    Really, you always show up<end_line>
+    at the perfect time.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あなたってホントいつも<end_line>
       いいところに現れるよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Really, you always show up<end_line>
     at the perfect time.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -209,6 +213,11 @@
       ミューノの村へは行けそうに<end_line>
       ないよな<three_dots><end_line>
     </sjis>
+    <ascii>
+    But in your condition,<end_line>
+    I don't think you'll be able to<end_line>
+    go to Murno's village<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -216,12 +225,12 @@
       ミューノの村へは行けそうに<end_line>
       ないよね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     But in your condition,<end_line>
     I don't think you'll be able to<end_line>
     go to Murno's village<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -244,6 +253,11 @@
       すっごく反対されてたじゃないか<end_line>
       行っちゃダメだって<end_line>
     </sjis>
+    <ascii>
+    Well, your mother was really<end_line>
+    against it, saying<end_line>
+    you weren't allowed to go.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -251,12 +265,12 @@
       すっごく反対されてたじゃない<end_line>
       行っちゃダメだって<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, your mother was really<end_line>
     against it, saying<end_line>
     you weren't allowed to go.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -279,6 +293,11 @@
       お母さんだってお前のこと<end_line>
       心配してるんだしさ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Doesn't matter, you say<three_dots><end_line>
+    Your mother's worrying<end_line>
+    about you, you know<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -286,12 +305,12 @@
       お母さんだってあなたのこと<end_line>
       心配してるんだしさ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Doesn't matter, you say<three_dots><end_line>
     Your mother's worrying<end_line>
     about you, you know<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -331,6 +350,11 @@
       お前、どうしてそんなに<end_line>
       ボスタフさんにこだわるんだ？<end_line>
     </sjis>
+    <ascii>
+    Bostaph this, Bostaph that<three_dots><end_line>
+    Why are you so<end_line>
+    obsessed with him?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -338,12 +362,12 @@
       どうしてそんなにボスタフさんに<end_line>
       こだわるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Bostaph this, Bostaph that<three_dots><end_line>
     Why are you so<end_line>
     obsessed with him?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 09/061_25547068_185d13c.xml
+++ b/Day 09/061_25547068_185d13c.xml
@@ -263,6 +263,11 @@
       もったいぶるなよ！<end_line>
       ケチ！<end_line>
     </sjis>
+    <ascii>
+    Hey, Bro!<end_line>
+    Don't go acting all high and mighty!<end_line>
+    Stingy!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -270,12 +275,12 @@
       もったいぶらないでよ！<end_line>
       ケチ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, Bro!<end_line>
     Don't go acting all high and mighty!<end_line>
     Stingy!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 09/062_25548636_185d75c.xml
+++ b/Day 09/062_25548636_185d75c.xml
@@ -73,17 +73,21 @@
       <three_dots>って、お前<end_line>
       ついてくるつもりなのか？<end_line>
     </sjis>
+    <ascii>
+    <three_dots>Wait, you're<end_line>
+    coming too?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>って、あなた<end_line>
       ついてくるつもりなの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots>Wait, you're<end_line>
     coming too?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -203,6 +207,11 @@
       止められてたんだぜ<end_line>
       ムリしないで家にいた方がいいって<end_line>
     </sjis>
+    <ascii>
+    Even that Lemmy was<end_line>
+    dissuaded by his mother.<end_line>
+    She told him not to push himself.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -210,12 +219,12 @@
       止められてたんだよ<end_line>
       ムリしないで家にいた方がいいって<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Even that Lemmy was<end_line>
     dissuaded by his mother.<end_line>
     She told him not to push himself.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -240,15 +249,18 @@
     <sjis>
       遊びじゃないんだ！<end_line>
     </sjis>
+    <ascii>
+    This isn't a game!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       遊びじゃないの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This isn't a game!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -271,6 +283,11 @@
       両親は心配してるんだろ？<end_line>
       それなのにまた勝手にそんな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Your parents have been worried<end_line>
+    about you the whole time, right?<end_line>
+    Yet you keep running off<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -278,12 +295,12 @@
       ご両親は心配してるんでしょ？<end_line>
       それなのにまた勝手にそんな<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Your parents have been worried<end_line>
     about you the whole time, right?<end_line>
     Yet you keep running off<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -348,17 +365,21 @@
       そっか<end_line>
       両親もよろこぶとおもうぜ<end_line>
     </sjis>
+    <ascii>
+    Good, I'm sure your parents<end_line>
+    will be happy to see you.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっか<end_line>
       ご両親もよろこぶとおもうよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Good, I'm sure your parents<end_line>
     will be happy to see you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -383,17 +404,21 @@
       ん～<three_dots>？<end_line>
       なんだよ？<end_line>
     </sjis>
+    <ascii>
+    Hmm<three_dots>?<end_line>
+    What is it?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ん～<three_dots>？<end_line>
       なによ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hmm<three_dots>?<end_line>
     What is it?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -417,6 +442,11 @@
       オレひとりでいいのか？<end_line>
       みんなでアイサツに行った方が<three_dots><end_line>
     </sjis>
+    <ascii>
+    Eh<three_dots>?<end_line>
+    Just me?<end_line>
+    It'd be better if everyone<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -424,12 +454,12 @@
       わたしひとりでいいの？<end_line>
       みんなでアイサツに行った方が<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh<three_dots>?<end_line>
     Just me?<end_line>
     It'd be better if everyone<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 09/24646252_178126c.xml
+++ b/Day 09/24646252_178126c.xml
@@ -32,24 +32,29 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			それは、そうだけど<three_dots><end_line>
 			あまりムチャなことは<end_line>
 			考えないようにな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			それは、そうだけど<three_dots><end_line>
-			あまりムチャなことは<end_line>
-			考えないようにね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, yeah<three_dots><end_line>
     Don't do anything<end_line>
     too reckless.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			それは、そうだけど<three_dots><end_line>
+			あまりムチャなことは<end_line>
+			考えないようにね<end_line>
+		</sjis>
+    <ascii>
+    Well, yeah<three_dots><end_line>
+    Don't do anything<end_line>
+    too reckless.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -85,21 +90,25 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			あまりムチャなことは<end_line>
 			考えないようにな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あまりムチャなことは<end_line>
-			考えないようにね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Don't do anything<end_line>
     too crazy.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あまりムチャなことは<end_line>
+			考えないようにね<end_line>
+		</sjis>
+    <ascii>
+    Don't do anything<end_line>
+    too crazy.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -135,21 +144,25 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			あまりムチャなことは<end_line>
 			考えないようにな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あまりムチャなことは<end_line>
-			考えないようにね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Don't do anything<end_line>
     too crazy.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あまりムチャなことは<end_line>
+			考えないようにね<end_line>
+		</sjis>
+    <ascii>
+    Don't do anything<end_line>
+    too crazy.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -182,21 +195,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			あまりムチャなことは<end_line>
 			考えないようにな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あまりムチャなことは<end_line>
-			考えないようにね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Don't do anything<end_line>
     too reckless.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あまりムチャなことは<end_line>
+			考えないようにね<end_line>
+		</sjis>
+    <ascii>
+    Don't do anything<end_line>
+    too reckless.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -234,18 +251,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Right<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -295,18 +315,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Right<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -358,18 +381,21 @@
 	<portrait_l entry="player" eye="sad" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			わかったよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わかったわよ、もう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright, fine.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わかったわよ、もう<end_line>
+		</sjis>
+    <ascii>
+    Alright, fine.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -418,18 +444,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Right<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -478,24 +507,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノなら大丈夫だよ<end_line>
 			ベンソン親方もついてるしさ<end_line>
 			オレたちもできることをやらなきゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノなら大丈夫だよ<end_line>
-			ベンソン親方もついてるしさ<end_line>
-			わたしたちもできることをやらなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Murno will be fine.<end_line>
     Master Benson is with her.<end_line>
     We have to do what we can!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノなら大丈夫だよ<end_line>
+			ベンソン親方もついてるしさ<end_line>
+			わたしたちもできることをやらなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    Murno will be fine.<end_line>
+    Master Benson is with her.<end_line>
+    We have to do what we can!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -547,24 +581,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノなら大丈夫だよ<end_line>
 			ベンソン親方もついてるしさ<end_line>
 			オレたちもできることをやらなきゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノなら大丈夫だよ<end_line>
-			ベンソン親方もついてるしさ<end_line>
-			わたしたちもできることをやらなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Murno will be fine.<end_line>
     Master Benson is with her.<end_line>
     We have to do what we can!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノなら大丈夫だよ<end_line>
+			ベンソン親方もついてるしさ<end_line>
+			わたしたちもできることをやらなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    Murno will be fine.<end_line>
+    Master Benson is with her.<end_line>
+    We have to do what we can!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -616,24 +655,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノなら大丈夫だよ<end_line>
 			ベンソン親方もついてるしさ<end_line>
 			オレたちもできることをやらなきゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノなら大丈夫だよ<end_line>
-			ベンソン親方もついてるしさ<end_line>
-			わたしたちもできることをやらなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Murno will be fine.<end_line>
     Master Benson is with her.<end_line>
     We have to do what we can!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノなら大丈夫だよ<end_line>
+			ベンソン親方もついてるしさ<end_line>
+			わたしたちもできることをやらなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    Murno will be fine.<end_line>
+    Master Benson is with her.<end_line>
+    We have to do what we can!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -684,24 +728,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノなら大丈夫だよ<end_line>
 			ベンソン親方もついてるしさ<end_line>
 			オレたちもできることをやらなきゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノなら大丈夫だよ<end_line>
-			ベンソン親方もついてるしさ<end_line>
-			わたしたちもできることをやらなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Murno will be fine.<end_line>
     Master Benson is with her.<end_line>
     We have to do what we can!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノなら大丈夫だよ<end_line>
+			ベンソン親方もついてるしさ<end_line>
+			わたしたちもできることをやらなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    Murno will be fine.<end_line>
+    Master Benson is with her.<end_line>
+    We have to do what we can!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -724,24 +773,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間がリュート岩窟に<end_line>
 			いたみたいだ！<end_line>
 			急ぐぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間がリュート岩窟に<end_line>
-			いたみたい！<end_line>
-			急ごう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise must be hiding<end_line>
     out in Lute Cave!<end_line>
     Let's go!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間がリュート岩窟に<end_line>
+			いたみたい！<end_line>
+			急ごう！<end_line>
+		</sjis>
+    <ascii>
+    Anise must be hiding<end_line>
+    out in Lute Cave!<end_line>
+    Let's go!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -763,21 +817,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よぉし！<end_line>
-			行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
     Come on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よぉし！<end_line>
+			行こう！<end_line>
+		</sjis>
+    <ascii>
+    Right!<end_line>
+    Come on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -785,24 +843,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間がリュート岩窟に<end_line>
 			いたみたいだ！<end_line>
 			急ぐぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間がリュート岩窟に<end_line>
-			いたみたい！<end_line>
-			急ごう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise must be hiding<end_line>
     out in Lute Cave!<end_line>
     Let's go!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間がリュート岩窟に<end_line>
+			いたみたい！<end_line>
+			急ごう！<end_line>
+		</sjis>
+    <ascii>
+    Anise must be hiding<end_line>
+    out in Lute Cave!<end_line>
+    Let's go!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -826,21 +889,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よぉし！<end_line>
-			行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
     Come on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よぉし！<end_line>
+			行こう！<end_line>
+		</sjis>
+    <ascii>
+    Right!<end_line>
+    Come on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -848,24 +915,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間がリュート岩窟に<end_line>
 			いたみたいだ！<end_line>
 			急ぐぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間がリュート岩窟に<end_line>
-			いたみたい！<end_line>
-			急ごう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise must be hiding<end_line>
     out in Lute Cave!<end_line>
     Let's go!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間がリュート岩窟に<end_line>
+			いたみたい！<end_line>
+			急ごう！<end_line>
+		</sjis>
+    <ascii>
+    Anise must be hiding<end_line>
+    out in Lute Cave!<end_line>
+    Let's go!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -887,45 +959,54 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="special" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よぉし！<end_line>
-			行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
     Come on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よぉし！<end_line>
+			行こう！<end_line>
+		</sjis>
+    <ascii>
+    Right!<end_line>
+    Come on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間がリュート岩窟に<end_line>
 			いたみたいだ！<end_line>
 			急ぐぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間がリュート岩窟に<end_line>
-			いたみたい！<end_line>
-			急ごう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise must be hiding<end_line>
     out in Lute Cave!<end_line>
     Let's go!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間がリュート岩窟に<end_line>
+			いたみたい！<end_line>
+			急ごう！<end_line>
+		</sjis>
+    <ascii>
+    Anise must be hiding<end_line>
+    out in Lute Cave!<end_line>
+    Let's go!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -945,21 +1026,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よぉし！<end_line>
-			行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
     Come on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よぉし！<end_line>
+			行こう！<end_line>
+		</sjis>
+    <ascii>
+    Right!<end_line>
+    Come on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -967,24 +1052,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			スポート洞窟に入っていった<end_line>
 			アニスの仲間を追いかけよう<end_line>
 			きっとヤツらのアジトがあるはずだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			スポート洞窟に入っていった<end_line>
-			アニスの仲間を追いかけよう<end_line>
-			きっとアジトが見つかるハズよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's follow Anise's<end_line>
     comrades to Spoat Grotto.<end_line>
     Their hideout must be there.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			スポート洞窟に入っていった<end_line>
+			アニスの仲間を追いかけよう<end_line>
+			きっとアジトが見つかるハズよ<end_line>
+		</sjis>
+    <ascii>
+    Let's follow Anise's<end_line>
+    comrades to Spoat Grotto.<end_line>
+    Their hideout must be there.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1008,21 +1098,25 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			う<three_dots><end_line>
 			イタイとこ突くなぁ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			う<three_dots><end_line>
-			イタイとこ突くわね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ugh<three_dots><end_line>
     You hit where it hurts<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			う<three_dots><end_line>
+			イタイとこ突くわね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Ugh<three_dots><end_line>
+    You hit where it hurts<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1030,24 +1124,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			スポート洞窟に入っていった<end_line>
 			アニスの仲間を追いかけよう<end_line>
 			きっとヤツらのアジトがあるはずだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			スポート洞窟に入っていった<end_line>
-			アニスの仲間を追いかけよう<end_line>
-			きっとアジトが見つかるハズよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's follow Anise's<end_line>
     comrades to Spoat Grotto.<end_line>
     Their hideout must be there.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			スポート洞窟に入っていった<end_line>
+			アニスの仲間を追いかけよう<end_line>
+			きっとアジトが見つかるハズよ<end_line>
+		</sjis>
+    <ascii>
+    Let's follow Anise's<end_line>
+    comrades to Spoat Grotto.<end_line>
+    Their hideout must be there.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1071,21 +1170,25 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			また何かむずかしい言葉で<end_line>
 			責められてるぞ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			また何かむずかしい言葉で<end_line>
-			責められてる<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Again with the difficult<end_line>
     to understand phrases<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			また何かむずかしい言葉で<end_line>
+			責められてる<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Again with the difficult<end_line>
+    to understand phrases<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1093,24 +1196,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			スポート洞窟に入っていった<end_line>
 			アニスの仲間を追いかけよう<end_line>
 			きっとヤツらのアジトがあるはずだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			スポート洞窟に入っていった<end_line>
-			アニスの仲間を追いかけよう<end_line>
-			きっとアジトが見つかるハズよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's follow Anise's<end_line>
     comrades to Spoat Grotto.<end_line>
     Their hideout must be there.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			スポート洞窟に入っていった<end_line>
+			アニスの仲間を追いかけよう<end_line>
+			きっとアジトが見つかるハズよ<end_line>
+		</sjis>
+    <ascii>
+    Let's follow Anise's<end_line>
+    comrades to Spoat Grotto.<end_line>
+    Their hideout must be there.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1134,45 +1242,54 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			う<three_dots><end_line>
 			わかったよ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			う<three_dots><end_line>
-			わかったわよ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ugh<three_dots><end_line>
     Okay<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			う<three_dots><end_line>
+			わかったわよ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Ugh<three_dots><end_line>
+    Okay<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			スポート洞窟に入っていった<end_line>
 			アニスの仲間を追いかけよう<end_line>
 			きっとヤツらのアジトがあるはずだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			スポート洞窟に入っていった<end_line>
-			アニスの仲間を追いかけよう<end_line>
-			きっとアジトが見つかるハズよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's follow Anise's<end_line>
     comrades to Spoat Grotto.<end_line>
     Their hideout must be there.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			スポート洞窟に入っていった<end_line>
+			アニスの仲間を追いかけよう<end_line>
+			きっとアジトが見つかるハズよ<end_line>
+		</sjis>
+    <ascii>
+    Let's follow Anise's<end_line>
+    comrades to Spoat Grotto.<end_line>
+    Their hideout must be there.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1194,18 +1311,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			まかせとけって！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			まかせといてよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Leave it to me!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			まかせといてよ！<end_line>
+		</sjis>
+    <ascii>
+    Leave it to me!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1213,24 +1333,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間がスポート洞窟の奥に<end_line>
 			逃げていったぞ！<end_line>
 			急いで追いかけよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間がスポート洞窟の奥に<end_line>
-			逃げていったよ！<end_line>
-			急いで追いかけよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise's comrades fled further<end_line>
     in to Spoat Grotto.<end_line>
     After them!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間がスポート洞窟の奥に<end_line>
+			逃げていったよ！<end_line>
+			急いで追いかけよう！<end_line>
+		</sjis>
+    <ascii>
+    Anise's comrades fled further<end_line>
+    in to Spoat Grotto.<end_line>
+    After them!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1250,22 +1375,26 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			だ、だからオレは何もしてないって！<end_line>
 			見つかったのはオレのせいじゃない<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    H-hey, I didn't do anything!<end_line>
+    It's not my fault!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			だ、だからわたし、何もしてないよ！<end_line>
 			見つかったのはわたしのせいじゃ<end_line>
 			ないもん！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     H-hey, I didn't do anything!<end_line>
     It's not my fault!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1273,24 +1402,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間がスポート洞窟の奥に<end_line>
 			逃げていったぞ！<end_line>
 			急いで追いかけよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間がスポート洞窟の奥に<end_line>
-			逃げていったよ！<end_line>
-			急いで追いかけよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise's comrades fled further<end_line>
     in to Spoat Grotto.<end_line>
     After them!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間がスポート洞窟の奥に<end_line>
+			逃げていったよ！<end_line>
+			急いで追いかけよう！<end_line>
+		</sjis>
+    <ascii>
+    Anise's comrades fled further<end_line>
+    in to Spoat Grotto.<end_line>
+    After them!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1312,22 +1446,26 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			だ、だからオレは何もしてないって！<end_line>
 			見つかったのはオレのせいじゃない<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    H-hey, I didn't do anything!<end_line>
+    It's not my fault!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			だ、だからわたし、何もしてないよ！<end_line>
 			見つかったのはわたしのせいじゃ<end_line>
 			ないもん！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     H-hey, I didn't do anything!<end_line>
     It's not my fault!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1335,24 +1473,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間がスポート洞窟の奥に<end_line>
 			逃げていったぞ！<end_line>
 			急いで追いかけよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間がスポート洞窟の奥に<end_line>
-			逃げていったよ！<end_line>
-			急いで追いかけよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise's comrades fled further<end_line>
     in to Spoat Grotto.<end_line>
     After them!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間がスポート洞窟の奥に<end_line>
+			逃げていったよ！<end_line>
+			急いで追いかけよう！<end_line>
+		</sjis>
+    <ascii>
+    Anise's comrades fled further<end_line>
+    in to Spoat Grotto.<end_line>
+    After them!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1374,46 +1517,55 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			だ、だからオレは何もしてないって！<end_line>
 			見つかったのはオレのせいじゃない<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    H-hey, I didn't do anything!<end_line>
+    It's not my fault!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			だ、だからわたし、何もしてないよ！<end_line>
 			見つかったのはわたしのせいじゃ<end_line>
 			ないもん！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     H-hey, I didn't do anything!<end_line>
     It's not my fault!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間がスポート洞窟の奥に<end_line>
 			逃げていったぞ！<end_line>
 			急いで追いかけよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間がスポート洞窟の奥に<end_line>
-			逃げていったよ！<end_line>
-			急いで追いかけよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise's comrades fled further<end_line>
     in to Spoat Grotto.<end_line>
     After them!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間がスポート洞窟の奥に<end_line>
+			逃げていったよ！<end_line>
+			急いで追いかけよう！<end_line>
+		</sjis>
+    <ascii>
+    Anise's comrades fled further<end_line>
+    in to Spoat Grotto.<end_line>
+    After them!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1433,20 +1585,24 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			だ、だからオレは何もしてないって！<end_line>
 			見つかったのはオレのせいじゃない<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    H-hey, I didn't do anything!<end_line>
+    It's not my fault!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			だ、だからわたし、何もしてないよ！<end_line>
 			見つかったのはわたしのせいじゃ<end_line>
 			ないもん！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     H-hey, I didn't do anything!<end_line>
     It's not my fault!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 10/Jade/000_25584956_186653c.xml
+++ b/Day 10/Jade/000_25584956_186653c.xml
@@ -6,17 +6,21 @@
       あれ？<end_line>
       <partner>、ドコ行くんだよ<end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    <partner>, where are you going?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あれ？<end_line>
       <partner>、ドコ行くの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     <partner>, where are you going?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -90,6 +94,11 @@
       そうだな<three_dots><end_line>
       わかったよ<end_line>
     </sjis>
+    <ascii>
+    Oh<three_dots><end_line>
+    Okay<three_dots><end_line>
+    Understood.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -97,12 +106,12 @@
       そうだね<three_dots><end_line>
       わかったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh<three_dots><end_line>
     Okay<three_dots><end_line>
     Understood.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -249,17 +258,21 @@
       オレ<three_dots><end_line>
       そのナックルと勝負したいんだ<end_line>
     </sjis>
+    <ascii>
+    I<three_dots> want to fight<end_line>
+    against those knuckles.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたし<three_dots><end_line>
       そのナックルと勝負したいの<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I<three_dots> want to fight<end_line>
     against those knuckles.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="right" effect="big">
@@ -282,6 +295,11 @@
       オレの武器がどこまで通用するか<end_line>
       知りたいんだ<end_line>
     </sjis>
+    <ascii>
+    I want to know how my<end_line>
+    weapons compare to one<end_line>
+    that Master Rob acknowledged.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -289,12 +307,12 @@
       わたしの武器がどこまで通用するか<end_line>
       知りたいの<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I want to know how my<end_line>
     weapons compare to one<end_line>
     that Master Rob acknowledged.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -374,15 +392,19 @@
       工房の前だね！<end_line>
       よっし！<end_line>
     </sjis>
+    <ascii>
+    Outside the workshop!<end_line>
+    Right!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       工房の前ね！<end_line>
       わかった！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Outside the workshop!<end_line>
     Right!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 10/Jade/002_25605740_186b66c.xml
+++ b/Day 10/Jade/002_25605740_186b66c.xml
@@ -7,16 +7,19 @@
       この武器なら<end_line>
       アニキのナックルに<three_dots><end_line>
     </sjis>
+    <ascii>
+    This one should be able to do it<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       この武器なら<end_line>
       アニキのナックルに<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This one should be able to do it<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
   <dialogue>
   <info box="right">

--- a/Day 10/Jade/003_25587836_186707c.xml
+++ b/Day 10/Jade/003_25587836_186707c.xml
@@ -8,6 +8,11 @@
       大切な武器なのに<three_dots><end_line>
       ごめん<three_dots>、オレ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Br<three_dots> bro<three_dots>!<end_line>
+    Such a precious weapon, yet<three_dots><end_line>
+    Sorry<three_dots>, I<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -15,12 +20,12 @@
       大切な武器なのに<three_dots><end_line>
       ごめん<three_dots>、わたし<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Br<three_dots> bro<three_dots>!<end_line>
     Such a precious weapon, yet<three_dots><end_line>
     Sorry<three_dots>, I<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -31,17 +36,21 @@
       どうしたんだよ、アニキ<end_line>
       ちょっと動きがおかしかった<three_dots><end_line>
     </sjis>
+    <ascii>
+    What's wrong, Bro?<end_line>
+    You're acting strange<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしたの、アニキ<end_line>
       ちょっと動きがおかしかったよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's wrong, Bro?<end_line>
     You're acting strange<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -64,6 +73,11 @@
       そんな<three_dots>、オレ<three_dots><end_line>
       こわすつもりなんて<three_dots><end_line>
     </sjis>
+    <ascii>
+    Uwah!<end_line>
+    But<three_dots>, I<three_dots><end_line>
+    I didn't mean to break it<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -71,12 +85,12 @@
       そんな<three_dots>、わたし<three_dots><end_line>
       こわすつもりなんて<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uwah!<end_line>
     But<three_dots>, I<three_dots><end_line>
     I didn't mean to break it<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -131,6 +145,11 @@
       それって<three_dots><end_line>
       オレが<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah<three_dots>, Bro<three_dots><end_line>
+    You mean<three_dots><end_line>
+    That I<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -138,12 +157,12 @@
       それって<three_dots><end_line>
       わたし<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah<three_dots>, Bro<three_dots><end_line>
     You mean<three_dots><end_line>
     That I<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -249,15 +268,18 @@
     <sjis>
       へへ<end_line>
     </sjis>
+    <ascii>
+    Heheh.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       えへへ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Heheh.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">

--- a/Day 10/Lemmy/000_25577756_186491c.xml
+++ b/Day 10/Lemmy/000_25577756_186491c.xml
@@ -6,17 +6,21 @@
       あれ？<end_line>
       <partner>、ドコ行くんだよ<end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    <partner>, where are you going?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あれ？<end_line>
       <partner>、ドコ行くの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     <partner>, where are you going?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -90,6 +94,11 @@
       そうだな<three_dots><end_line>
       わかったよ<end_line>
     </sjis>
+    <ascii>
+    Oh<three_dots><end_line>
+    Okay<three_dots><end_line>
+    Understood.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -97,12 +106,12 @@
       そうだね<three_dots><end_line>
       わかったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh<three_dots><end_line>
     Okay<three_dots><end_line>
     Understood.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <player gender="male">
@@ -173,7 +182,7 @@
     わたしはわたしでミューノの村へ行く<end_line>
     準備をすすめておこう<end_line>
   </sjis>
-   <ascii>
+  <ascii>
     Oh well.<end_line>
     I need to get my own<end_line>
     things ready too.<end_line>

--- a/Day 10/Lemmy/001_25579084_1864e4c.xml
+++ b/Day 10/Lemmy/001_25579084_1864e4c.xml
@@ -6,17 +6,21 @@
       あれ<three_dots>？<end_line>
       何やってんだ？<end_line>
     </sjis>
+    <ascii>
+    Huh<three_dots>?<end_line>
+    What's going on?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あれ<three_dots>？<end_line>
       何やってんだろ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh<three_dots>?<end_line>
     What's going on?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -151,6 +155,11 @@
       普通、心配するだろ？<end_line>
       母親だぜ？<end_line>
     </sjis>
+    <ascii>
+    It's normal to worry when your<end_line>
+    child might be in danger, isn't it?<end_line>
+    That's what a mother does.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -158,12 +167,12 @@
       普通、心配するでしょ？<end_line>
       母親だよ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's normal to worry when your<end_line>
     child might be in danger, isn't it?<end_line>
     That's what a mother does.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -190,6 +199,11 @@
       <partner>がいなくたって<end_line>
       オレは<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    What's that!?<end_line>
+    Even without <partner>,<end_line>
+    I'm<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -197,12 +211,12 @@
       <partner>がいなくたって<end_line>
       わたしは<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's that!?<end_line>
     Even without <partner>,<end_line>
     I'm<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -242,6 +256,11 @@
       オレひとりだってお前くらい<end_line>
       たおせるさ！<end_line>
     </sjis>
+    <ascii>
+    Well, look who's talking!<end_line>
+    I could beat someone like<end_line>
+    you alone, easy!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -249,12 +268,12 @@
       わたしひとりだってあんたくらい<end_line>
       たおしてみせるわ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, look who's talking!<end_line>
     I could beat someone like<end_line>
     you alone, easy!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -281,6 +300,11 @@
       一度お前とは１対１で<end_line>
       勝負してみたかったんだ！<end_line>
     </sjis>
+    <ascii>
+    Shut up!<end_line>
+    I've always wanted to fight you,<end_line>
+    one on one!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -288,12 +312,12 @@
       一度あんたとは１対１で<end_line>
       勝負してみたかったのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Shut up!<end_line>
     I've always wanted to fight you,<end_line>
     one on one!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -371,6 +395,11 @@
       わかった<end_line>
       待ってろよ！<end_line>
     </sjis>
+    <ascii>
+    The North Gate.<end_line>
+    Okay!<end_line>
+    I'll be there!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -378,10 +407,10 @@
       わかったわ<end_line>
       待ってなさいよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The North Gate.<end_line>
     Okay!<end_line>
     I'll be there!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 10/Lemmy/003_25606508_186b96c.xml
+++ b/Day 10/Lemmy/003_25606508_186b96c.xml
@@ -3,18 +3,21 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="zakk" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			お前、ケガは大丈夫なのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あなた、ケガは大丈夫なの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey, how are your wounds?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あなた、ケガは大丈夫なの？<end_line>
+		</sjis>
+    <ascii>
+    Hey, how are your wounds?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -34,21 +37,25 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="zakk" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			良かった<three_dots><end_line>
 			みんな心配してたぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			良かった<three_dots><end_line>
-			みんな心配してたよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Thank goodness<three_dots><end_line>
     Everyone was worried.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			良かった<three_dots><end_line>
+			みんな心配してたよ<end_line>
+		</sjis>
+    <ascii>
+    Thank goodness<three_dots><end_line>
+    Everyone was worried.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -68,24 +75,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="zakk" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			お前があやまることないよ<end_line>
 			でも、今度からはあんまり<end_line>
 			ムチャなことすんなよな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あなたがあやまることないよ<end_line>
-			でも、今度からはあんまり<end_line>
-			ムチャなことしないでね！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You don't need to apologize.<end_line>
     But make sure not to do<end_line>
     anything too reckless from now on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あなたがあやまることないよ<end_line>
+			でも、今度からはあんまり<end_line>
+			ムチャなことしないでね！<end_line>
+		</sjis>
+    <ascii>
+    You don't need to apologize.<end_line>
+    But make sure not to do<end_line>
+    anything too reckless from now on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">

--- a/Day 10/Lemmy/005_25604908_186b32c.xml
+++ b/Day 10/Lemmy/005_25604908_186b32c.xml
@@ -58,15 +58,19 @@
       なんだと<three_dots><end_line>
       行くぞ！<end_line>
     </sjis>
+    <ascii>
+    Oh, shut up<three_dots><end_line>
+    Here I come!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なんですって<three_dots><end_line>
       行っくぞー！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, shut up<three_dots><end_line>
     Here I come!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 10/Lemmy/006_25581884_186593c.xml
+++ b/Day 10/Lemmy/006_25581884_186593c.xml
@@ -23,6 +23,11 @@
       迷ってちゃ<end_line>
       いい勝負はできないぜ<end_line>
     </sjis>
+    <ascii>
+    You know<three_dots><end_line>
+    If you hesitate,<end_line>
+    we can't have a good fight.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -30,12 +35,12 @@
       そんな風に迷ってたら<end_line>
       いい勝負はできないよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You know<three_dots><end_line>
     If you hesitate,<end_line>
     we can't have a good fight.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -60,6 +65,11 @@
       勝負に集中してないっていうか<three_dots><end_line>
       アレだろ？　母親のことだろ？<end_line>
     </sjis>
+    <ascii>
+    How should I put this<three_dots><end_line>
+    It's like you can't focus<three_dots><end_line>
+    It's that, isn't it? Your mother?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -67,12 +77,12 @@
       勝負に集中してないっていうか<three_dots><end_line>
       アレでしょ？　お母さんのことでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How should I put this<three_dots><end_line>
     It's like you can't focus<three_dots><end_line>
     It's that, isn't it? Your mother?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -97,6 +107,11 @@
       悩みがあんなら話してみろよ<end_line>
       スッキリするかもしれないぜ？<end_line>
     </sjis>
+    <ascii>
+    Why dont you try talking<end_line>
+    about your troubles?<end_line>
+    It might make you feel better.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -104,12 +119,12 @@
       悩みがあるなら話してみない？<end_line>
       スッキリするかもしれないよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Why dont you try talking<end_line>
     about your troubles?<end_line>
     It might make you feel better.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -131,17 +146,21 @@
       んで、スッキリしたら<end_line>
       もう１回勝負だ！<end_line>
     </sjis>
+    <ascii>
+    And once you're feeling better,<end_line>
+    we'll have another match!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       それでスッキリしたら<end_line>
       もう１回勝負よ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And once you're feeling better,<end_line>
     we'll have another match!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -183,6 +202,11 @@
       お前は鍛冶職人の修行だろ？<end_line>
       どうしてだよ？<end_line>
     </sjis>
+    <ascii>
+    But look, your mother's a Summoner,<end_line>
+    and you're training as a smithy?<end_line>
+    Isn't that odd?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -190,12 +214,12 @@
       どうして鍛冶職人の修行してるの？<end_line>
       ヘンじゃない？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     But look, your mother's a Summoner,<end_line>
     and you're training as a smithy?<end_line>
     Isn't that odd?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -222,6 +246,10 @@
       だからお前も全部話しちまえば<end_line>
       いいんだよ<end_line>
     </sjis>
+    <ascii>
+    Is that so?<end_line>
+    See, it's okay to be open!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -229,11 +257,11 @@
       だからあなたも全部話しちゃえば<end_line>
       いいのよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Is that so?<end_line>
     See, it's okay to be open!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -591,6 +619,10 @@
       なんでそんな風に言えるんだよ？<end_line>
       お母さんからそう聞いたのか？<end_line>
     </sjis>
+    <ascii>
+    And how can you be so sure?<end_line>
+    You didn't ask her, did you?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -598,11 +630,11 @@
       お母さんからそう聞いたワケじゃ<end_line>
       ないんでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And how can you be so sure?<end_line>
     You didn't ask her, did you?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -902,7 +934,7 @@
     I hate to admit it, but it's<end_line>
     as you said. I do feel better.<end_line>
     But the match will have to wait<three_dots><end_line>
-  </ascii>  
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 10/Murno/000_25551612_185e2fc.xml
+++ b/Day 10/Murno/000_25551612_185e2fc.xml
@@ -405,17 +405,21 @@
       どうしたんだよ、ミューノ<end_line>
       今日はなんかヘンだよ<end_line>
     </sjis>
+    <ascii>
+    What's wrong, Murno?<end_line>
+    You're acting strange.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしたのよ、ミューノ<end_line>
       今日はなんかヘンだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's wrong, Murno?<end_line>
     You're acting strange.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 10/Murno/001_25553356_185e9cc.xml
+++ b/Day 10/Murno/001_25553356_185e9cc.xml
@@ -76,17 +76,21 @@
       ちょっと<three_dots>本当に<end_line>
       本気、なのか<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Murno<three_dots><end_line>
+    Are you sure<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちょっと<three_dots>本当に<end_line>
       本気、なの<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Murno<three_dots><end_line>
     Are you sure<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -141,6 +145,11 @@
       ミューノの武器はひとつだから<end_line>
       オレも武器をひとつ選ぶよ<end_line>
     </sjis>
+    <ascii>
+    I know, I know.<end_line>
+    You only have one weapon,<end_line>
+    so I'll only use one too.<end_line>
+ </ascii>
   </male>
   <female>
     <sjis>
@@ -148,12 +157,12 @@
       ミューノの武器はひとつだから<end_line>
       わたしも武器をひとつ選ぶよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know, I know.<end_line>
     You only have one weapon,<end_line>
     so I'll only use one too.<end_line>
  </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 10/Murno/004_25555404_185f1cc.xml
+++ b/Day 10/Murno/004_25555404_185f1cc.xml
@@ -8,6 +8,11 @@
       だからゴカイだって<end_line>
       言ってるだろ！？<end_line>
     </sjis>
+    <ascii>
+    Calm down!<end_line>
+    I told you,<end_line>
+    it's a misunderstanding!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -15,12 +20,12 @@
       だからゴカイだって<end_line>
       言ってるでしょ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Calm down!<end_line>
     I told you,<end_line>
     it's a misunderstanding!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -250,17 +255,21 @@
       もちろん！<end_line>
       みんなでやろうぜ！<end_line>
     </sjis>
+    <ascii>
+    Of course!<end_line>
+    Let's do it together!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       もちろん！<end_line>
       みんなでやろう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Of course!<end_line>
     Let's do it together!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 10/Partner/000_25556988_185f7fc.xml
+++ b/Day 10/Partner/000_25556988_185f7fc.xml
@@ -9,6 +9,11 @@
       今までお前とは<end_line>
       たくさん武器を作ってきたよなぁ<end_line>
     </sjis>
+    <ascii>
+    Come to think of it, <partner>,<end_line>
+    we've crafted quite a few<end_line>
+    weapons so far.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -16,12 +21,12 @@
       今まであなたとは<end_line>
       たくさん武器を作ってきたよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Come to think of it, <partner>,<end_line>
     we've crafted quite a few<end_line>
     weapons so far.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -79,6 +84,11 @@
       何度も作ってきたんだから<end_line>
       あるだろ？　お気に入りとか<end_line>
     </sjis>
+    <ascii>
+    Not like that, the one you like.<end_line>
+    We've crafted so many, you have to<end_line>
+    have one, right? A favorite.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -86,12 +96,12 @@
       何度も作ってきたんだから<end_line>
       あるでしょ？　お気に入りとか<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Not like that, the one you like.<end_line>
     We've crafted so many, you have to<end_line>
     have one, right? A favorite.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -150,6 +160,11 @@
       ちょっと待てよ<three_dots><end_line>
       すぐには決められないな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Eh~!<end_line>
+    Hold on<three_dots><end_line>
+    I can't decide so quickly<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -157,12 +172,12 @@
       ちょっと待ってよ<three_dots><end_line>
       すぐには決められないなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh~!<end_line>
     Hold on<three_dots><end_line>
     I can't decide so quickly<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -299,6 +314,11 @@
       そういえば、あの時お前は<end_line>
       本気が出せなかったんだよな<end_line>
     </sjis>
+    <ascii>
+    Well<three_dots><end_line>
+    That reminds me, you couldn't<end_line>
+    bring out your true strength.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -306,12 +326,12 @@
       そういえば、あの時あなたは<end_line>
       本気が出せなかったんだよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well<three_dots><end_line>
     That reminds me, you couldn't<end_line>
     bring out your true strength.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -355,17 +375,21 @@
       そうだな<three_dots><end_line>
       勝負するか！<end_line>
     </sjis>
+    <ascii>
+    You're right<three_dots><end_line>
+    Why don't we have a match?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そうだね<three_dots><end_line>
       勝負しよっか！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're right<three_dots><end_line>
     Why don't we have a match?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -392,6 +416,11 @@
       というか、お前に勝負を申し込んで<end_line>
       礼を言われるなんて、感動だよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Oh, it's nothing<three_dots><end_line>
+    Rather, I'm touched that you'd thank<end_line>
+    me for challenging you to a fight<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -399,12 +428,12 @@
       というか、あなたに勝負を申し込んで<end_line>
       お礼を言われるなんて、感動だよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, it's nothing<three_dots><end_line>
     Rather, I'm touched that you'd thank<end_line>
     me for challenging you to a fight<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -432,17 +461,21 @@
       なるほど<three_dots><end_line>
       たしかにそうかもな<end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    That might be true.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なるほど<three_dots><end_line>
       たしかに、それってあるかも<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     That might be true.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -469,6 +502,11 @@
       よっしゃ！<end_line>
       待ってろよ！<end_line>
     </sjis>
+    <ascii>
+    Front of the workshop.<end_line>
+    Alright!<end_line>
+    Just you wait!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -476,12 +514,12 @@
       よおっし！<end_line>
       待っててよね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Front of the workshop.<end_line>
     Alright!<end_line>
     Just you wait!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -494,6 +532,11 @@
       今までお前とは<end_line>
       たくさん武器を作ってきたよなぁ<end_line>
     </sjis>
+    <ascii>
+    Come to think of it, <partner>,<end_line>
+    we've crafted quite a few<end_line>
+    weapons so far.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -501,12 +544,12 @@
       今まであなたとは<end_line>
       たくさん武器を作ってきたよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Come to think of it, <partner>,<end_line>
     we've crafted quite a few<end_line>
     weapons so far.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -550,17 +593,21 @@
       ん？<end_line>
       どうしたんだ？<end_line>
     </sjis>
+    <ascii>
+    Hm?<end_line>
+    What's up?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ん？<end_line>
       どうしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hm?<end_line>
     What's up?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -587,15 +634,18 @@
     <sjis>
       なんだよ、突然<end_line>
     </sjis>
+    <ascii>
+    What's this all of a sudden?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、突然<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's this all of a sudden?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -624,6 +674,11 @@
       もういいじゃないか<end_line>
       今さら<three_dots><end_line>
     </sjis>
+    <ascii>
+    Aren't you a sore loser?<end_line>
+    Don't worry about it, that was<end_line>
+    already long ago<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -631,12 +686,12 @@
       もういいじゃない<end_line>
       今さら<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Aren't you a sore loser?<end_line>
     Don't worry about it, that was<end_line>
     already long ago<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -860,6 +915,11 @@
       今までお前とは<end_line>
       たくさん武器を作ってきたよなぁ<end_line>
     </sjis>
+    <ascii>
+    Come to think of it, <partner>,<end_line>
+    we've crafted quite a few<end_line>
+    weapons so far.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -867,12 +927,12 @@
       今まであなたとは<end_line>
       たくさん武器を作ってきたよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Come to think of it, <partner>,<end_line>
     we've crafted quite a few<end_line>
     weapons so far.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -900,17 +960,21 @@
       昨日もそんなこと言ってたよな<three_dots><end_line>
       意外とシツコイなぁ<end_line>
     </sjis>
+    <ascii>
+    You said the same thing yesterday<three_dots><end_line>
+    You're surprisingly stubborn<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       昨日もそんなこと言ってたよね<three_dots><end_line>
       意外とシツコイんだ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You said the same thing yesterday<three_dots><end_line>
     You're surprisingly stubborn<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -950,17 +1014,21 @@
       ん？<end_line>
       どうしたんだ？<end_line>
     </sjis>
+    <ascii>
+    Hm?<end_line>
+    What's wrong?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ん？<end_line>
       どうしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hm?<end_line>
     What's wrong?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -985,15 +1053,18 @@
     <sjis>
       なんだよ、突然<end_line>
     </sjis>
+    <ascii>
+    What's this all of a sudden?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、突然<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's this all of a sudden?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1038,6 +1109,11 @@
       もういいじゃないか<end_line>
       今さら<three_dots><end_line>
     </sjis>
+    <ascii>
+    Aren't you a sore loser?<end_line>
+    Don't worry about it, that was<end_line>
+    already long ago<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1045,12 +1121,12 @@
       もういいじゃない<end_line>
       今さら<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Aren't you a sore loser?<end_line>
     Don't worry about it, that was<end_line>
     already long ago<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1139,6 +1215,11 @@
       勝負するったら<end_line>
       勝負だ！<end_line>
     </sjis>
+    <ascii>
+    Shut up!<end_line>
+    I said I'll fight you,<end_line>
+    so let's go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1146,12 +1227,12 @@
       勝負するったら<end_line>
       勝負よ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Shut up!<end_line>
     I said I'll fight you,<end_line>
     so let's go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1313,6 +1394,11 @@
       今までお前とは<end_line>
       たくさん武器を作ってきたよなぁ<end_line>
     </sjis>
+    <ascii>
+    Come to think of it, <partner>,<end_line>
+    we've crafted quite a few<end_line>
+    weapons so far.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1320,12 +1406,12 @@
       今まであなたとは<end_line>
       たくさん武器を作ってきたよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Come to think of it, <partner>,<end_line>
     we've crafted quite a few<end_line>
     weapons so far.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1392,6 +1478,11 @@
       そんなことないだろ？<end_line>
       なんならもう１回勝負するか？<end_line>
     </sjis>
+    <ascii>
+    Definitely? You can't be so sure,<end_line>
+    can you? Then how about we fight,<end_line>
+    one last time?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1399,12 +1490,12 @@
       そんなことないでしょ？<end_line>
       なんならもう１回勝負する？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Definitely? You can't be so sure,<end_line>
     can you? Then how about we fight,<end_line>
     one last time?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1429,6 +1520,11 @@
       あーもー勝負だ！<end_line>
       勝負しよう！<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+    Argh, alright, let's do this!<end_line>
+    Let's have a match!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1436,12 +1532,12 @@
       あーもー勝負よ！<end_line>
       勝負しよう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
     Argh, alright, let's do this!<end_line>
     Let's have a match!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1507,15 +1603,18 @@
     <sjis>
       なんだよ、それ<end_line>
     </sjis>
+    <ascii>
+    What's that supposed to mean?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's that supposed to mean?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1564,15 +1663,18 @@
     <sjis>
       ひとつだ！<end_line>
     </sjis>
+    <ascii>
+    One!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ひとつよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     One!<end_line>
   </ascii>
+  </female>
 </bigtext>
 <dialogue>
   <partner name="rufeel">
@@ -1597,6 +1699,12 @@
       ひとつで十分だって<end_line>
       言ってるんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I'm saying that using<end>
+    only one weapon will be<end_line>
+    enough to deal with you<three_dots><end_line>
+  </end>
+    </ascii>
   </male>
   <female>
     <sjis>
@@ -1604,12 +1712,13 @@
       ひとつで十分だって<end_line>
       言ってるんだよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm saying that using<end>
     only one weapon will be<end_line>
     enough to deal with you<three_dots><end_line>
-  </ascii>
+  </end>
+    </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1659,17 +1768,21 @@
       じゃあ、オレは武器を選ぶから<end_line>
       少し待ってろよ<end_line>
     </sjis>
+    <ascii>
+    Then I need to pick out a weapon,<end_line>
+    so wait a bit.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       じゃあ、わたしは武器を選ぶから<end_line>
       少し待っててよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Then I need to pick out a weapon,<end_line>
     so wait a bit.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 10/Partner/001_25561340_18608fc.xml
+++ b/Day 10/Partner/001_25561340_18608fc.xml
@@ -110,16 +110,19 @@
       まあ、一番好きだっていうんだから<end_line>
       一本だよなぁ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Well, you're right about that<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       まあ、一番好きだっていうんだから<end_line>
       一本だよね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, you're right about that<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Day 10/Partner/002_25602588_186aa1c.xml
+++ b/Day 10/Partner/002_25602588_186aa1c.xml
@@ -9,6 +9,10 @@
       お前にオレの魂を<end_line>
       伝えてやるぜ！<end_line>
     </sjis>
+    <ascii>
+    With this weapon<three_dots><end_line>
+    I'll show you my determination!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -16,11 +20,11 @@
       あなたにわたしの魂を<end_line>
       伝えてあげる！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     With this weapon<three_dots><end_line>
     I'll show you my determination!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -44,17 +48,21 @@
       お前の本気、見せてもらうぜ<end_line>
       <partner><three_dots><end_line>
     </sjis>
+    <ascii>
+    Show me what you're made of,<end_line>
+    <partner><three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あなたの本気、見せてもらうわ<end_line>
       <partner><three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Show me what you're made of,<end_line>
     <partner><three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -80,17 +88,21 @@
       手加減はいらないぜ<end_line>
       <partner><three_dots><end_line>
     </sjis>
+    <ascii>
+    Don't hold back,<end_line>
+    <partner><three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       手加減はいらないわよ<end_line>
       <partner><three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't hold back,<end_line>
     <partner><three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -118,17 +130,21 @@
       この武器ならお前も<end_line>
       手加減してられないだろ？<end_line>
     </sjis>
+    <ascii>
+    With this weapon, you won't be<end_line>
+    able to hold back, right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       この武器ならあなたも<end_line>
       手加減してられないでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     With this weapon, you won't be<end_line>
     able to hold back, right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Day 10/Partner/Enzi_25564572_186159c.xml
+++ b/Day 10/Partner/Enzi_25564572_186159c.xml
@@ -22,6 +22,11 @@
       お前の戦い方を見ていれば<end_line>
       オレにケガさせないようにって<three_dots><end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots><three_dots><end_line>
+    The way you fought<three_dots><end_line>
+    You were obviously holding back.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -29,12 +34,12 @@
       あなたの戦い方を見ていれば<end_line>
       わたしにケガさせないようにって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots><three_dots><end_line>
     The way you fought<three_dots><end_line>
     You were obviously holding back.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -72,6 +77,11 @@
       オレが勝てたのはこの武器の<three_dots><end_line>
       お前との修行のおかげだよ！<end_line>
     </sjis>
+    <ascii>
+    Ahaha! You're right!<end_line>
+    I won thanks to this weapon<three_dots><end_line>
+    And you, too!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -79,12 +89,12 @@
       わたしが勝てたのはこの武器の<three_dots><end_line>
       あなたとの修行のおかげだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ahaha! You're right!<end_line>
     I won thanks to this weapon<three_dots><end_line>
     And you, too!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -119,17 +129,21 @@
       なんだよ、それ？<end_line>
       バカにしてんのか？<end_line>
     </sjis>
+    <ascii>
+    What's that supposed to mean?<end_line>
+    Are you making fun of me?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ？<end_line>
       バカにしてるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's that supposed to mean?<end_line>
     Are you making fun of me?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -186,6 +200,11 @@
       どうして？<end_line>
       何か悪いことでもしたのかよ？<end_line>
     </sjis>
+    <ascii>
+    They hated you<three_dots>?<end_line>
+    Why?<end_line>
+    Did you do something bad to them?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -193,12 +212,12 @@
       どうして？<end_line>
       何か悪いことでもしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     They hated you<three_dots>?<end_line>
     Why?<end_line>
     Did you do something bad to them?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -225,6 +244,10 @@
       ことじゃないか<end_line>
       何で憎まれなきゃなんないんだ？<end_line>
     </sjis>
+    <ascii>
+    Isn't that the right thing to do?<end_line>
+    Why would they hate you for it?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -232,11 +255,11 @@
       ことじゃないの<end_line>
       何で憎まれなきゃなんないのよ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Isn't that the right thing to do?<end_line>
     Why would they hate you for it?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -360,6 +383,11 @@
       オレだって<partner>に会えて<end_line>
       本当に良かったぜ！<end_line>
     </sjis>
+    <ascii>
+    Wha, um<three_dots><end_line>
+    I'm really happy I met<end_line>
+    you too, <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -367,12 +395,12 @@
       わたしだって<partner>に会えて<end_line>
       本当に良かったよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wha, um<three_dots><end_line>
     I'm really happy I met<end_line>
     you too, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 10/Partner/Killfith_25566700_1861dec.xml
+++ b/Day 10/Partner/Killfith_25566700_1861dec.xml
@@ -19,15 +19,18 @@
     <sjis>
       ありがとな、<partner><end_line>
     </sjis>
+    <ascii>
+    Thanks, <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ありがとう、<partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Thanks, <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -52,6 +55,11 @@
       オレなんか一発で<end_line>
       吹き飛んでたはずだぜ<end_line>
     </sjis>
+    <ascii>
+    Well, if you used your magic,<end_line>
+    I would have been<end_line>
+    blown away in an instant.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -59,12 +67,12 @@
       わたしなんか一発で<end_line>
       吹き飛んでたはずだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, if you used your magic,<end_line>
     I would have been<end_line>
     blown away in an instant.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -168,6 +176,11 @@
       <partner>がミューノのこと<end_line>
       大事にしてるのは、わかったからさ<end_line>
     </sjis>
+    <ascii>
+    Oh, cut the act already<three_dots><end_line>
+    I know you really<end_line>
+    treasure her.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -175,12 +188,12 @@
       <partner>がミューノのこと<end_line>
       大事にしてるのは、わかったから<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, cut the act already<three_dots><end_line>
     I know you really<end_line>
     treasure her.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -203,6 +216,11 @@
       素直に言った方が<end_line>
       ミューノもよろこぶと思うぜ<end_line>
     </sjis>
+    <ascii>
+    If you would just come out and<end_line>
+    tell her your feelings, I'm sure<end_line>
+    Murno would be happy.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -210,12 +228,12 @@
       素直に言った方が<end_line>
       ミューノもよろこぶと思うよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     If you would just come out and<end_line>
     tell her your feelings, I'm sure<end_line>
     Murno would be happy.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -240,6 +258,11 @@
       じゃあお前にはミューノを守る気<end_line>
       ないのかよ<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    What now!?<end_line>
+    Then are you saying you don't<end_line>
+    want to protect her?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -247,12 +270,12 @@
       じゃああなたにはミューノを<end_line>
       守る気がないっていうの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What now!?<end_line>
     Then are you saying you don't<end_line>
     want to protect her?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -313,17 +336,21 @@
       ミューノが命がけでお前を<three_dots><end_line>
       一体なにがあったんだ？<end_line>
     </sjis>
+    <ascii>
+    Murno risked her life for you<three_dots><end_line>
+    What on earth happened?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ミューノが命がけであなたを<three_dots><end_line>
       一体なにがあったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Murno risked her life for you<three_dots><end_line>
     What on earth happened?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -409,6 +436,11 @@
       それ、どういうことだよ？<end_line>
       お前、犬が弱点なのか？<end_line>
     </sjis>
+    <ascii>
+    Woah, hold on!<end_line>
+    What do you mean?<end_line>
+    <partner>, are you scared of dogs?<end_line>
+   </ascii>
   </male>
   <female>
     <sjis>
@@ -416,12 +448,12 @@
       それ、どういうことなの？<end_line>
       <partner>、犬が弱点なの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Woah, hold on!<end_line>
     What do you mean?<end_line>
     <partner>, are you scared of dogs?<end_line>
    </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -529,15 +561,18 @@
     <sjis>
       お前ってヤツは<three_dots><end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       まったく、あんたは<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -669,17 +704,21 @@
       <three_dots>って、おい！？<end_line>
       どういうことだよ？<end_line>
     </sjis>
+    <ascii>
+    <three_dots>wait, what!?<end_line>
+    What do you mean?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>って、ちょっと！？<end_line>
       それ、どういうこと？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots>wait, what!?<end_line>
     What do you mean?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -735,6 +774,11 @@
       お前<three_dots><end_line>
       本当にそれでいいのかよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots><end_line>
+    Is that<three_dots><end_line>
+    really okay with you<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -742,12 +786,12 @@
       あなた<three_dots><end_line>
       本当にそれでいいの<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots><end_line>
     Is that<three_dots><end_line>
     really okay with you<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 10/Partner/Rufeel_25569532_18628fc.xml
+++ b/Day 10/Partner/Rufeel_25569532_18628fc.xml
@@ -59,18 +59,23 @@
       そんなに勝ちたちゃ<end_line>
       強い技を使えばよかったのに<end_line>
     </sjis>
+    <ascii>
+    If you wanted to win that badly,<end_line>
+    you should have used your<end_line>
+    strongest moves.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなに勝ちたいなら<end_line>
       強い技を使えばよかったのに<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     If you wanted to win that badly,<end_line>
     you should have used your<end_line>
     strongest moves.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -167,17 +172,21 @@
       だってけっこう<end_line>
       コワがってただろ？<end_line>
     </sjis>
+    <ascii>
+    You did look pretty<end_line>
+    scared, you know?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       だってけっこう<end_line>
       コワがってたでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You did look pretty<end_line>
     scared, you know?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -199,17 +208,21 @@
       どっちなんだよ<end_line>
       コワがりじゃなかったのか？<end_line>
     </sjis>
+    <ascii>
+    Which is it,<end_line>
+    are you a coward or not?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どっちなのよ<end_line>
       コワがりじゃなかったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Which is it,<end_line>
     are you a coward or not?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -247,15 +260,18 @@
     <sjis>
       そうだったのか<three_dots><end_line>
     </sjis>
+    <ascii>
+    Is that so<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そうだったんだ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Is that so<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 10/Partner/Run-Dor_25562556_1860dbc.xml
+++ b/Day 10/Partner/Run-Dor_25562556_1860dbc.xml
@@ -6,17 +6,21 @@
       どうだ？<end_line>
       なんか伝わっただろ？<end_line>
     </sjis>
+    <ascii>
+    How was that?<end_line>
+    You felt it, didn't you?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どう？<end_line>
       なんか伝わったでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How was that?<end_line>
     You felt it, didn't you?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -241,6 +245,10 @@
       ガーンときただろ？<end_line>
       ガーンと<end_line>
     </sjis>
+    <ascii>
+    Like, when you got hit,<end_line>
+    didn't it feel like a shock?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -248,11 +256,11 @@
       ガーンときたでしょ？<end_line>
       ガーンと<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Like, when you got hit,<end_line>
     didn't it feel like a shock?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -291,17 +299,21 @@
       あとはお前が<end_line>
       それを感じるだけだ！<end_line>
     </sjis>
+    <ascii>
+    All that's left is for<end_line>
+    you to feel it!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あとはあなたが<end_line>
       それを感じるだけよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     All that's left is for<end_line>
     you to feel it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -324,6 +336,11 @@
       相手の動きとか表情をみていれば<end_line>
       何を考えているか大体わかるだろ<end_line>
     </sjis>
+    <ascii>
+    That's right. You know how you can<end_line>
+    figure out what your opponent is<end_line>
+    thinking from their body language?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -331,12 +348,12 @@
       相手の動きとか表情をみていれば<end_line>
       何を考えているか大体わかるでしょ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's right. You know how you can<end_line>
     figure out what your opponent is<end_line>
     thinking from their body language?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -449,6 +466,10 @@
       <partner>はやさしくて<end_line>
       いいやつだ<end_line>
     </sjis>
+    <ascii>
+    You are.<end_line>
+    <partner> is kind and gentle.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -456,11 +477,11 @@
       <partner>はやさしくて<end_line>
       いい子よ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You are.<end_line>
     <partner> is kind and gentle.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -495,17 +516,21 @@
       うわっ！　ちょっと！？<end_line>
       そんなに泣くなよ<end_line>
     </sjis>
+    <ascii>
+    Uwah! What!?<end_line>
+    Don't cry!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うわっ！　ちょっと！？<end_line>
       そんなに泣かないで<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uwah! What!?<end_line>
     Don't cry!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 10/Tier/000_25589724_18677dc.xml
+++ b/Day 10/Tier/000_25589724_18677dc.xml
@@ -6,17 +6,21 @@
       あれ？<end_line>
       <partner>、ドコ行くんだよ<end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    <partner>, where are you going?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あれ？<end_line>
       <partner>、ドコ行くの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     <partner>, where are you going?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -90,6 +94,11 @@
       そうだな<three_dots><end_line>
       わかったよ<end_line>
     </sjis>
+    <ascii>
+    Oh<three_dots><end_line>
+    Okay<three_dots><end_line>
+    Understood.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -97,12 +106,12 @@
       そうだね<three_dots><end_line>
       わかったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh<three_dots><end_line>
     Okay<three_dots><end_line>
     Understood.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -136,16 +145,19 @@
       そっか<end_line>
       そうだったな<end_line>
     </sjis>
+    <ascii>
+    Oh, right.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっか<end_line>
       そうだったね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, right.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <choice>
   <info box="left">
@@ -177,17 +189,21 @@
       準備するから<end_line>
       ちょっと待っててくれよ<end_line>
     </sjis>
+    <ascii>
+    I need to get ready,<end_line>
+    wait a moment.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       準備するから<end_line>
       ちょっと待ってて<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I need to get ready,<end_line>
     wait a moment.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 10/Tier/001_25592076_186810c.xml
+++ b/Day 10/Tier/001_25592076_186810c.xml
@@ -7,17 +7,21 @@
       へー、そんなことが<three_dots><end_line>
       <player_nickname>くんも大変だねぇ<end_line>
     </sjis>
+    <ascii>
+    Huh, I see<three_dots><end_line>
+    You've got it hard too.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       へー、そんなことが<three_dots><end_line>
       <player_nickname>ちゃんも大変だねぇ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh, I see<three_dots><end_line>
     You've got it hard too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -82,17 +86,21 @@
       ちょっと待てよ！<end_line>
       今回は留守番じゃなかったのか？<end_line>
     </sjis>
+    <ascii>
+    Wait a minute!<end_line>
+    Didn't you say you'd watch the inn?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちょっと待ってよ！<end_line>
       今回は留守番じゃなかったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wait a minute!<end_line>
     Didn't you say you'd watch the inn?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -267,17 +275,21 @@
       よしなさい、ティエ<end_line>
       <player_nickname>くんも困ってるだろう<end_line>
     </sjis>
+    <ascii>
+    Cut it out, Tier.<end_line>
+    You're troubling <player_nickname>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よしなさい、ティエ<end_line>
       <player_nickname>ちゃんも困ってるだろう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Cut it out, Tier.<end_line>
     You're troubling <player_nickname>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -311,15 +323,18 @@
     <sjis>
       <player_nickname>くん<three_dots><end_line>
     </sjis>
+    <ascii>
+    <player_nickname><three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <player_nickname>ちゃん<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <player_nickname><three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -344,6 +359,11 @@
       勝負してやるぜ<end_line>
       ティエ！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Let's have a match,<end_line>
+    Tier!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -351,12 +371,12 @@
       勝負してあげるよ<end_line>
       ティエ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Let's have a match,<end_line>
     Tier!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 10/Tier/002_25593868_186880c.xml
+++ b/Day 10/Tier/002_25593868_186880c.xml
@@ -63,15 +63,18 @@
     <sjis>
       <player_nickname>くん<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    <player_nickname>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <player_nickname>ちゃん<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <player_nickname>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -83,6 +86,11 @@
       この勝負、ティエの両親のためにも<end_line>
       絶対に負けるわけにはいかない！<end_line>
     </sjis>
+    <ascii>
+    That's right<three_dots><end_line>
+    I have to win, not just for me,<end_line>
+    but for Tier's parents!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -90,10 +98,10 @@
       この勝負、ティエの両親のためにも<end_line>
       絶対に負けるわけにはいかない！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's right<three_dots><end_line>
     I have to win, not just for me,<end_line>
     but for Tier's parents!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 10/Tier/003_25594780_1868b9c.xml
+++ b/Day 10/Tier/003_25594780_1868b9c.xml
@@ -8,6 +8,11 @@
       これで自分の力がわかっただろ？<end_line>
       やっぱ留守番してろよ<end_line>
     </sjis>
+    <ascii>
+    Now then<three_dots><end_line>
+    Do you understand?<end_line>
+    You really should stay home.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -15,12 +20,12 @@
       これで自分の力がわかったでしょ？<end_line>
       やっぱり留守番してなよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Now then<three_dots><end_line>
     Do you understand?<end_line>
     You really should stay home.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -56,17 +61,21 @@
       なんだと？<end_line>
       どうして<three_dots><end_line>
     </sjis>
+    <ascii>
+    What?<end_line>
+    Why<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ？<end_line>
       どうして<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What?<end_line>
     Why<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -158,6 +167,11 @@
       それほどまでに<end_line>
       <player_nickname>くんを<three_dots><end_line>
     </sjis>
+    <ascii>
+    Tier<three_dots><end_line>
+    You care for <player_nickname><end_line>
+    that much<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -165,12 +179,12 @@
       それほどまでに<end_line>
       <player_nickname>ちゃんを<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Tier<three_dots><end_line>
     You care for <player_nickname><end_line>
     that much<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -182,6 +196,11 @@
       悪いがティエをいっしょに<end_line>
       連れて行ってくれないか？<end_line>
     </sjis>
+    <ascii>
+    <player_nickname>,<end_line>
+    I'm sorry, but could you<end_line>
+    take her with you?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -189,12 +208,12 @@
       悪いがティエをいっしょに<end_line>
       連れて行ってくれないか？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <player_nickname>,<end_line>
     I'm sorry, but could you<end_line>
     take her with you?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -274,6 +293,11 @@
       そんな、あの<end_line>
       すみません、オレ、あの<end_line>
     </sjis>
+    <ascii>
+    Wha,<end_line>
+    well, um,<end_line>
+    sorry, I<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -281,12 +305,12 @@
       そんな、あの<end_line>
       すみません、わたし、あの<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wha,<end_line>
     well, um,<end_line>
     sorry, I<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -333,6 +357,11 @@
       良かったなティエ<end_line>
       さあ、元気だしなさい<end_line>
     </sjis>
+    <ascii>
+    Thank you, <player_nickname>.<end_line>
+    Isn't that great, Tier?<end_line>
+    Now, cheer up, alright?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -340,12 +369,12 @@
       良かったなティエ<end_line>
       さあ、元気だしなさい<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Thank you, <player_nickname>.<end_line>
     Isn't that great, Tier?<end_line>
     Now, cheer up, alright?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -356,17 +385,21 @@
       だから、ほら<end_line>
       もう泣くなよ<end_line>
     </sjis>
+    <ascii>
+    Yeah, come on,<end_line>
+    don't cry.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       だから、ほら<end_line>
       もう泣かないで<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, come on,<end_line>
     don't cry.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -517,6 +550,10 @@
       なんとも<three_dots><end_line>
       すまない、<player_nickname>くん<three_dots><end_line>
     </sjis>
+    <ascii>
+    Our daughter is just so<three_dots><end_line>
+    I'm sorry, <player_nickname><three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -524,11 +561,11 @@
       なんとも<three_dots><end_line>
       すまない、<player_nickname>ちゃん<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Our daughter is just so<three_dots><end_line>
     I'm sorry, <player_nickname><three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 10/V.E/001_25572044_18632cc.xml
+++ b/Day 10/V.E/001_25572044_18632cc.xml
@@ -6,17 +6,21 @@
       あれ？<end_line>
       <partner>、ドコ行くんだよ<end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    <partner>, where are you going?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あれ？<end_line>
       <partner>、ドコ行くの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     <partner>, where are you going?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -90,6 +94,11 @@
       そうだな<three_dots><end_line>
       わかったよ<end_line>
     </sjis>
+    <ascii>
+    Oh<three_dots><end_line>
+    Okay<three_dots><end_line>
+    Understood.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -97,12 +106,12 @@
       そうだね<three_dots><end_line>
       わかったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh<three_dots><end_line>
     Okay<three_dots><end_line>
     Understood.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -142,6 +151,11 @@
       この武器、ロブ親方と作った<end_line>
       親方のお気に入りの斧じゃないか！<end_line>
     </sjis>
+    <ascii>
+    <three_dots>Wait, Master!<end_line>
+    Isn't this your favorite axe,<end_line>
+    one you crafted with Master Rob!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -149,12 +163,12 @@
       この武器、ロブ親方と作った<end_line>
       親方のお気に入りの斧じゃない！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots>Wait, Master!<end_line>
     Isn't this your favorite axe,<end_line>
     one you crafted with Master Rob!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -180,17 +194,21 @@
       でも、これ<three_dots><end_line>
       オレが直してもいいの<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    But this<three_dots><end_line>
+    Is it really okay for me to<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       でも、これ<three_dots><end_line>
       わたしが直してもいいの<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     But this<three_dots><end_line>
     Is it really okay for me to<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -217,6 +235,11 @@
       わかった<three_dots>！<end_line>
       まかせといてよ！<end_line>
     </sjis>
+    <ascii>
+    O-of course I can!<end_line>
+    Okay<three_dots>!<end_line>
+    Leave it to me!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -224,12 +247,12 @@
       わかった<three_dots>！<end_line>
       まかせといて！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     O-of course I can!<end_line>
     Okay<three_dots>!<end_line>
     Leave it to me!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 10/V.E/002_25573772_186398c.xml
+++ b/Day 10/V.E/002_25573772_186398c.xml
@@ -103,17 +103,21 @@
       使ってみなくちゃわからない<end_line>
       <three_dots>ってことか<end_line>
     </sjis>
+    <ascii>
+    Until we test it.<end_line>
+    <three_dots>Right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       使ってみなくちゃわからない<end_line>
       <three_dots>だね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Until we test it.<end_line>
     <three_dots>Right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -253,15 +257,19 @@
       オレたちのすべてをかけた武器、か<three_dots><end_line>
       どれにしようかな<end_line>
     </sjis>
+    <ascii>
+    The best one I've got, huh<three_dots><end_line>
+    I wonder which one to choose.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしたちのすべてをかけた武器、ね<three_dots><end_line>
       どれにしようかな<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The best one I've got, huh<three_dots><end_line>
     I wonder which one to choose.<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Day 10/V.E/004_25604124_186b01c.xml
+++ b/Day 10/V.E/004_25604124_186b01c.xml
@@ -7,16 +7,19 @@
       この武器に<end_line>
       オレと<partner>のすべてを<three_dots><end_line>
     </sjis>
+    <ascii>
+    With this weapon, I'm sure<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       この武器に<end_line>
       わたしと<partner>のすべてを<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     With this weapon, I'm sure<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Day 10/V.E/005_25576012_186424c.xml
+++ b/Day 10/V.E/005_25576012_186424c.xml
@@ -19,6 +19,11 @@
       ごめん、親方<three_dots><end_line>
       オレ、またこわしちゃって<three_dots><end_line>
     </sjis>
+    <ascii>
+    Uwah<three_dots><end_line>
+    Sorry, Master<three_dots><end_line>
+    I broke it again<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -26,12 +31,12 @@
       ごめん、親方<three_dots><end_line>
       わたし、またこわしちゃって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uwah<three_dots><end_line>
     Sorry, Master<three_dots><end_line>
     I broke it again<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -97,6 +102,11 @@
       オレ<three_dots><end_line>
       勝ったんだ<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    I<three_dots><end_line>
+    I won<three_dots><end_line>
+    I really won<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -104,12 +114,12 @@
       わたし<three_dots><end_line>
       勝ったんだ<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I<three_dots><end_line>
     I won<three_dots><end_line>
     I really won<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Final Day/003_25607980_186bf2c.xml
+++ b/Final Day/003_25607980_186bf2c.xml
@@ -7,17 +7,21 @@
       よっし！<end_line>
       じゃあ今日は<three_dots><end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    So today I'll<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よーし！<end_line>
       じゃあ今日は<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     So today I'll<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Final Day/005_25609372_186c49c.xml
+++ b/Final Day/005_25609372_186c49c.xml
@@ -29,24 +29,29 @@
 	<info box="right">
 	<portrait_r entry="player" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>ってことは<end_line>
 			ふたりで出かけたってことか？<end_line>
 			ドコへ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots>ってことは<end_line>
-			ふたりで出かけたってこと？<end_line>
-			ドコへ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots>Which means,<end_line>
     they left together?<end_line>
     Where to?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots>ってことは<end_line>
+			ふたりで出かけたってこと？<end_line>
+			ドコへ？<end_line>
+		</sjis>
+    <ascii>
+    <three_dots>Which means,<end_line>
+    they left together?<end_line>
+    Where to?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -132,21 +137,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			もう少しこの辺りもさがしてみよう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-			もう少しこの辺りもさがしてみよう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You're right.<end_line>
     Let's look around for a bit longer.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+			もう少しこの辺りもさがしてみよう<end_line>
+		</sjis>
+    <ascii>
+    You're right.<end_line>
+    Let's look around for a bit longer.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">

--- a/Final Day/007_25610764_186ca0c.xml
+++ b/Final Day/007_25610764_186ca0c.xml
@@ -791,13 +791,16 @@
     <sjis>
       おう！<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Final Day/040_25614476_186d88c.xml
+++ b/Final Day/040_25614476_186d88c.xml
@@ -42,15 +42,18 @@
     <sjis>
       ミューノを返せ！<end_line>
     </sjis>
+    <ascii>
+    Let her go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ミューノを返して！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Let her go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -62,6 +65,11 @@
       返すも何も、あいつの父親が<end_line>
       私たちを連れ出したんだ<end_line>
     </sjis>
+    <ascii>
+    Let her go? Ha!<end_line>
+    Why should I? Her father's the<end_line>
+    one who led us here.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -69,12 +77,12 @@
       返すも何も、あいつの父親が<end_line>
       私たちを連れ出したんだ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Let her go? Ha!<end_line>
     Why should I? Her father's the<end_line>
     one who led us here.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -211,6 +219,11 @@
       村に帰るなら、なんであいつらと<end_line>
       いっしょなんだ！？<end_line>
     </sjis>
+    <ascii>
+    Wait, he did?<end_line>
+    But then why are<end_line>
+    you with Anise!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -218,12 +231,12 @@
       村に帰るなら、なんであいつらと<end_line>
       いっしょなのよ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wait, he did?<end_line>
     But then why are<end_line>
     you with Anise!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -355,17 +368,21 @@
       ちょっと待てよ！<end_line>
       ちゃんとワケを<three_dots><end_line>
     </sjis>
+    <ascii>
+    Wait!<end_line>
+    Hear me out<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちょっと待ってよ！<end_line>
       ちゃんとワケを<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wait!<end_line>
     Hear me out<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -482,17 +499,21 @@
       ミューノ<three_dots><end_line>
       オレ<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Murno<three_dots><end_line>
+    I<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ミューノ<three_dots><end_line>
       わたし<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Murno<three_dots><end_line>
     I<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -517,15 +538,18 @@
     <sjis>
       そんな！　ウソだろ！？<end_line>
     </sjis>
+    <ascii>
+    Murno! Why!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんな！　ウソでしょ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Murno! Why!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -586,17 +610,21 @@
       <three_dots><end_line>
       なん、だよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    <three_dots><end_line>
+    What<three_dots>was that<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots><end_line>
       なんなの<three_dots>よ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots><end_line>
     What<three_dots>was that<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -630,7 +658,7 @@
   <sjis>
     <player_nickname>！<end_line>
   </sjis>
-   <ascii>
+  <ascii>
     <player_nickname>!<end_line>
   </ascii>
 </dialogue>
@@ -642,7 +670,7 @@
   <sjis>
     <player_nickname>さん！<end_line>
   </sjis>
-   <ascii>
+  <ascii>
     <player_nickname>!<end_line>
   </ascii>
 </dialogue>
@@ -777,6 +805,11 @@
       村に帰るから、ついてくるなって<end_line>
       ミューノが<three_dots><end_line>
     </sjis>
+    <ascii>
+    Well<three_dots><end_line>
+    Murno said she's heading home,<end_line>
+    and not to follow her<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -784,12 +817,12 @@
       村に帰るから、ついてこないでって<end_line>
       ミューノが<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well<three_dots><end_line>
     Murno said she's heading home,<end_line>
     and not to follow her<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -814,15 +847,18 @@
     <sjis>
       そんなこと、オレが知るかよ！<end_line>
     </sjis>
+    <ascii>
+    That's what I want to know!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなのわかんないよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's what I want to know!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -859,6 +895,11 @@
       納得なんてできるわけないだろ<three_dots><end_line>
       でも、ミューノが<three_dots><end_line>
     </sjis>
+    <ascii>
+    With Anise there<three_dots><end_line>
+    Of course not<three_dots><end_line>
+    But Murno<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -866,12 +907,12 @@
       納得なんてできるわけないよ<three_dots><end_line>
       でも、ミューノが<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     With Anise there<three_dots><end_line>
     Of course not<three_dots><end_line>
     But Murno<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -881,17 +922,21 @@
       いってー！<end_line>
       なにすんだよ！<end_line>
     </sjis>
+    <ascii>
+    Owww!<end_line>
+    What was that for!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       いったーい！<end_line>
       なにするのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Owww!<end_line>
     What was that for!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -1072,15 +1117,18 @@
     <sjis>
       オレの答え<three_dots><end_line>
     </sjis>
+    <ascii>
+    My answer<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしの答え<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     My answer<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -1145,15 +1193,19 @@
       そんなこと<three_dots><end_line>
       決まってるだろ！<end_line>
     </sjis>
+    <ascii>
+    Isn't it obvious?<end_line>
+    Let's go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなこと<three_dots><end_line>
       決まってるでしょ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Isn't it obvious?<end_line>
     Let's go!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Final Day/042_25619308_186eb6c.xml
+++ b/Final Day/042_25619308_186eb6c.xml
@@ -183,24 +183,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="murno" eye="sad" mouth="stressed">
 	<male>
-		<sjis>
+    <sjis>
 			行っちゃダメだ！<end_line>
 			本当はミューノだって<end_line>
 			そう思ってるんだろ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			行っちゃダメだよ！<end_line>
-			本当はミューノだって<end_line>
-			そう思ってるんでしょ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Don't go!<end_line>
     I'm sure that deep down,<end_line>
     this isn't what you want!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			行っちゃダメだよ！<end_line>
+			本当はミューノだって<end_line>
+			そう思ってるんでしょ！<end_line>
+		</sjis>
+    <ascii>
+    Don't go!<end_line>
+    I'm sure that deep down,<end_line>
+    this isn't what you want!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -426,19 +431,19 @@
 	<info box="right">
 	<portrait_r entry="jade" eye="special" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			オレが見込んだ男だからだ！<end_line>
 		</sjis>
     <ascii>
       a man I can respect!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			オレが見込んだ女だからだ！<end_line>
 		</sjis>
     <ascii>
       a woman I can respect!<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>

--- a/Final Day/043_25647404_187592c.xml
+++ b/Final Day/043_25647404_187592c.xml
@@ -102,6 +102,11 @@
       この廃墟の奥に、ミューノが<three_dots><end_line>
       今ならまだ追いつけるはずだ！<end_line>
     </sjis>
+    <ascii>
+    You're right<three_dots>!<end_line>
+    Murno is futher inside<three_dots><end_line>
+    We should still be able to catch up!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -109,10 +114,10 @@
       この廃墟の奥に、ミューノが<three_dots><end_line>
       今ならまだ追いつけるはずだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're right<three_dots>!<end_line>
     Murno is futher inside<three_dots><end_line>
     We should still be able to catch up!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Final Day/045_25622540_186f80c.xml
+++ b/Final Day/045_25622540_186f80c.xml
@@ -88,6 +88,11 @@
       ミューノを放せ！<end_line>
       話はそれからだ！！！<end_line>
     </sjis>
+    <ascii>
+    Enough already,<end_line>
+    just let Murno go!<end_line>
+    We can talk after that!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -95,12 +100,12 @@
       ミューノを放して<end_line>
       話はそれからだよ！！！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Enough already,<end_line>
     just let Murno go!<end_line>
     We can talk after that!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Final Day/051_25624812_18700ec.xml
+++ b/Final Day/051_25624812_18700ec.xml
@@ -7,6 +7,11 @@
       こわれた家が多いな<three_dots><end_line>
       何があったんだろ<three_dots><end_line>
     </sjis>
+    <ascii>
+    There's quite a lot of<end_line>
+    wrecked homes here<three_dots><end_line>
+    I wonder what happened<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -14,12 +19,12 @@
       こわれた家が多いね<three_dots><end_line>
       何があったんだろ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There's quite a lot of<end_line>
     wrecked homes here<three_dots><end_line>
     I wonder what happened<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -105,17 +110,21 @@
       ゴヴァンの遺跡だな<three_dots>！<end_line>
       急ぐぞ！<end_line>
     </sjis>
+    <ascii>
+    The Govan Ruins<three_dots>!<end_line>
+    Let's hurry!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ゴヴァンの遺跡だね<three_dots>！<end_line>
       急ごう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The Govan Ruins<three_dots>!<end_line>
     Let's hurry!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -201,17 +210,21 @@
       ゴヴァンの遺跡だな<three_dots>！<end_line>
       急ぐぞ！<end_line>
     </sjis>
+    <ascii>
+    The Govan Ruins<three_dots>!<end_line>
+    Let's hurry!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ゴヴァンの遺跡だね<three_dots>！<end_line>
       急ごう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The Govan Ruins<three_dots>!<end_line>
     Let's hurry!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -296,17 +309,21 @@
       ゴヴァンの遺跡だな<three_dots>！<end_line>
       急ぐぞ！<end_line>
     </sjis>
+    <ascii>
+    The Govan Ruins<three_dots>!<end_line>
+    Let's hurry!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ゴヴァンの遺跡だね<three_dots>！<end_line>
       急ごう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The Govan Ruins<three_dots>!<end_line>
     Let's hurry!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -392,15 +409,19 @@
       ゴヴァンの遺跡だな<three_dots>！<end_line>
       急ぐぞ！<end_line>
     </sjis>
+    <ascii>
+    The Govan Ruins<three_dots>!<end_line>
+    Let's hurry!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ゴヴァンの遺跡だね<three_dots>！<end_line>
       急ごう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The Govan Ruins<three_dots>!<end_line>
     Let's hurry!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Final Day/053_25626348_18706ec.xml
+++ b/Final Day/053_25626348_18706ec.xml
@@ -115,38 +115,45 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			大丈夫か？　<partner><three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			大丈夫？　<partner><three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <partner>, are you okay?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			大丈夫？　<partner><three_dots><end_line>
+		</sjis>
+    <ascii>
+    <partner>, are you okay?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そこの家で<end_line>
 			少し休んでいくか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そこの家で<end_line>
-			少し休もうか？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Want to rest<end_line>
     over there?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そこの家で<end_line>
+			少し休もうか？<end_line>
+		</sjis>
+    <ascii>
+    Want to rest<end_line>
+    over there?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">

--- a/Final Day/055_25627660_1870c0c.xml
+++ b/Final Day/055_25627660_1870c0c.xml
@@ -5,15 +5,18 @@
     <sjis>
       お、お前たち<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Y-you two<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、あんたたち<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Y-you two<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -67,6 +70,11 @@
       親方は<three_dots><end_line>
       アニキはどうした！？<end_line>
     </sjis>
+    <ascii>
+    Why are you here<three_dots>?<end_line>
+    What about Master<three_dots><end_line>
+    Where are Master and Jade!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -74,12 +82,12 @@
       親方は<three_dots><end_line>
       アニキはどうしたの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Why are you here<three_dots>?<end_line>
     What about Master<three_dots><end_line>
     Where are Master and Jade!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -104,15 +112,18 @@
     <sjis>
       なんだと<three_dots>っ！？<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
   </ascii>
+  </female>
 </bigtext>
 <dialogue>
   <info box="right">
@@ -137,15 +148,18 @@
     <sjis>
       キサマら<three_dots>、なんてこと<three_dots><end_line>
     </sjis>
+    <ascii>
+    You<three_dots> How could you<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんたたち<three_dots>、なんてこと<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You<three_dots> How could you<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -172,6 +186,11 @@
       本当によかったわ<three_dots><end_line>
       やっぱりアナタたちとの落とし前は<three_dots><end_line>
     </sjis>
+    <ascii>
+    That's right, I'm so glad<end_line>
+    I was able to see you again<three_dots><end_line>
+    Before I take you out<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -179,12 +198,12 @@
       本当によかったわ<three_dots><end_line>
       やっぱりアナタたちとの落とし前は<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's right, I'm so glad<end_line>
     I was able to see you again<three_dots><end_line>
     Before I take you out<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -502,6 +521,11 @@
       下らないことを話してくれたおかげで<end_line>
       落ちつくことができたぜ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Thanks to your stupid speech<end_line>
+    going on so long,<end_line>
+    I was able to calm down<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -509,12 +533,12 @@
       下らないことを話してくれたおかげで<end_line>
       落ちつくことができたわ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Thanks to your stupid speech<end_line>
     going on so long,<end_line>
     I was able to calm down<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -612,17 +636,21 @@
       よっしゃあ！！！<end_line>
       いくぞ、<partner>！<end_line>
     </sjis>
+    <ascii>
+    Bring it on!!!<end_line>
+    Let's go, <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉしっ！！！<end_line>
       いくよ、<partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Bring it on!!!<end_line>
     Let's go, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Final Day/056_25630812_187185c.xml
+++ b/Final Day/056_25630812_187185c.xml
@@ -89,17 +89,21 @@
       う、うごくなよ！<end_line>
       うごくと<three_dots><end_line>
     </sjis>
+    <ascii>
+    D-don't move!<end_line>
+    Or else<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       う、うごかないで！<end_line>
       うごくと<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     D-don't move!<end_line>
     Or else<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -183,17 +187,21 @@
       そんな<three_dots><end_line>
       やめろ、<partner><three_dots>！<end_line>
     </sjis>
+    <ascii>
+    No<three_dots><end_line>
+    Stop, <partner><three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんな<three_dots><end_line>
       やめて、<partner><three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No<three_dots><end_line>
     Stop, <partner><three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="right" effect="big">
@@ -605,17 +613,21 @@
       ご、ごめん<three_dots><end_line>
       レミィも悪かったな<end_line>
     </sjis>
+    <ascii>
+    S-sorry<three_dots><end_line>
+    I even made Lemmy worry about me.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ご、ごめん<three_dots><end_line>
       レミィも心配かけちゃったね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     S-sorry<three_dots><end_line>
     I even made Lemmy worry about me.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Final Day/061_25637196_187314c.xml
+++ b/Final Day/061_25637196_187314c.xml
@@ -63,15 +63,18 @@
     <sjis>
       なんだよ、これ！？<end_line>
     </sjis>
+    <ascii>
+    What's going on!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、これ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's going on!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -545,15 +548,18 @@
     <sjis>
       はいっ！<end_line>
     </sjis>
+    <ascii>
+    Yes!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       はいっ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yes!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -626,6 +632,11 @@
       いくぞ<end_line>
       <partner>！<end_line>
     </sjis>
+    <ascii>
+    Like I'd let you!<end_line>
+    Let's go,<end_line>
+    <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -633,12 +644,12 @@
       いくよ<end_line>
       <partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Like I'd let you!<end_line>
     Let's go,<end_line>
     <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Final Day/062_25641116_187409c.xml
+++ b/Final Day/062_25641116_187409c.xml
@@ -7,17 +7,21 @@
       これまでだ！<end_line>
       ミューノを返せ！<end_line>
     </sjis>
+    <ascii>
+    That's it!<end_line>
+    Let Murno go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ここまでよ！<end_line>
       ミューノを返して！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's it!<end_line>
     Let Murno go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -230,17 +234,21 @@
       なんだと<three_dots><end_line>
       今なんて<three_dots><end_line>
     </sjis>
+    <ascii>
+    What<three_dots>?<end_line>
+    What was that<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによそれ<three_dots>？<end_line>
       今なんて<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What<three_dots>?<end_line>
     What was that<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="simple" effect="big">
@@ -477,6 +485,11 @@
       おい<three_dots><end_line>
       大丈夫か！？<end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots>!<end_line>
+    Hey<three_dots><end_line>
+    Are you okay!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -484,12 +497,12 @@
       ねえ<three_dots><end_line>
       大丈夫！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots>!<end_line>
     Hey<three_dots><end_line>
     Are you okay!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -599,15 +612,18 @@
     <sjis>
       あ、待て<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Ah, wait<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、待って<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, wait<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Final Day/064_25650316_187648c.xml
+++ b/Final Day/064_25650316_187648c.xml
@@ -7,6 +7,11 @@
       さっきとあんまり<end_line>
       変わんないみたいだけど<three_dots><end_line>
     </sjis>
+    <ascii>
+    Is<three_dots>this it?<end_line>
+    It doesn't seem any<end_line>
+    different from before<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -14,12 +19,12 @@
       さっきとあんまり<end_line>
       変わらないみたいだけど<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Is<three_dots>this it?<end_line>
     It doesn't seem any<end_line>
     different from before<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -48,6 +53,11 @@
       幻龍鬼とかマグドラドがいた<end_line>
       ルイーズ村の迷宮に、似てるな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Actually, this place<three_dots><end_line>
+    It's quite similar to the<end_line>
+    labyrinth in Louise Village.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -55,12 +65,12 @@
       幻龍鬼とかマグドラドがいた<end_line>
       ルイーズ村の迷宮に、似てるね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Actually, this place<three_dots><end_line>
     It's quite similar to the<end_line>
     labyrinth in Louise Village.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -88,6 +98,11 @@
       とにかく前へ進むぞ！<end_line>
       ミューノを取り返すんだ！<end_line>
     </sjis>
+    <ascii>
+    I don't really get it, but anyway,<end_line>
+    let's keep moving!<end_line>
+    We're gonna get Murno back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -95,12 +110,12 @@
       とにかく前へ進もう！<end_line>
       ミューノを取り返すのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I don't really get it, but anyway,<end_line>
     let's keep moving!<end_line>
     We're gonna get Murno back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -153,6 +168,11 @@
       幻龍鬼とかマグドラドがいた<end_line>
       ルイーズ村の迷宮に、似てるな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Actually, this place<three_dots><end_line>
+    It's quite similar to the<end_line>
+    labyrinth in Louise Village.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -160,12 +180,12 @@
       幻龍鬼とかマグドラドがいた<end_line>
       ルイーズ村の迷宮に、似てるね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Actually, this place<three_dots><end_line>
     It's quite similar to the<end_line>
     labyrinth in Louise Village.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -194,6 +214,11 @@
       とにかく前へ進むぞ！<end_line>
       ミューノを取り返すんだ！<end_line>
     </sjis>
+    <ascii>
+    I don't really get it, but anyway,<end_line>
+    let's keep moving!<end_line>
+    We're gonna get Murno back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -201,12 +226,12 @@
       とにかく前へ進もう！<end_line>
       ミューノを取り返すのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I don't really get it, but anyway,<end_line>
     let's keep moving!<end_line>
     We're gonna get Murno back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -261,6 +286,11 @@
       幻龍鬼とかマグドラドがいた<end_line>
       ルイーズ村の迷宮に、似てるな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Actually, this place<three_dots><end_line>
+    It's quite similar to the<end_line>
+    labyrinth in Louise Village.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -268,12 +298,12 @@
       幻龍鬼とかマグドラドがいた<end_line>
       ルイーズ村の迷宮に、似てるね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Actually, this place<three_dots><end_line>
     It's quite similar to the<end_line>
     labyrinth in Louise Village.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -302,6 +332,11 @@
       とにかく前へ進むぞ！<end_line>
       ミューノを取り返すんだ！<end_line>
     </sjis>
+    <ascii>
+    I don't really get it, but anyway,<end_line>
+    let's keep moving!<end_line>
+    We're gonna get Murno back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -309,12 +344,12 @@
       とにかく前へ進もう！<end_line>
       ミューノを取り返すのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I don't really get it, but anyway,<end_line>
     let's keep moving!<end_line>
     We're gonna get Murno back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -369,6 +404,11 @@
       幻龍鬼とかマグドラドがいた<end_line>
       ルイーズ村の迷宮に、似てるな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Actually, this place<three_dots><end_line>
+    It's quite similar to the<end_line>
+    labyrinth in Louise Village.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -376,12 +416,12 @@
       幻龍鬼とかマグドラドがいた<end_line>
       ルイーズ村の迷宮に、似てるね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Actually, this place<three_dots><end_line>
     It's quite similar to the<end_line>
     labyrinth in Louise Village.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -408,6 +448,11 @@
       とにかく前へ進むぞ！<end_line>
       ミューノを取り返すんだ！<end_line>
     </sjis>
+    <ascii>
+    I don't really get it, but anyway,<end_line>
+    let's keep moving!<end_line>
+    We're gonna get Murno back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -415,12 +460,12 @@
       とにかく前へ進もう！<end_line>
       ミューノを取り返すのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I don't really get it, but anyway,<end_line>
     let's keep moving!<end_line>
     We're gonna get Murno back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Final Day/070_25652188_1876bdc.xml
+++ b/Final Day/070_25652188_1876bdc.xml
@@ -1,4 +1,3 @@
-#401
 <dialogue>
   <info box="left">
   <portrait_l entry="player" eye="decided" mouth="yell">
@@ -8,6 +7,11 @@
       待てよ！<end_line>
       ミューノを返せ！<end_line>
     </sjis>
+    <ascii>
+    Hey!<end_line>
+    Wait!<end_line>
+    Let Murno go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -15,12 +19,12 @@
       待ちなさい！<end_line>
       ミューノを返して！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey!<end_line>
     Wait!<end_line>
     Let Murno go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -269,17 +273,21 @@
       あ！？<end_line>
       おい<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah!?<end_line>
+    Hey<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ！？<end_line>
       ちょっと<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah!?<end_line>
     Hey<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -303,17 +311,21 @@
       な<three_dots><end_line>
       ちょっと待てよ！？<end_line>
     </sjis>
+    <ascii>
+    Wha<three_dots><end_line>
+    Will you just wait a second!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な<three_dots><end_line>
       ちょっと待ってよ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wha<three_dots><end_line>
     Will you just wait a second!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -362,15 +374,18 @@
     <sjis>
       な、なんだと！<end_line>
     </sjis>
+    <ascii>
+    What was that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な、なんですって！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -437,15 +452,18 @@
     <sjis>
       お、お前<three_dots>！？<end_line>
     </sjis>
+    <ascii>
+    A-anise<three_dots>!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、あんた<three_dots>！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     A-anise<three_dots>!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -533,6 +551,11 @@
       待て！<end_line>
       これはオレじゃない！<end_line>
     </sjis>
+    <ascii>
+    I-its mad!?<end_line>
+    Wait!<end_line>
+    I didn't do anything!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -540,12 +563,12 @@
       待って！<end_line>
       これはわたしじゃないの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I-its mad!?<end_line>
     Wait!<end_line>
     I didn't do anything!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="left" effect="big">
@@ -870,6 +893,11 @@
       あつい、ぞ<three_dots>？<end_line>
       これ<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    What<three_dots>?<end_line>
+    It's<three_dots> hot?<end_line>
+    This<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -877,12 +905,12 @@
       あつい、よ<three_dots>？<end_line>
       これ<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What<three_dots>?<end_line>
     It's<three_dots> hot?<end_line>
     This<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -908,15 +936,18 @@
     <sjis>
       次はなんだよ！？<end_line>
     </sjis>
+    <ascii>
+    What is it this time!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今度はなんなのよ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is it this time!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -957,6 +988,11 @@
       あつい、ぞ<three_dots>？<end_line>
       これ<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    What<three_dots>?<end_line>
+    It's<three_dots> hot?<end_line>
+    This<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -964,12 +1000,12 @@
       あつい、よ<three_dots>？<end_line>
       これ<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What<three_dots>?<end_line>
     It's<three_dots> hot?<end_line>
     This<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -995,15 +1031,18 @@
     <sjis>
       次はなんだよ！？<end_line>
     </sjis>
+    <ascii>
+    What is it this time!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今度はなんなのよ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is it this time!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -1042,6 +1081,11 @@
       あつい、ぞ<three_dots>？<end_line>
       これ<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    What<three_dots>?<end_line>
+    It's<three_dots> hot?<end_line>
+    This<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1049,12 +1093,12 @@
       あつい、よ<three_dots>？<end_line>
       これ<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What<three_dots>?<end_line>
     It's<three_dots> hot?<end_line>
     This<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1080,15 +1124,18 @@
     <sjis>
       次はなんだよ！？<end_line>
     </sjis>
+    <ascii>
+    What is it this time!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今度はなんなのよ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is it this time!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1127,6 +1174,11 @@
       あつい、ぞ<three_dots>？<end_line>
       これ<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    What<three_dots>?<end_line>
+    It's<three_dots> hot?<end_line>
+    This<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1134,12 +1186,12 @@
       あつい、よ<three_dots>？<end_line>
       これ<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What<three_dots>?<end_line>
     It's<three_dots> hot?<end_line>
     This<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1165,15 +1217,18 @@
     <sjis>
       次はなんだよ！？<end_line>
     </sjis>
+    <ascii>
+    What is it this time!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今度はなんなのよ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is it this time!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Final Day/071_25657932_187824c.xml
+++ b/Final Day/071_25657932_187824c.xml
@@ -17,6 +17,11 @@
       マグドラド、おちついた<three_dots><end_line>
       かな<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    We did it!<end_line>
+    Magdrad calmed down<three_dots><end_line>
+    Right<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -24,12 +29,12 @@
       マグドラド、おちついた<three_dots><end_line>
       かな<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We did it!<end_line>
     Magdrad calmed down<three_dots><end_line>
     Right<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -52,6 +57,10 @@
       大丈夫か！？<end_line>
       早くなんとかしないと<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah! Are you okay?<end_line>
+    I have to do something<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -59,11 +68,11 @@
       大丈夫！？<end_line>
       早くなんとかしないと<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah! Are you okay?<end_line>
     I have to do something<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -89,17 +98,21 @@
       でもお前<three_dots><end_line>
       そのケガで<three_dots><end_line>
     </sjis>
+    <ascii>
+    But<three_dots><end_line>
+    With your injuries<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       でもあんた<three_dots><end_line>
       そのケガで<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     But<three_dots><end_line>
     With your injuries<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -109,17 +122,21 @@
       お<three_dots>おい<three_dots><end_line>
       な、なんだよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    H<three_dots>hey<three_dots><end_line>
+    W-what is this<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え<three_dots>ちょっと<three_dots><end_line>
       な、なんなのよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     H<three_dots>hey<three_dots><end_line>
     W-what is this<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -221,6 +238,11 @@
       お前<three_dots><end_line>
       大丈夫か？<end_line>
     </sjis>
+    <ascii>
+    H-hey<three_dots>!<end_line>
+    Are<three_dots><end_line>
+    Are you okay?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -228,12 +250,12 @@
       あんた<three_dots><end_line>
       大丈夫なの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     H-hey<three_dots>!<end_line>
     Are<three_dots><end_line>
     Are you okay?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -322,15 +344,18 @@
     <sjis>
       なんだよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    What's with her<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なんなのよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's with her<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -350,17 +375,21 @@
       あ、そうだ<end_line>
       ありがとうな<end_line>
     </sjis>
+    <ascii>
+    Ah, right.<end_line>
+    Thanks.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、そうだ<end_line>
       ありがとうね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, right.<end_line>
     Thanks.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -381,6 +410,11 @@
       幻龍鬼があらわれるなんて<end_line>
       思ってもみなかったぜ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I had no idea<end_line>
+    the Phantom Dragon<end_line>
+    would show up here<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -388,12 +422,12 @@
       幻龍鬼があらわれるなんて<end_line>
       思ってもみなかったよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I had no idea<end_line>
     the Phantom Dragon<end_line>
     would show up here<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -461,6 +495,11 @@
       ま、とにかく今は<end_line>
       先に進もう！<end_line>
     </sjis>
+    <ascii>
+    Maybe<three_dots><end_line>
+    Anyway, we've<end_line>
+    got to keep moving!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -468,10 +507,10 @@
       ま、とにかく今は<end_line>
       先に進もう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Maybe<three_dots><end_line>
     Anyway, we've<end_line>
     got to keep moving!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Final Day/077_25660204_1878b2c.xml
+++ b/Final Day/077_25660204_1878b2c.xml
@@ -7,6 +7,10 @@
       <partner>！<end_line>
       大丈夫か？<end_line>
     </sjis>
+    <ascii>
+    <partner>,<end_line>
+    what's wrong!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -14,11 +18,11 @@
       <partner>！<end_line>
       大丈夫？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner>,<end_line>
     what's wrong!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -93,15 +97,19 @@
       お、おう<three_dots><end_line>
       わかった！<end_line>
     </sjis>
+    <ascii>
+    Y-yeah<three_dots><end_line>
+    I will!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       う、うん<three_dots><end_line>
       わかった！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Y-yeah<three_dots><end_line>
     I will!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Final Day/079_25661388_1878fcc.xml
+++ b/Final Day/079_25661388_1878fcc.xml
@@ -6,17 +6,21 @@
       なんだ、あれ<three_dots><end_line>
       剣？<end_line>
     </sjis>
+    <ascii>
+    What is that<three_dots><end_line>
+    A sword?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに、あれ<three_dots><end_line>
       剣？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is that<three_dots><end_line>
     A sword?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -104,15 +108,18 @@
     <sjis>
       こいつが、原因<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    This is it<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あいつが、原因<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This is it<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -238,15 +245,18 @@
     <sjis>
       そこをどけ！<end_line>
     </sjis>
+    <ascii>
+    Move aside!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そこをどいて！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Move aside!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -352,17 +362,21 @@
       エラそうなのはどっちだよ！<end_line>
       とにかくミューノを返せ！<end_line>
     </sjis>
+    <ascii>
+    No, that's you!<end_line>
+    Anyway, give Murno back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       エラそうなのはどっちよ！<end_line>
       とにかくミューノを返して！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No, that's you!<end_line>
     Anyway, give Murno back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Final Day/080_25665676_187a08c.xml
+++ b/Final Day/080_25665676_187a08c.xml
@@ -311,6 +311,11 @@
       おい、どうしたんだ？<end_line>
       <partner>！？<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+    Hey, what's going on?<end_line>
+    <partner>!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -318,12 +323,12 @@
       ねえ、どうしたの？<end_line>
       <partner>！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
     Hey, what's going on?<end_line>
     <partner>!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -400,6 +405,11 @@
       おい、<partner>！<end_line>
       どうしたんだよ！？<end_line>
     </sjis>
+    <ascii>
+    Wha!?<end_line>
+    Hey, <partner>!<end_line>
+    What's wrong!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -407,12 +417,12 @@
       ちょっと、<partner>！<end_line>
       どうしたの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wha!?<end_line>
     Hey, <partner>!<end_line>
     What's wrong!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -436,17 +446,21 @@
       なんだよ<end_line>
       何が起こってるんだよ！？<end_line>
     </sjis>
+    <ascii>
+    What?<end_line>
+    What's going on!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なんなの<end_line>
       何が起こってるのよ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What?<end_line>
     What's going on!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="simple" effect="big">
@@ -647,6 +661,11 @@
       <partner>、ウソだろ<three_dots><end_line>
       お前<three_dots><end_line>
     </sjis>
+    <ascii>
+    No<three_dots><end_line>
+    <partner><three_dots><end_line>
+    Why<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -654,12 +673,12 @@
       <partner>、ウソでしょ<three_dots><end_line>
       あなた<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No<three_dots><end_line>
     <partner><three_dots><end_line>
     Why<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -703,17 +722,21 @@
       やめろ、<partner>っ！<end_line>
       目を覚ませ！<end_line>
     </sjis>
+    <ascii>
+    Stop it, <partner>!<end_line>
+    Open your eyes!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       やめて、<partner>っ！<end_line>
       目を覚まして！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Stop it, <partner>!<end_line>
     Open your eyes!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -891,17 +914,21 @@
       お前<three_dots><end_line>
       アニス<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    You're<three_dots><end_line>
+    Anise<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんた<three_dots><end_line>
       アニス<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're<three_dots><end_line>
     Anise<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1165,16 +1192,19 @@
       なんだと<three_dots><end_line>
       お前、それって<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Don't tell me, you<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ<three_dots><end_line>
       あんた、もしかして<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't tell me, you<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Final Day/081_25677660_187cf5c.xml
+++ b/Final Day/081_25677660_187cf5c.xml
@@ -1,4 +1,3 @@
-#final fight vee
 <bigtext>
   <info box="right" effect="big">
   <portrait_r entry="partner" eye="decided" mouth="yell">
@@ -76,6 +75,10 @@
       忘れたなんて<end_line>
       ウソだろ、<partner>！<end_line>
     </sjis>
+    <ascii>
+    No<three_dots><end_line>
+    That's a lie, right, <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -83,11 +86,11 @@
       忘れたなんて<end_line>
       ウソでしょ、<partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No<three_dots><end_line>
     That's a lie, right, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -227,6 +230,11 @@
       <partner>はもう<end_line>
       オレのことなんかわからないって<three_dots><end_line>
     </sjis>
+    <ascii>
+    Even if you say that,<end_line>
+    <partner> doesn't<end_line>
+    recognize me anymore<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -234,12 +242,12 @@
       <partner>はもう<end_line>
       わたしのことなんかわからないって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Even if you say that,<end_line>
     <partner> doesn't<end_line>
     recognize me anymore<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -399,6 +407,11 @@
       お前と鍛えたこの武器で<end_line>
       今すぐ目覚めさせてやるぜ！<end_line>
     </sjis>
+    <ascii>
+    Come! <partner>!<end_line>
+    I'll bring you back right now<end_line>
+    with the weapons we forged together!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -406,10 +419,10 @@
       あなたと鍛えたこの武器で<end_line>
       今すぐ目覚めさせてあげる！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Come! <partner>!<end_line>
     I'll bring you back right now<end_line>
     with the weapons we forged together!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Final Day/082_25687516_187f5dc.xml
+++ b/Final Day/082_25687516_187f5dc.xml
@@ -24,17 +24,21 @@
       オレがわかるのか、<partner>？<end_line>
       もとにもどったのか！<end_line>
     </sjis>
+    <ascii>
+    You recognize me, <partner>?<end_line>
+    You're back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしがわかるの、<partner>？<end_line>
       もとにもどったのね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You recognize me, <partner>?<end_line>
     You're back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -74,15 +78,18 @@
     <sjis>
       あの遺跡だな！<end_line>
     </sjis>
+    <ascii>
+    The ruins, right!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あの遺跡ね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The ruins, right!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -108,17 +115,21 @@
       よっしゃ！<end_line>
       やってみるか！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    I'll give it a try!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       やってみよう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     I'll give it a try!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -146,17 +157,21 @@
       オレがわかるのか、<partner>？<end_line>
       もとにもどったのか！<end_line>
     </sjis>
+    <ascii>
+    You recognize me, <partner>?<end_line>
+    You're back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしがわかるの、<partner>？<end_line>
       もとにもどったのね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You recognize me, <partner>?<end_line>
     You're back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -195,15 +210,18 @@
     <sjis>
       あの遺跡だな！<end_line>
     </sjis>
+    <ascii>
+    The ruins, right!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あの遺跡ね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The ruins, right!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -229,17 +247,21 @@
       よっしゃ！<end_line>
       やってみるか！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    I'll give it a try!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       やってみよう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     I'll give it a try!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -267,17 +289,21 @@
       オレがわかるのか、<partner>？<end_line>
       もとにもどったのか！<end_line>
     </sjis>
+    <ascii>
+    You recognize me, <partner>?<end_line>
+    You're back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしがわかるの、<partner>？<end_line>
       もとにもどったのね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You recognize me, <partner>?<end_line>
     You're back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -318,15 +344,18 @@
     <sjis>
       あの遺跡だな！<end_line>
     </sjis>
+    <ascii>
+    The ruins, right!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あの遺跡ね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The ruins, right!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -352,17 +381,21 @@
       よっしゃ！<end_line>
       やってみるか！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    I'll give it a try!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       やってみよう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     I'll give it a try!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -390,17 +423,21 @@
       オレがわかるのか、<partner>？<end_line>
       もとにもどったのか！<end_line>
     </sjis>
+    <ascii>
+    You recognize me, <partner>?<end_line>
+    You're back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしがわかるの、<partner>？<end_line>
       もとにもどったのね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You recognize me, <partner>?<end_line>
     You're back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -439,15 +476,18 @@
     <sjis>
       あの遺跡だな！<end_line>
     </sjis>
+    <ascii>
+    The ruins, right!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あの遺跡ね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The ruins, right!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -473,17 +513,21 @@
       よっしゃ！<end_line>
       やってみるか！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    I'll give it a try!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       やってみよう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     I'll give it a try!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -531,6 +575,11 @@
       いいところに来た！<end_line>
       アニスをたのむ！<end_line>
     </sjis>
+    <ascii>
+    Tier!<end_line>
+    Good timing!<end_line>
+    Take care of Anise for me!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -538,12 +587,12 @@
       いいところに来てくれたね！<end_line>
       アニスをおねがい！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Tier!<end_line>
     Good timing!<end_line>
     Take care of Anise for me!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -580,17 +629,21 @@
       レミィもウェルマンさんを<end_line>
       たのむ！<end_line>
     </sjis>
+    <ascii>
+    Lemmy, you take care of Wellman,<end_line>
+    please!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       レミィもウェルマンさんを<end_line>
       おねがい！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Lemmy, you take care of Wellman,<end_line>
     please!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -682,17 +735,21 @@
       さすが親方！　カッコイイ！<end_line>
       その調子でアニスもたのむよ！<end_line>
     </sjis>
+    <ascii>
+    That's my Master! So cool!<end_line>
+    I'll leave Anise to you!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       さすが親方！　カッコイイ！<end_line>
       その調子でアニスもおねがいね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's my Master! So cool!<end_line>
     I'll leave Anise to you!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -718,17 +775,21 @@
       レミィもウェルマンさんを<end_line>
       たのむ！<end_line>
     </sjis>
+    <ascii>
+    Lemmy, you take care of Wellman,<end_line>
+    please!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       レミィもウェルマンさんを<end_line>
       おねがい！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Lemmy, you take care of Wellman,<end_line>
     please!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -810,6 +871,11 @@
       いいところに来てくれたよ！<end_line>
       アニスをたのむ！<end_line>
     </sjis>
+    <ascii>
+    Brother!<end_line>
+    Good timing!<end_line>
+    Take care of Anise for me!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -817,12 +883,12 @@
       いいところに来てくれたね！<end_line>
       アニスをおねがい！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Brother!<end_line>
     Good timing!<end_line>
     Take care of Anise for me!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -859,17 +925,21 @@
       レミィもウェルマンさんを<end_line>
       たのむ！<end_line>
     </sjis>
+    <ascii>
+    Lemmy, you take care of Wellman,<end_line>
+    please!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       レミィもウェルマンさんを<end_line>
       おねがい！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Lemmy, you take care of Wellman,<end_line>
     please!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -981,15 +1051,18 @@
     <sjis>
       いくぞ、<partner>！<end_line>
     </sjis>
+    <ascii>
+    Let's go, <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       いくよ、<partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Let's go, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Final Day/084_25691036_188039c.xml
+++ b/Final Day/084_25691036_188039c.xml
@@ -159,6 +159,11 @@
       おそくなっちゃって<three_dots><end_line>
       本当に、ごめん<three_dots><end_line>
     </sjis>
+    <ascii>
+    I'm the one who should apologize<three_dots><end_line>
+    I was late<three_dots><end_line>
+    I'm really sorry<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -166,12 +171,12 @@
       おそくなっちゃって<three_dots><end_line>
       本当に、ごめんね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm the one who should apologize<three_dots><end_line>
     I was late<three_dots><end_line>
     I'm really sorry<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -391,15 +396,18 @@
     <sjis>
       なにするんだ！<end_line>
     </sjis>
+    <ascii>
+    What are you doing!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なにするの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What are you doing!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Final Day/085_25901276_18b38dc.xml
+++ b/Final Day/085_25901276_18b38dc.xml
@@ -15,13 +15,16 @@
     <sjis>
       こっちからは上に戻れないみたいだ<end_line>
     </sjis>
+    <ascii>
+    Can't go up this way.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       こっちからは上に戻れないみたい<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Can't go up this way.<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Final Day/086_25693692_1880dfc.xml
+++ b/Final Day/086_25693692_1880dfc.xml
@@ -1,4 +1,3 @@
-#More branching dialogue here
 <dialogue>
   <partner name="run-dor">
   <info box="simple">
@@ -258,17 +257,21 @@
       あ、ああ<three_dots><end_line>
       オレは<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Ah, huh<three_dots><end_line>
+    I<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、あれ<three_dots><end_line>
       わたし<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, huh<three_dots><end_line>
     I<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -508,17 +511,21 @@
       あ、大丈夫だぜ～！<end_line>
       レミィ！<end_line>
     </sjis>
+    <ascii>
+    Ah, I'm fine~!<end_line>
+    Lemmy~!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、大丈夫だよ～！<end_line>
       レミィ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, I'm fine~!<end_line>
     Lemmy~!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Final Day/087_25696044_188172c.xml
+++ b/Final Day/087_25696044_188172c.xml
@@ -1,4 +1,3 @@
-#390
 <dialogue>
   <info box="left">
   <portrait_l entry="player" eye="surprised" mouth="talk">
@@ -266,6 +265,11 @@
       オレたちだって大丈夫だったんだ<end_line>
       だから、きっと<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah<three_dots>, um<three_dots><end_line>
+    We got out of it fine,<end_line>
+    so I'm sure<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -273,12 +277,12 @@
       わたしたちだって大丈夫だったんだよ<end_line>
       だから、きっと<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah<three_dots>, um<three_dots><end_line>
     We got out of it fine,<end_line>
     so I'm sure<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -353,15 +357,18 @@
     <sjis>
       なんだよ、それ<three_dots><end_line>
     </sjis>
+    <ascii>
+    What the<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What the<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -1089,17 +1096,21 @@
       こ<three_dots><end_line>
       こんな、でかい<three_dots><end_line>
     </sjis>
+    <ascii>
+    It's<three_dots><end_line>
+    It's huge<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       こ<three_dots><end_line>
       こんな、おっきい<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's<three_dots><end_line>
     It's huge<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="right" effect="big">

--- a/Final Day/088_25702060_1882eac.xml
+++ b/Final Day/088_25702060_1882eac.xml
@@ -74,15 +74,18 @@
     <sjis>
       もうやめろ！<end_line>
     </sjis>
+    <ascii>
+    Enough already!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       もうやめて！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Enough already!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="right" effect="big">
@@ -101,15 +104,18 @@
     <sjis>
       なんだ！？<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、これ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -169,7 +175,7 @@
     あの人の体が<three_dots><end_line>
     取り込まれてしまいますわ<three_dots>！<end_line>
   </sjis>
-   <ascii>
+  <ascii>
     What<three_dots> this awful power<three_dots><end_line>
     His body is<three_dots><end_line>
     Being consumed<three_dots>!<end_line>
@@ -183,15 +189,18 @@
     <sjis>
       剣に<three_dots>、喰われる！？<end_line>
     </sjis>
+    <ascii>
+    Consumed<three_dots> by the sword!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       剣に<three_dots>、喰べられる！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Consumed<three_dots> by the sword!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="right" effect="big">
@@ -212,6 +221,11 @@
       吸い込まれる<three_dots>！？<end_line>
       <partner><three_dots>！<end_line>
     </sjis>
+    <ascii>
+    What is this<three_dots>!<end_line>
+    I'm getting sucked in<three_dots>!?<end_line>
+    <partner><three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -219,12 +233,12 @@
       吸い込まれる<three_dots>！？<end_line>
       <partner><three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is this<three_dots>!<end_line>
     I'm getting sucked in<three_dots>!?<end_line>
     <partner><three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Final Day/090_25704076_188368c.xml
+++ b/Final Day/090_25704076_188368c.xml
@@ -6,17 +6,21 @@
       なんだよ<three_dots>？<end_line>
       ここはドコなんだよ<three_dots>！？<end_line>
     </sjis>
+    <ascii>
+    What just<three_dots>?<end_line>
+    Where are we<three_dots>!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、これ<three_dots>？<end_line>
       ここはドコなのよ<three_dots>！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What just<three_dots>?<end_line>
     Where are we<three_dots>!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -531,15 +535,18 @@
     <sjis>
       行くぞ、<partner>！<end_line>
     </sjis>
+    <ascii>
+    Let's go, <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       行くよ、<partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Let's go, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Final Day/091_25707212_18842cc.xml
+++ b/Final Day/091_25707212_18842cc.xml
@@ -77,15 +77,18 @@
     <sjis>
       なんだよ！　あれ！？<end_line>
     </sjis>
+    <ascii>
+    What is that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！　あれ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -227,6 +230,11 @@
       どうしたんだ<three_dots>？<end_line>
       暗くなってくぞ<three_dots>！？<end_line>
     </sjis>
+    <ascii>
+    Huh<three_dots>!?<end_line>
+    What's going on<three_dots>?<end_line>
+    It's getting dark<three_dots>!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -234,12 +242,12 @@
       どうしたの<three_dots>？<end_line>
       暗くなってく<three_dots>！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh<three_dots>!?<end_line>
     What's going on<three_dots>?<end_line>
     It's getting dark<three_dots>!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -432,17 +440,21 @@
       お前が先だ！<end_line>
       行けぇっ！<end_line>
     </sjis>
+    <ascii>
+    You first!<end_line>
+    Go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あなたが先よ！<end_line>
       行ってぇっ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You first!<end_line>
     Go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -504,17 +516,21 @@
       オレも<three_dots><end_line>
       間に合えっ<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    I can<three_dots><end_line>
+    Make it<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしも<three_dots><end_line>
       間に合って<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I can<three_dots><end_line>
     Make it<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1429,15 +1445,18 @@
     <sjis>
       何だ、今<three_dots><end_line>
     </sjis>
+    <ascii>
+    Just now, that was<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       何、今<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Just now, that was<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1560,6 +1579,11 @@
       みんなの元へ！<end_line>
       だから<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    I'm going back!<end_line>
+    To where everyone is!<end_line>
+    So<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1567,12 +1591,12 @@
       みんなの元へ！<end_line>
       だから<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm going back!<end_line>
     To where everyone is!<end_line>
     So<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1805,15 +1829,18 @@
     <sjis>
       開けっ！！！<end_line>
     </sjis>
+    <ascii>
+    Open!!!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       開いてっ！！！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Open!!!<end_line>
   </ascii>
+  </female>
 </bigtext>
 <dialogue>
   <info box="left">

--- a/Final Day/093_25713660_1885bfc.xml
+++ b/Final Day/093_25713660_1885bfc.xml
@@ -29,6 +29,11 @@
       オレ<three_dots><end_line>
       戻ったんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    This is<three_dots><end_line>
+    I<three_dots><end_line>
+    I'm back<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -36,12 +41,12 @@
       わたし<three_dots><end_line>
       戻ったんだ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This is<three_dots><end_line>
     I<three_dots><end_line>
     I'm back<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -223,6 +228,11 @@
       わからないよ！<end_line>
       だから<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    I won't know<end_line>
+    until I try!<end_line>
+    So<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -230,12 +240,12 @@
       わからないですよ！<end_line>
       だから<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I won't know<end_line>
     until I try!<end_line>
     So<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="left" effect="big">
@@ -509,6 +519,11 @@
       ありがとう<three_dots>！<end_line>
       オレ、絶対にあきらめないぜ！<end_line>
     </sjis>
+    <ascii>
+    Everyone<three_dots><end_line>
+    Thank you<three_dots>!<end_line>
+    I will never give up!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -516,12 +531,12 @@
       ありがとう<three_dots>！<end_line>
       わたし、絶対にあきらめないよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Everyone<three_dots><end_line>
     Thank you<three_dots>!<end_line>
     I will never give up!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -966,7 +981,8 @@
   <portrait_r entry="jade" eye="decided" mouth="talk">
   <sjis>
     おう<end_line>
-  </sjis><ascii>
+  </sjis>
+  <ascii>
     Yeah.<end_line>
   </ascii>
 </dialogue>

--- a/Final Day/095_25946652_18bea1c.xml
+++ b/Final Day/095_25946652_18bea1c.xml
@@ -151,17 +151,21 @@
       え<three_dots>？<end_line>
       なんだよ？<end_line>
     </sjis>
+    <ascii>
+    Eh<three_dots>?<end_line>
+    What's that mean?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え<three_dots>？<end_line>
       なによ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh<three_dots>?<end_line>
     What's that mean?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -743,17 +747,21 @@
       ミューノ<three_dots><end_line>
       本当にそれでいいのか？<end_line>
     </sjis>
+    <ascii>
+    Murno<three_dots><end_line>
+    Are you really okay with this?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ミューノ<three_dots><end_line>
       本当にそれでいいの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Murno<three_dots><end_line>
     Are you really okay with this?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -780,6 +788,11 @@
       じゃ、これからもよろしくたのむぜ<end_line>
       <partner><end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    Let's continue to get along then,<end_line>
+    <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -787,12 +800,12 @@
       じゃあ、これからもよろしくね<end_line>
       <partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     Let's continue to get along then,<end_line>
     <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -903,17 +916,21 @@
       え、お前<end_line>
       召喚獣いるの？<end_line>
     </sjis>
+    <ascii>
+    Eh, you have<end_line>
+    a Summon Beast?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え、あんた<end_line>
       召喚獣いるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh, you have<end_line>
     a Summon Beast?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -950,17 +967,21 @@
       へえ<three_dots><end_line>
       どうだ、<partner>？<end_line>
     </sjis>
+    <ascii>
+    Ohh<three_dots><end_line>
+    Well, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       へえ<three_dots><end_line>
       どう、<partner>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ohh<three_dots><end_line>
     Well, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -1025,17 +1046,21 @@
       そっか<end_line>
       じゃ、決まりだな<end_line>
     </sjis>
+    <ascii>
+    I see.<end_line>
+    Then it's decided.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっか<end_line>
       じゃ、決まりね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see.<end_line>
     Then it's decided.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -1337,6 +1362,11 @@
       ミューノ<three_dots><end_line>
       必ずまた会おうぜ！<end_line>
     </sjis>
+    <ascii>
+    I will!<end_line>
+    Murno<three_dots><end_line>
+    I'm sure we'll meet again!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1344,12 +1374,12 @@
       ミューノ<three_dots><end_line>
       必ずまた会おうね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I will!<end_line>
     Murno<three_dots><end_line>
     I'm sure we'll meet again!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Final Day/101_25959308_18c1b8c.xml
+++ b/Final Day/101_25959308_18c1b8c.xml
@@ -66,6 +66,11 @@
       第一ロックって、名も無き世界の<end_line>
       音楽なんだろ？<end_line>
     </sjis>
+    <ascii>
+    I really don't get it<three_dots><end_line>
+    First of all, rock is music from<end_line>
+    the Nameless World, right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -73,12 +78,12 @@
       第一ロックって、名も無き世界の<end_line>
       音楽なんでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I really don't get it<three_dots><end_line>
     First of all, rock is music from<end_line>
     the Nameless World, right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Final Day/25671964_187b91c.xml
+++ b/Final Day/25671964_187b91c.xml
@@ -1,4 +1,3 @@
-#similar text to 187cf5c. maybe this depends on who you chose in day 10? shit.
 <bigtext>
 	<info box="right" effect="big">
 	<portrait_r entry="partner" eye="decided" mouth="yell">
@@ -72,23 +71,27 @@
 	<portrait_l entry="player" eye="sad" mouth="yell">
 	<portrait_r entry="anise" eye="special" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そんな<three_dots><end_line>
 			忘れたなんて<end_line>
 			ウソだろ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    No<three_dots><end_line>
+    That's a lie, right, <partner>!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そんな<three_dots><end_line>
 			忘れたなんて<end_line>
 			ウソでしょ、<partner>！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     No<three_dots><end_line>
     That's a lie, right, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
@@ -266,22 +269,27 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			こいっ！　<partner>！<end_line>
 			お前と鍛えたこの武器で<end_line>
 			今すぐ目覚めさせてやるぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			きなさい！　<partner>！<end_line>
-			あなたと鍛えたこの武器で<end_line>
-			今すぐ目覚めさせてあげる！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Come! <partner>!<end_line>
     I'll bring you back right now<end_line>
     with the weapons we forged together!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			きなさい！　<partner>！<end_line>
+			あなたと鍛えたこの武器で<end_line>
+			今すぐ目覚めさせてあげる！<end_line>
+		</sjis>
+    <ascii>
+    Come! <partner>!<end_line>
+    I'll bring you back right now<end_line>
+    with the weapons we forged together!<end_line>
+  </ascii>
+  </female>
 </dialogue>

--- a/Final Day/25674140_187c19c.xml
+++ b/Final Day/25674140_187c19c.xml
@@ -2,24 +2,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			うるさい！<end_line>
 			やめろ！<end_line>
 			<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うるさい！<end_line>
-			やめて！<end_line>
-			<partner>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Calm down!<end_line>
     Stop!<end_line>
     <partner>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うるさい！<end_line>
+			やめて！<end_line>
+			<partner>！<end_line>
+		</sjis>
+    <ascii>
+    Calm down!<end_line>
+    Stop!<end_line>
+    <partner>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -55,21 +60,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="talk">
 	<portrait_r entry="partner" eye="surprised" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			<partner><three_dots>！<end_line>
 			元にもどったのか！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<partner><three_dots>！<end_line>
-			元にもどったの！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <partner><three_dots>!<end_line>
     Are you okay!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<partner><three_dots>！<end_line>
+			元にもどったの！？<end_line>
+		</sjis>
+    <ascii>
+    <partner><three_dots>!<end_line>
+    Are you okay!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -109,21 +118,25 @@
 	<portrait_l entry="player" eye="sad" mouth="serious">
 	<portrait_r entry="partner" eye="surprised" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ？<end_line>
 			オレ、どうすればいいんだ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ？<end_line>
-			わたし、どうすればいいの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Wait, what?<end_line>
     So what do I do?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ？<end_line>
+			わたし、どうすればいいの？<end_line>
+		</sjis>
+    <ascii>
+    Wait, what?<end_line>
+    So what do I do?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -169,24 +182,29 @@
 	<portrait_l entry="player" eye="surprised" mouth="yell">
 	<portrait_r entry="partner" eye="surprised" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			こわせ<three_dots>って<end_line>
 			バカ！　なに言ってるんだよ！？<end_line>
 			そんなことできるかよ！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			こわして<three_dots>って<end_line>
-			バカ！　なに言ってるの！？<end_line>
-			そんなことできるわけないよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Destroy<three_dots>!?<end_line>
     Idiot! What are you saying!?<end_line>
     I can't do that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			こわして<three_dots>って<end_line>
+			バカ！　なに言ってるの！？<end_line>
+			そんなことできるわけないよ！<end_line>
+		</sjis>
+    <ascii>
+    Destroy<three_dots>!?<end_line>
+    Idiot! What are you saying!?<end_line>
+    I can't do that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -261,21 +279,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="talk">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			<partner><three_dots>！<end_line>
 			元にもどったのか！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<partner><three_dots>！<end_line>
-			元にもどったの！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <partner><three_dots>!<end_line>
     Are you okay!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<partner><three_dots>！<end_line>
+			元にもどったの！？<end_line>
+		</sjis>
+    <ascii>
+    <partner><three_dots>!<end_line>
+    Are you okay!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -315,24 +337,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="special" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			怨念<three_dots>？<end_line>
 			<partner>！<end_line>
 			しっかりしろよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			怨念<three_dots>？<end_line>
-			<partner>！<end_line>
-			しっかりして！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hatred<three_dots>?<end_line>
     <partner>!<end_line>
     Hold on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			怨念<three_dots>？<end_line>
+			<partner>！<end_line>
+			しっかりして！<end_line>
+		</sjis>
+    <ascii>
+    Hatred<three_dots>?<end_line>
+    <partner>!<end_line>
+    Hold on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -356,21 +383,25 @@
 	<portrait_l entry="player" eye="sad" mouth="serious">
 	<portrait_r entry="partner" eye="special" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ？<end_line>
 			オレ、どうすればいいんだ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なに？<end_line>
-			わたし、どうすればいいの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     What should I do?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なに？<end_line>
+			わたし、どうすればいいの？<end_line>
+		</sjis>
+    <ascii>
+    Huh?<end_line>
+    What should I do?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -390,24 +421,29 @@
 	<portrait_l entry="player" eye="surprised" mouth="yell">
 	<portrait_r entry="partner" eye="special" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			討て、<three_dots>って<end_line>
 			バカ！　なに言ってるんだよ！？<end_line>
 			そんなことできるかよ！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			討て、<three_dots>って<end_line>
-			バカ！　なに言ってるの！？<end_line>
-			そんなことできるわけないよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Take you down<three_dots>!?<end_line>
     Idiot! What are you saying!?<end_line>
     I can't do that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			討て、<three_dots>って<end_line>
+			バカ！　なに言ってるの！？<end_line>
+			そんなことできるわけないよ！<end_line>
+		</sjis>
+    <ascii>
+    Take you down<three_dots>!?<end_line>
+    Idiot! What are you saying!?<end_line>
+    I can't do that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -480,21 +516,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="talk">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			<partner><three_dots>！<end_line>
 			元にもどったのか！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<partner><three_dots>！<end_line>
-			元にもどったの！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <partner><three_dots>!<end_line>
     Are you okay!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<partner><three_dots>！<end_line>
+			元にもどったの！？<end_line>
+		</sjis>
+    <ascii>
+    <partner><three_dots>!<end_line>
+    Are you okay!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -534,24 +574,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			怨念<three_dots>？<end_line>
 			<partner>！<end_line>
 			しっかりしろよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			怨念<three_dots>？<end_line>
-			<partner>！<end_line>
-			しっかりして！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hatred<three_dots>?<end_line>
     <partner>!<end_line>
     Hold on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			怨念<three_dots>？<end_line>
+			<partner>！<end_line>
+			しっかりして！<end_line>
+		</sjis>
+    <ascii>
+    Hatred<three_dots>?<end_line>
+    <partner>!<end_line>
+    Hold on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -575,21 +620,25 @@
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ？<end_line>
 			オレ、どうすればいいんだ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なに？<end_line>
-			わたし、どうすればいいの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What?<end_line>
     What should I do?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なに？<end_line>
+			わたし、どうすればいいの？<end_line>
+		</sjis>
+    <ascii>
+    What?<end_line>
+    What should I do?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -611,24 +660,29 @@
 	<portrait_l entry="player" eye="surprised" mouth="yell">
 	<portrait_r entry="partner" eye="special" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			討て<three_dots>って<end_line>
 			バカ！　なに言ってるんだよ！？<end_line>
 			そんなことできるかよ！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			討て<three_dots>って<end_line>
-			バカ！　なに言ってるの！？<end_line>
-			そんなことできるわけないよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Take you down<three_dots>!?<end_line>
     Idiot! What are you saying!?<end_line>
     I can't do that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			討て<three_dots>って<end_line>
+			バカ！　なに言ってるの！？<end_line>
+			そんなことできるわけないよ！<end_line>
+		</sjis>
+    <ascii>
+    Take you down<three_dots>!?<end_line>
+    Idiot! What are you saying!?<end_line>
+    I can't do that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -701,21 +755,25 @@
 	<portrait_l name="player">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			<partner><three_dots>！<end_line>
 			元にもどったのか！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<partner><three_dots>！<end_line>
-			元にもどったの！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <partner><three_dots>!<end_line>
     Are you okay!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<partner><three_dots>！<end_line>
+			元にもどったの！？<end_line>
+		</sjis>
+    <ascii>
+    <partner><three_dots>!<end_line>
+    Are you okay!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -753,24 +811,29 @@
 	<portrait_l name="player">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			怨念<three_dots>？<end_line>
 			<partner>！<end_line>
 			しっかりしろよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			怨念<three_dots>？<end_line>
-			<partner>！<end_line>
-			しっかりして！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hatred<three_dots>?<end_line>
     <partner>!<end_line>
     Hold on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			怨念<three_dots>？<end_line>
+			<partner>！<end_line>
+			しっかりして！<end_line>
+		</sjis>
+    <ascii>
+    Hatred<three_dots>?<end_line>
+    <partner>!<end_line>
+    Hold on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -793,21 +856,25 @@
 	<portrait_l name="player">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ？<end_line>
 			オレ、どうすればいいんだ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なに？<end_line>
-			わたし、どうすればいいの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What?<end_line>
     What should I do?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なに？<end_line>
+			わたし、どうすればいいの？<end_line>
+		</sjis>
+    <ascii>
+    What?<end_line>
+    What should I do?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -851,24 +918,29 @@
 	<portrait_l entry="player" eye="surprised" mouth="yell">
 	<portrait_r entry="partner" eye="sad" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			討って<three_dots>って<end_line>
 			バカ！　なに言ってるんだよ！？<end_line>
 			そんなことできるかよ！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			討って<three_dots>って<end_line>
-			バカ！　なに言ってるの！？<end_line>
-			そんなことできるわけないよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Take you down<three_dots>!?<end_line>
     Idiot! What are you saying!?<end_line>
     I can't do that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			討って<three_dots>って<end_line>
+			バカ！　なに言ってるの！？<end_line>
+			そんなことできるわけないよ！<end_line>
+		</sjis>
+    <ascii>
+    Take you down<three_dots>!?<end_line>
+    Idiot! What are you saying!?<end_line>
+    I can't do that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -969,21 +1041,25 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="anise" eye="special" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			忘れただと<three_dots><end_line>
 			くっそお<three_dots>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			忘れた、ですって<three_dots><end_line>
-			なによ、それ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     No<three_dots><end_line>
     That's a lie, right, <partner>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			忘れた、ですって<three_dots><end_line>
+			なによ、それ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    No<three_dots><end_line>
+    That's a lie, right, <partner>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<player gender="male">
@@ -1063,22 +1139,27 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			だからオレが思い出させてやる<end_line>
 			お前と鍛えた<end_line>
 			この武器で！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			だからわたしが思い出させてあげる<end_line>
-			あなたと鍛えた<end_line>
-			この武器で！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Then I'll make you remember!<end_line>
     I'll bring you back right now<end_line>
     with the weapons we forged together!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			だからわたしが思い出させてあげる<end_line>
+			あなたと鍛えた<end_line>
+			この武器で！<end_line>
+		</sjis>
+    <ascii>
+    Then I'll make you remember!<end_line>
+    I'll bring you back right now<end_line>
+    with the weapons we forged together!<end_line>
+  </ascii>
+  </female>
 </dialogue>

--- a/Final Day/25680300_187d9ac.xml
+++ b/Final Day/25680300_187d9ac.xml
@@ -71,23 +71,27 @@
 	<portrait_l entry="player" eye="sad" mouth="yell">
 	<portrait_r entry="anise" eye="special" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そんな<three_dots><end_line>
 			忘れたなんて<end_line>
 			ウソだろ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    No<three_dots><end_line>
+    That's a lie, right, <partner>!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そんな<three_dots><end_line>
 			忘れたなんて<end_line>
 			ウソでしょ、<partner>！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     No<three_dots><end_line>
     That's a lie, right, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
@@ -103,7 +107,7 @@
 	<info box="left">
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			くっそ<three_dots><end_line>
 			オレは、どうすればいいんだ<three_dots><end_line>
 		</sjis>
@@ -111,9 +115,9 @@
       Shit<three_dots><end_line>
       What should I do<three_dots><end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			それじゃあ<three_dots><end_line>
 			わたしは、どうすればいいのよ<three_dots><end_line>
 		</sjis>
@@ -121,7 +125,7 @@
       Then<three_dots><end_line>
       What should I do<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -162,24 +166,29 @@
 	<portrait_l entry="player" eye="sad" mouth="yell">
 	<portrait_r entry="lemmy" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			でも、どうすりゃいいんだ！？<end_line>
 			もう<partner>には<end_line>
 			オレの声も届かないんだ<three_dots>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも、どうすればいいの！？<end_line>
-			もう<partner>には<end_line>
-			わたしの声も届かないよ<three_dots>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     But what should I do!?<end_line>
     <partner> can't hear<end_line>
     my voice anymore<three_dots>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でも、どうすればいいの！？<end_line>
+			もう<partner>には<end_line>
+			わたしの声も届かないよ<three_dots>！<end_line>
+		</sjis>
+    <ascii>
+    But what should I do!?<end_line>
+    <partner> can't hear<end_line>
+    my voice anymore<three_dots>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -198,48 +207,58 @@
 	<info box="left">
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			オレは、鍛冶師<three_dots><end_line>
 			<three_dots><end_line>
 			へっ、そうか<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしは、鍛冶師<three_dots><end_line>
-			<three_dots><end_line>
-			あはっ、そっか<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What do you mean, I'm a<three_dots><end_line>
     <three_dots><end_line>
     Ah, right<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしは、鍛冶師<three_dots><end_line>
+			<three_dots><end_line>
+			あはっ、そっか<three_dots><end_line>
+		</sjis>
+    <ascii>
+    What do you mean, I'm a<three_dots><end_line>
+    <three_dots><end_line>
+    Ah, right<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="lemmy" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			わかったよ、レミィ<end_line>
 			<partner>はオレが<end_line>
 			絶対に目覚めさせてやる<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わかったよ、レミィ<end_line>
-			<partner>はわたしが<end_line>
-			絶対に目覚めさせてみせる<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Okay, Lemmy.<end_line>
     I'll definitely make<end_line>
     <partner> snap out of it.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わかったよ、レミィ<end_line>
+			<partner>はわたしが<end_line>
+			絶対に目覚めさせてみせる<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Okay, Lemmy.<end_line>
+    I'll definitely make<end_line>
+    <partner> snap out of it.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -268,22 +287,27 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			こいっ！　<partner>！<end_line>
 			お前と鍛えたこの武器で<end_line>
 			今すぐ目覚めさせてやるぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			きなさい！　<partner>！<end_line>
-			あなたと鍛えたこの武器で<end_line>
-			今すぐ目覚めさせてあげる！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Come! <partner>!<end_line>
     I'll bring you back right now<end_line>
     with the weapons we forged together!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			きなさい！　<partner>！<end_line>
+			あなたと鍛えたこの武器で<end_line>
+			今すぐ目覚めさせてあげる！<end_line>
+		</sjis>
+    <ascii>
+    Come! <partner>!<end_line>
+    I'll bring you back right now<end_line>
+    with the weapons we forged together!<end_line>
+  </ascii>
+  </female>
 </dialogue>

--- a/Final Day/25682460_187e21c.xml
+++ b/Final Day/25682460_187e21c.xml
@@ -71,23 +71,27 @@
 	<portrait_l entry="player" eye="sad" mouth="yell">
 	<portrait_r entry="anise" eye="special" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そんな<three_dots><end_line>
 			忘れたなんて<end_line>
 			ウソだろ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    No<three_dots><end_line>
+    That's a lie, right, <partner>!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そんな<three_dots><end_line>
 			忘れたなんて<end_line>
 			ウソでしょ、<partner>！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     No<three_dots><end_line>
     That's a lie, right, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
@@ -103,7 +107,7 @@
 	<info box="left">
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			くっそ<three_dots><end_line>
 			オレは、どうすればいいんだ<three_dots><end_line>
 		</sjis>
@@ -111,9 +115,9 @@
       Shit<three_dots><end_line>
       What should I do<three_dots><end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			それじゃあ<three_dots><end_line>
 			わたしは、どうすればいいのよ<three_dots><end_line>
 		</sjis>
@@ -121,7 +125,7 @@
       Then<three_dots><end_line>
       What should I do<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
@@ -196,21 +200,25 @@
 	<portrait_l entry="player" eye="sad" mouth="serious">
 	<portrait_r entry="jade" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			もう、オレのことなんか<end_line>
 			わからなくなったって<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			もう、わたしのことなんか<end_line>
-			わからなくなったって<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     No longer<end_line>
     recognizes me<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			もう、わたしのことなんか<end_line>
+			わからなくなったって<three_dots><end_line>
+		</sjis>
+    <ascii>
+    No longer<end_line>
+    recognizes me<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -256,24 +264,29 @@
 	<portrait_l entry="player" eye="sad" mouth="yell">
 	<portrait_r entry="jade" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			でも<three_dots><end_line>
 			<partner>にはもう<end_line>
 			オレの声も届かないんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも<three_dots><end_line>
-			<partner>にはもう<end_line>
-			わたしの声も届かないんだよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     But what should I do!?<end_line>
     <partner> can't hear<end_line>
     my voice anymore<three_dots>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でも<three_dots><end_line>
+			<partner>にはもう<end_line>
+			わたしの声も届かないんだよ！<end_line>
+		</sjis>
+    <ascii>
+    But what should I do!?<end_line>
+    <partner> can't hear<end_line>
+    my voice anymore<three_dots>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -390,22 +403,27 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			こいっ！　<partner>！<end_line>
 			お前と鍛えたこの武器で<end_line>
 			今すぐ目覚めさせてやるぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			きなさい！　<partner>！<end_line>
-			あなたと鍛えたこの武器で<end_line>
-			今すぐ目覚めさせてあげる！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Come! <partner>!<end_line>
     I'll bring you back right now<end_line>
     with the weapons we forged together!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			きなさい！　<partner>！<end_line>
+			あなたと鍛えたこの武器で<end_line>
+			今すぐ目覚めさせてあげる！<end_line>
+		</sjis>
+    <ascii>
+    Come! <partner>!<end_line>
+    I'll bring you back right now<end_line>
+    with the weapons we forged together!<end_line>
+  </ascii>
+  </female>
 </dialogue>

--- a/Final Day/25684988_187ebfc.xml
+++ b/Final Day/25684988_187ebfc.xml
@@ -71,23 +71,27 @@
 	<portrait_l entry="player" eye="sad" mouth="yell">
 	<portrait_r entry="anise" eye="special" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そんな<three_dots><end_line>
 			忘れたなんて<end_line>
 			ウソだろ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    No<three_dots><end_line>
+    That's a lie, right, <partner>!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そんな<three_dots><end_line>
 			忘れたなんて<end_line>
 			ウソでしょ、<partner>！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     No<three_dots><end_line>
     That's a lie, right, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
@@ -103,7 +107,7 @@
 	<info box="left">
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			くっそ<three_dots><end_line>
 			オレは、どうすればいいんだ<three_dots><end_line>
 		</sjis>
@@ -111,9 +115,9 @@
       Shit<three_dots><end_line>
       What should I do<three_dots><end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			それじゃあ<three_dots><end_line>
 			わたしは、どうすればいいのよ<three_dots><end_line>
 		</sjis>
@@ -121,7 +125,7 @@
       Then<three_dots><end_line>
       What should I do<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
@@ -198,21 +202,25 @@
 	<portrait_l entry="player" eye="sad" mouth="serious">
 	<portrait_r entry="tier" eye="surprised" mouth="stressed">
 	<male>
-		<sjis>
+    <sjis>
 			もう、オレのことなんか<end_line>
 			わからなくなったって<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			もう、わたしのことなんか<end_line>
-			わからなくなったって<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     No longer<end_line>
     recognizes me<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			もう、わたしのことなんか<end_line>
+			わからなくなったって<three_dots><end_line>
+		</sjis>
+    <ascii>
+    No longer<end_line>
+    recognizes me<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -260,24 +268,29 @@
 	<portrait_l entry="player" eye="sad" mouth="stressed">
 	<portrait_r entry="tier" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			でも<three_dots><end_line>
 			<partner>にはもう<end_line>
 			オレの声も届かないんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも<three_dots><end_line>
-			<partner>にはもう<end_line>
-			わたしの声も届かないんだよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     But what should I do!?<end_line>
     <partner> can't hear<end_line>
     my voice anymore<three_dots>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でも<three_dots><end_line>
+			<partner>にはもう<end_line>
+			わたしの声も届かないんだよ！<end_line>
+		</sjis>
+    <ascii>
+    But what should I do!?<end_line>
+    <partner> can't hear<end_line>
+    my voice anymore<three_dots>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -383,22 +396,27 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			こいっ！　<partner>！<end_line>
 			お前と鍛えたこの武器で<end_line>
 			今すぐ目覚めさせてやるぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			きなさい！　<partner>！<end_line>
-			あなたと鍛えたこの武器で<end_line>
-			今すぐ目覚めさせてあげる！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Come! <partner>!<end_line>
     I'll bring you back right now<end_line>
     with the weapons we forged together!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			きなさい！　<partner>！<end_line>
+			あなたと鍛えたこの武器で<end_line>
+			今すぐ目覚めさせてあげる！<end_line>
+		</sjis>
+    <ascii>
+    Come! <partner>!<end_line>
+    I'll bring you back right now<end_line>
+    with the weapons we forged together!<end_line>
+  </ascii>
+  </female>
 </dialogue>

--- a/Final Day/25719628_188734c.xml
+++ b/Final Day/25719628_188734c.xml
@@ -49,144 +49,174 @@
 	<portrait_l entry="player" eye="neutral_blush" mouth="talk">
 	<portrait_r entry="tier" eye="surprised_blush" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			聞こえたよ<three_dots><end_line>
 			みんなの声<three_dots>、それから<three_dots><end_line>
 			君の声<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			聞こえたよ<three_dots><end_line>
-			みんなの声<three_dots>、それから<three_dots><end_line>
-			あなたの声<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I heard it<three_dots><end_line>
     Everyone's voices<three_dots> And then<three_dots><end_line>
     Yours<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			聞こえたよ<three_dots><end_line>
+			みんなの声<three_dots>、それから<three_dots><end_line>
+			あなたの声<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I heard it<three_dots><end_line>
+    Everyone's voices<three_dots> And then<three_dots><end_line>
+    Yours<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="neutral_blush" mouth="talk">
 	<portrait_r entry="tier" eye="surprised_blush" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			聞こえたよ<three_dots><end_line>
 			みんなの声<three_dots>、それから<three_dots><end_line>
 			<partner>の声<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			聞こえたよ<three_dots><end_line>
-			みんなの声<three_dots>、それから<three_dots><end_line>
-			あなたの声<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I heard it<three_dots><end_line>
     Everyone's voices<three_dots> And then<three_dots><end_line>
     Yours<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			聞こえたよ<three_dots><end_line>
+			みんなの声<three_dots>、それから<three_dots><end_line>
+			あなたの声<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I heard it<three_dots><end_line>
+    Everyone's voices<three_dots> And then<three_dots><end_line>
+    Yours<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="neutral_blush" mouth="talk">
 	<portrait_r entry="tier" eye="surprised_blush" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			聞こえたよ<three_dots><end_line>
 			みんなの声<three_dots>、それから<three_dots><end_line>
 			親方の声<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			聞こえたよ<three_dots><end_line>
-			みんなの声<three_dots>、それから<three_dots><end_line>
-			親方の声<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I heard it<three_dots><end_line>
     Everyone's voices<three_dots> And then<three_dots><end_line>
     Master's<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			聞こえたよ<three_dots><end_line>
+			みんなの声<three_dots>、それから<three_dots><end_line>
+			親方の声<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I heard it<three_dots><end_line>
+    Everyone's voices<three_dots> And then<three_dots><end_line>
+    Master's<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="neutral_blush" mouth="talk">
 	<portrait_r entry="tier" eye="surprised_blush" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			聞こえたよ<three_dots><end_line>
 			みんなの声<three_dots>、それから<three_dots><end_line>
 			お前の声<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			聞こえたよ<three_dots><end_line>
-			みんなの声<three_dots>、それから<three_dots><end_line>
-			あなたの声<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I heard it<three_dots><end_line>
     Everyone's voices<three_dots> And then<three_dots><end_line>
     Yours<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			聞こえたよ<three_dots><end_line>
+			みんなの声<three_dots>、それから<three_dots><end_line>
+			あなたの声<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I heard it<three_dots><end_line>
+    Everyone's voices<three_dots> And then<three_dots><end_line>
+    Yours<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="neutral_blush" mouth="talk">
 	<portrait_r entry="tier" eye="surprised_blush" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			聞こえたよ<three_dots><end_line>
 			みんなの声<three_dots>、それから<three_dots><end_line>
 			アニキの声<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			聞こえたよ<three_dots><end_line>
-			みんなの声<three_dots>、それから<three_dots><end_line>
-			アニキの声<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I heard it<three_dots><end_line>
     Everyone's voices<three_dots> And then<three_dots><end_line>
     Brother's<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			聞こえたよ<three_dots><end_line>
+			みんなの声<three_dots>、それから<three_dots><end_line>
+			アニキの声<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I heard it<three_dots><end_line>
+    Everyone's voices<three_dots> And then<three_dots><end_line>
+    Brother's<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="neutral_blush" mouth="talk">
 	<portrait_r entry="tier" eye="surprised_blush" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			聞こえたよ<three_dots><end_line>
 			みんなの声<three_dots>、それから<three_dots><end_line>
 			ティエの声<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			聞こえたよ<three_dots><end_line>
-			みんなの声<three_dots>、それから<three_dots><end_line>
-			ティエの声<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I heard it<three_dots><end_line>
     Everyone's voices<three_dots> And then<three_dots><end_line>
     Tier's<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			聞こえたよ<three_dots><end_line>
+			みんなの声<three_dots>、それから<three_dots><end_line>
+			ティエの声<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I heard it<three_dots><end_line>
+    Everyone's voices<three_dots> And then<three_dots><end_line>
+    Tier's<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">

--- a/Final Day/25953596_18c053c.xml
+++ b/Final Day/25953596_18c053c.xml
@@ -18,24 +18,29 @@
 	<portrait_l entry="murno" eye="sad" mouth="talk">
 	<portrait_r entry="player" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			ホント<end_line>
 			オレたちが悪いことしたワケじゃ<end_line>
 			ないってのに<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ホント<end_line>
-			わたしたちが悪いことしたワケじゃ<end_line>
-			ないってのに<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Really.<end_line>
     It's not like it's our fault<end_line>
     any of this happened<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ホント<end_line>
+			わたしたちが悪いことしたワケじゃ<end_line>
+			ないってのに<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Really.<end_line>
+    It's not like it's our fault<end_line>
+    any of this happened<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -137,21 +142,25 @@
 	<portrait_l entry="murno" eye="sad" mouth="neutral">
 	<portrait_r entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			それにあの魔石のおかげで<end_line>
 			オレはミューノに会えたんだし<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			それにあの魔石のおかげで<end_line>
-			わたしはミューノに会えたんだし<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     And its because of the<end_line>
     Demon Stone that I met you, Murno<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			それにあの魔石のおかげで<end_line>
+			わたしはミューノに会えたんだし<three_dots><end_line>
+		</sjis>
+    <ascii>
+    And its because of the<end_line>
+    Demon Stone that I met you, Murno<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -184,24 +193,29 @@
 	<portrait_l entry="murno" eye="decided" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			うん、がんばろう<end_line>
 			オレももっともっと強くなる<end_line>
 			いっしょにがんばろう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん、がんばろう<end_line>
-			わたしももっともっと強くなる<end_line>
-			いっしょにがんばろう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah, you can do it!<end_line>
     I'm still getting stronger too.<end_line>
     Let's work at it together.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん、がんばろう<end_line>
+			わたしももっともっと強くなる<end_line>
+			いっしょにがんばろう<end_line>
+		</sjis>
+    <ascii>
+    Yeah, you can do it!<end_line>
+    I'm still getting stronger too.<end_line>
+    Let's work at it together.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -223,24 +237,29 @@
 	<portrait_l entry="murno" eye="decided" mouth="talk">
 	<portrait_r entry="player" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			じゃあオレだって<end_line>
 			毎日ミューノを思いだして<end_line>
 			それ以上がんばる！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			じゃあわたしだって<end_line>
-			毎日ミューノを思いだして<end_line>
-			それ以上がんばる！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Me too, I'll think about<end_line>
     you every day Murno,<end_line>
     and try even harder than that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			じゃあわたしだって<end_line>
+			毎日ミューノを思いだして<end_line>
+			それ以上がんばる！<end_line>
+		</sjis>
+    <ascii>
+    Me too, I'll think about<end_line>
+    you every day Murno,<end_line>
+    and try even harder than that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -260,21 +279,25 @@
 	<portrait_l entry="murno" eye="happy" mouth="neutral">
 	<portrait_r entry="player" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ<end_line>
 			ミューノだって<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ<end_line>
-			ミューノだって<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey,<end_line>
     aren't you the same?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ<end_line>
+			ミューノだって<end_line>
+		</sjis>
+    <ascii>
+    Hey,<end_line>
+    aren't you the same?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">

--- a/Final Day/25955020_18c0acc.xml
+++ b/Final Day/25955020_18c0acc.xml
@@ -4,24 +4,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノと出会って<end_line>
 			<partner>の召喚石を拾って<end_line>
 			ホントに色んなコトがあったな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノと出会って<end_line>
-			あなたの召喚石を拾って<end_line>
-			ホントに色んなコトがあったね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     A lot's happened since I<end_line>
     met Murno and picked<end_line>
     up your Summonstone.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノと出会って<end_line>
+			あなたの召喚石を拾って<end_line>
+			ホントに色んなコトがあったね<end_line>
+		</sjis>
+    <ascii>
+    A lot's happened since I<end_line>
+    met Murno and picked<end_line>
+    up your Summonstone.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -45,24 +50,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、そんなこと<three_dots><end_line>
 			<three_dots><end_line>
 			あるかな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、そんなこと<three_dots><end_line>
-			<three_dots><end_line>
-			あるかな<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey, that<three_dots><end_line>
     <three_dots><end_line>
     Is true.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、そんなこと<three_dots><end_line>
+			<three_dots><end_line>
+			あるかな<end_line>
+		</sjis>
+    <ascii>
+    Hey, that<three_dots><end_line>
+    <three_dots><end_line>
+    Is true.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -118,24 +128,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			あはは<three_dots>、ズバリ言うなぁ<end_line>
 			でも、そうだな！<end_line>
 			これからもよろしくたのむぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あはは<three_dots>、ズバリ言うねぇ<end_line>
-			でも、そうだね！<end_line>
-			これからもよろしくたのむよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ahaha<three_dots> How blunt.<end_line>
     But you're right!<end_line>
     Let's continue to work hard!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あはは<three_dots>、ズバリ言うねぇ<end_line>
+			でも、そうだね！<end_line>
+			これからもよろしくたのむよ！<end_line>
+		</sjis>
+    <ascii>
+    Ahaha<three_dots> How blunt.<end_line>
+    But you're right!<end_line>
+    Let's continue to work hard!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -187,24 +202,29 @@
 	<portrait_l entry="partner" eye="surprised" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そ、そうか、気合いだな<three_dots><end_line>
 			わかったぜ！<end_line>
 			そういうときはアレだな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そ、そうか、気合いだね<three_dots><end_line>
-			わかった！<end_line>
-			そういうときはアレだね！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     R-right<three_dots> It's all about spirit<three_dots><end_line>
     Okay!<end_line>
     This is the perfect time for that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そ、そうか、気合いだね<three_dots><end_line>
+			わかった！<end_line>
+			そういうときはアレだね！<end_line>
+		</sjis>
+    <ascii>
+    R-right<three_dots> It's all about spirit<three_dots><end_line>
+    Okay!<end_line>
+    This is the perfect time for that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -274,24 +294,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ありがとう、<partner><end_line>
 			いっしょに叫んでくれるなんて<end_line>
 			すっごくうれしいぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ありがとう、<partner><end_line>
-			いっしょに叫んでくれるなんて<end_line>
-			すっごいうれしいよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Thanks, <partner>!<end_line>
     I'm so happy you<end_line>
     joined me this time!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ありがとう、<partner><end_line>
+			いっしょに叫んでくれるなんて<end_line>
+			すっごいうれしいよ！<end_line>
+		</sjis>
+    <ascii>
+    Thanks, <partner>!<end_line>
+    I'm so happy you<end_line>
+    joined me this time!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -311,24 +336,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			もちろん！<end_line>
 			燃えてきたぜ！<end_line>
 			よっしゃ、がんばるぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			もちろん！<end_line>
-			燃えてくるわ！<end_line>
-			よぉし、がんばるぞ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Of course!<end_line>
     I'm all fired up!<end_line>
     Alright, let's work hard!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			もちろん！<end_line>
+			燃えてくるわ！<end_line>
+			よぉし、がんばるぞ！<end_line>
+		</sjis>
+    <ascii>
+    Of course!<end_line>
+    I'm all fired up!<end_line>
+    Alright, let's work hard!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -348,24 +378,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノと出会って<end_line>
 			<partner>の召喚石を拾って<end_line>
 			ホントに色んなコトがあったな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノと出会って<end_line>
-			あなたの召喚石を拾って<end_line>
-			ホントに色んなコトがあったね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     A lot's happened since I<end_line>
     met Murno and picked<end_line>
     up your Summonstone.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノと出会って<end_line>
+			あなたの召喚石を拾って<end_line>
+			ホントに色んなコトがあったね<end_line>
+		</sjis>
+    <ascii>
+    A lot's happened since I<end_line>
+    met Murno and picked<end_line>
+    up your Summonstone.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -431,24 +466,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なに言ってるんだよ、<partner><end_line>
 			ホントはオレがいなくたって<end_line>
 			自分が助けたとか思ってるだろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なに言ってるのよ、<partner><end_line>
-			ホントはわたしがいなくたって<end_line>
-			自分が助けたとか思ってるでしょ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What's that?<end_line>
     You're thinking could've done<end_line>
     it without me too, right?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なに言ってるのよ、<partner><end_line>
+			ホントはわたしがいなくたって<end_line>
+			自分が助けたとか思ってるでしょ？<end_line>
+		</sjis>
+    <ascii>
+    What's that?<end_line>
+    You're thinking could've done<end_line>
+    it without me too, right?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -572,24 +612,29 @@
 	<portrait_l entry="partner" eye="decided" mouth="yell">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そ、そうか、気合いだな<three_dots><end_line>
 			わかったぜ！<end_line>
 			そういうときはアレだな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そ、そうか、気合いだね<three_dots><end_line>
-			わかった！<end_line>
-			そういうときはアレだね！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     R-right<three_dots> It's all about spirit<three_dots><end_line>
     Okay!<end_line>
     This is the perfect time for that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そ、そうか、気合いだね<three_dots><end_line>
+			わかった！<end_line>
+			そういうときはアレだね！<end_line>
+		</sjis>
+    <ascii>
+    R-right<three_dots> It's all about spirit<three_dots><end_line>
+    Okay!<end_line>
+    This is the perfect time for that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -659,24 +704,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="happy" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			ありがとう、<partner><end_line>
 			いっしょに叫んでくれるなんて<end_line>
 			すっごくうれしいぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ありがとう、<partner><end_line>
-			いっしょに叫んでくれるなんて<end_line>
-			すっごいうれしいよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Thanks, <partner>!<end_line>
     I'm so happy you<end_line>
     joined me this time!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ありがとう、<partner><end_line>
+			いっしょに叫んでくれるなんて<end_line>
+			すっごいうれしいよ！<end_line>
+		</sjis>
+    <ascii>
+    Thanks, <partner>!<end_line>
+    I'm so happy you<end_line>
+    joined me this time!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -700,24 +750,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノと出会って<end_line>
 			<partner>の召喚石を拾って<end_line>
 			ホントに色んなコトがあったな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノと出会って<end_line>
-			あなたの召喚石を拾って<end_line>
-			ホントに色んなコトがあったね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     A lot's happened since I<end_line>
     met Murno and picked<end_line>
     up your Summonstone.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノと出会って<end_line>
+			あなたの召喚石を拾って<end_line>
+			ホントに色んなコトがあったね<end_line>
+		</sjis>
+    <ascii>
+    A lot's happened since I<end_line>
+    met Murno and picked<end_line>
+    up your Summonstone.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -741,24 +796,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="talk">
 	<portrait_r entry="player" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、そんなこと<three_dots><end_line>
 			<three_dots><end_line>
 			あるかな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、そんなこと<three_dots><end_line>
-			<three_dots><end_line>
-			あるかな<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey, that<three_dots><end_line>
     <three_dots><end_line>
     Is true.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、そんなこと<three_dots><end_line>
+			<three_dots><end_line>
+			あるかな<end_line>
+		</sjis>
+    <ascii>
+    Hey, that<three_dots><end_line>
+    <three_dots><end_line>
+    Is true.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -794,24 +854,29 @@
 	<portrait_l entry="partner" eye="sad" mouth="tense">
 	<portrait_r entry="player" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、それ<end_line>
 			少しぐらい良いことだって<end_line>
 			あっただろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ<end_line>
-			少しぐらい良いことだって<end_line>
-			あったでしょ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Come on,<end_line>
     there has to be something good<end_line>
     worth mentioning, right?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ<end_line>
+			少しぐらい良いことだって<end_line>
+			あったでしょ？<end_line>
+		</sjis>
+    <ascii>
+    Come on,<end_line>
+    there has to be something good<end_line>
+    worth mentioning, right?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -833,24 +898,29 @@
 	<portrait_l entry="partner" eye="decided" mouth="serious">
 	<portrait_r entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ！　オレはあるぞ！<end_line>
 			<partner>がいてくれたおかげで<end_line>
 			スゴイ武器だってつくれたし<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ！　わたしはあるよ！<end_line>
-			<partner>がいてくれたおかげで<end_line>
-			スゴイ武器だってつくれたし<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, I have one!<end_line>
     Thanks to you, I was able to make<end_line>
     some really amazing weapons!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ！　わたしはあるよ！<end_line>
+			<partner>がいてくれたおかげで<end_line>
+			スゴイ武器だってつくれたし<end_line>
+		</sjis>
+    <ascii>
+    Well, I have one!<end_line>
+    Thanks to you, I was able to make<end_line>
+    some really amazing weapons!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -900,24 +970,29 @@
 	<portrait_l entry="partner" eye="surprised_blush" mouth="stressed">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			どうだ、<partner>！<end_line>
 			お前もいっこくらい良いこと<end_line>
 			思いつくだろ？　言えよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			どう、<partner>！<end_line>
-			あなたもいっこくらい良いこと<end_line>
-			思いつくでしょ？　言って！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     How's that, <partner>!<end_line>
     You must have one good<end_line>
     thing to say! Speak up!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			どう、<partner>！<end_line>
+			あなたもいっこくらい良いこと<end_line>
+			思いつくでしょ？　言って！<end_line>
+		</sjis>
+    <ascii>
+    How's that, <partner>!<end_line>
+    You must have one good<end_line>
+    thing to say! Speak up!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -939,18 +1014,21 @@
 	<portrait_l entry="partner" eye="decided_blush" mouth="serious">
 	<portrait_r entry="player" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			言えよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			言って！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Say it!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			言って！<end_line>
+		</sjis>
+    <ascii>
+    Say it!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -990,21 +1068,25 @@
 	<portrait_l entry="partner" eye="decided_blush" mouth="tense">
 	<portrait_r entry="player" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			また、なに言ってんだよ<end_line>
 			ホントは自分で守りたかったくせに<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			また、なに言ってんのよ<end_line>
-			ホントは自分で守りたかったくせに<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Oh, come on. You really wanted<end_line>
     to do that yourself, right?.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			また、なに言ってんのよ<end_line>
+			ホントは自分で守りたかったくせに<end_line>
+		</sjis>
+    <ascii>
+    Oh, come on. You really wanted<end_line>
+    to do that yourself, right?.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1028,24 +1110,29 @@
 	<portrait_l entry="partner" eye="surprised_blush" mouth="yell">
 	<portrait_r entry="player" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			あはは<three_dots><end_line>
 			ごめんごめん<end_line>
 			そんなに怒るなよ～<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あはは<three_dots><end_line>
-			ごめんごめん<end_line>
-			そんなに怒らないでよ～<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ahaha<three_dots><end_line>
     Sorry, sorry.<end_line>
     Don't be so angry~<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あはは<three_dots><end_line>
+			ごめんごめん<end_line>
+			そんなに怒らないでよ～<end_line>
+		</sjis>
+    <ascii>
+    Ahaha<three_dots><end_line>
+    Sorry, sorry.<end_line>
+    Don't be so angry~<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1069,21 +1156,25 @@
 	<portrait_l entry="partner" eye="decided" mouth="serious">
 	<portrait_r entry="player" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			１００万バームって言ってもな～<end_line>
 			やっぱムリだろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			１００万バームって言ってもね～<end_line>
-			やっぱムリでしょ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     About that~<end_line>
     Isn't that impossible?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			１００万バームって言ってもね～<end_line>
+			やっぱムリでしょ？<end_line>
+		</sjis>
+    <ascii>
+    About that~<end_line>
+    Isn't that impossible?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1107,24 +1198,29 @@
 	<portrait_l entry="partner" eye="special" mouth="yell">
 	<portrait_r entry="player" eye="surprised" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そ、そうか<three_dots><end_line>
 			とりあえずは気合い、かな<three_dots><end_line>
 			そういうときはアレだな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そ、そうね<three_dots><end_line>
-			とりあえずは気合い、かな<three_dots><end_line>
-			そういうときはアレだね！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     R-right<three_dots><end_line>
     We'll start with motivation<three_dots><end_line>
     This is the perfect time for that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そ、そうね<three_dots><end_line>
+			とりあえずは気合い、かな<three_dots><end_line>
+			そういうときはアレだね！<end_line>
+		</sjis>
+    <ascii>
+    R-right<three_dots><end_line>
+    We'll start with motivation<three_dots><end_line>
+    This is the perfect time for that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1194,24 +1290,29 @@
 	<portrait_l entry="partner" eye="neutral_blush" mouth="neutral">
 	<portrait_r entry="player" eye="happy" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			まさか<partner>がいっしょに<end_line>
 			叫んでくれるなんて、ユメみたいだ！<end_line>
 			すっごくうれしいぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			まさか<partner>がいっしょに<end_line>
-			叫んでくれるなんて、ユメみたい！<end_line>
-			すっごいうれしいよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I never thought you'd<end_line>
     join me, <partner>!<end_line>
     This is awesome!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			まさか<partner>がいっしょに<end_line>
+			叫んでくれるなんて、ユメみたい！<end_line>
+			すっごいうれしいよ！<end_line>
+		</sjis>
+    <ascii>
+    I never thought you'd<end_line>
+    join me, <partner>!<end_line>
+    This is awesome!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1260,24 +1361,29 @@
 	<info box="right">
 	<portrait_r name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノと出会って<end_line>
 			<partner>の召喚石を拾って<end_line>
 			ホントに色んなコトがあったな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノと出会って<end_line>
-			あなたの召喚石を拾って<end_line>
-			ホントに色んなコトがあったね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     A lot's happened since I<end_line>
     met Murno and picked<end_line>
     up your Summonstone.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノと出会って<end_line>
+			あなたの召喚石を拾って<end_line>
+			ホントに色んなコトがあったね<end_line>
+		</sjis>
+    <ascii>
+    A lot's happened since I<end_line>
+    met Murno and picked<end_line>
+    up your Summonstone.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1299,24 +1405,29 @@
 	<info box="right">
 	<portrait_r name="player">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、そんなこと<three_dots><end_line>
 			<three_dots><end_line>
 			あるかな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、そんなこと<three_dots><end_line>
-			<three_dots><end_line>
-			あるかな<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey, that<three_dots><end_line>
     <three_dots><end_line>
     Is true.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、そんなこと<three_dots><end_line>
+			<three_dots><end_line>
+			あるかな<end_line>
+		</sjis>
+    <ascii>
+    Hey, that<three_dots><end_line>
+    <three_dots><end_line>
+    Is true.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1442,24 +1553,29 @@
 	<info box="right">
 	<portrait_r name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだね<three_dots><end_line>
 			１００万バームをかせがないと<end_line>
 			ならないしな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<three_dots><end_line>
-			１００万バームをかせがないと<end_line>
-			ならないし<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
     We still have to earn<end_line>
     one million boam<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<three_dots><end_line>
+			１００万バームをかせがないと<end_line>
+			ならないし<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Right<three_dots><end_line>
+    We still have to earn<end_line>
+    one million boam<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1481,24 +1597,29 @@
 	<info box="right">
 	<portrait_r name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そ、そうか、気合いだな<three_dots><end_line>
 			わかったぜ！<end_line>
 			そういうときはアレだな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そ、そうか、気合いだね<three_dots><end_line>
-			わかった！<end_line>
-			そういうときはアレだね！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     R-right, it's all about spirit<three_dots><end_line>
     Okay!<end_line>
     This is the perfect time for that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そ、そうか、気合いだね<three_dots><end_line>
+			わかった！<end_line>
+			そういうときはアレだね！<end_line>
+		</sjis>
+    <ascii>
+    R-right, it's all about spirit<three_dots><end_line>
+    Okay!<end_line>
+    This is the perfect time for that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1564,24 +1685,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="happy" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			ありがとう、<partner><end_line>
 			いっしょに叫んでくれるなんて<end_line>
 			すっごくうれしいぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ありがとう、<partner><end_line>
-			いっしょに叫んでくれるなんて<end_line>
-			すっごいうれしいよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Thanks, <partner>!<end_line>
     I'm so happy you<end_line>
     joined me this time!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ありがとう、<partner><end_line>
+			いっしょに叫んでくれるなんて<end_line>
+			すっごいうれしいよ！<end_line>
+		</sjis>
+    <ascii>
+    Thanks, <partner>!<end_line>
+    I'm so happy you<end_line>
+    joined me this time!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1605,23 +1731,27 @@
 	<portrait_l entry="partner" eye="happy" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			これからもふたりで<end_line>
 			がんばろうぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Right.<end_line>
+    Let's do our best!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<end_line>
 			これからもふたりで<end_line>
 			がんばろう<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right.<end_line>
     Let's do our best!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">

--- a/Final Day/25960652_18c20cc.xml
+++ b/Final Day/25960652_18c20cc.xml
@@ -3,21 +3,25 @@
 	<portrait_l entry="lemmy" eye="serious" mouth="talk">
 	<portrait_r entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			へぇ<three_dots><end_line>
 			こんなとこ、あがれるんだな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			へぇ<three_dots><end_line>
-			こんなとこ、あがれるんだね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Huh<three_dots><end_line>
     I didn't know you could get up here.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			へぇ<three_dots><end_line>
+			こんなとこ、あがれるんだね<end_line>
+		</sjis>
+    <ascii>
+    Huh<three_dots><end_line>
+    I didn't know you could get up here.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -35,18 +39,21 @@
 	<portrait_l entry="lemmy" eye="serious" mouth="talk">
 	<portrait_r entry="player" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			で、話ってなんだよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			で、話ってなによ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So what did you want to talk about?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			で、話ってなによ<end_line>
+		</sjis>
+    <ascii>
+    So what did you want to talk about?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -96,21 +103,25 @@
 	<portrait_l entry="lemmy" eye="decided_blush" mouth="tense">
 	<portrait_r entry="player" eye="happy" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			オレにお礼を言うのは<end_line>
 			そんなに恥ずかしいことなのか<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしにお礼を言うのは<end_line>
-			そんなに恥ずかしいことなのね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Is it really<end_line>
     that embarrassing<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしにお礼を言うのは<end_line>
+			そんなに恥ずかしいことなのね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Is it really<end_line>
+    that embarrassing<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -130,24 +141,29 @@
 	<portrait_l entry="lemmy" eye="surprised" mouth="stressed">
 	<portrait_r entry="player" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			もういいよ<three_dots><end_line>
 			けど、なんだよ<end_line>
 			お礼って？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			もういいよ<three_dots><end_line>
-			けど、なによ<end_line>
-			お礼って？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright I guess<three_dots><end_line>
     But thanks for<end_line>
     what, exactly?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			もういいよ<three_dots><end_line>
+			けど、なによ<end_line>
+			お礼って？<end_line>
+		</sjis>
+    <ascii>
+    Alright I guess<three_dots><end_line>
+    But thanks for<end_line>
+    what, exactly?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -184,24 +200,29 @@
 	<portrait_l entry="lemmy" eye="serious" mouth="tense">
 	<portrait_r entry="player" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			そっか！　よかったな！<end_line>
 			これで悩みもなくなったから<end_line>
 			オレと勝負を<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そっか！　よかったね！<end_line>
-			これで悩みもなくなったから<end_line>
-			わたしと勝負を<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Oh, right! That's great!<end_line>
     So no more worries then?<end_line>
     About our match<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そっか！　よかったね！<end_line>
+			これで悩みもなくなったから<end_line>
+			わたしと勝負を<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Oh, right! That's great!<end_line>
+    So no more worries then?<end_line>
+    About our match<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <bigtext>
 	<info box="left" effect="big">
@@ -219,21 +240,25 @@
 	<portrait_l entry="lemmy" eye="decided" mouth="yell">
 	<portrait_r entry="player" eye="sad" mouth="stressed">
 	<male>
-		<sjis>
+    <sjis>
 			え～！？<end_line>
 			まだなんか残ってるのかよ～<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			え～！？<end_line>
-			まだなんか残ってるの～？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ehh!?<end_line>
     What else could there be?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			え～！？<end_line>
+			まだなんか残ってるの～？<end_line>
+		</sjis>
+    <ascii>
+    Ehh!?<end_line>
+    What else could there be?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -255,21 +280,25 @@
 	<portrait_l entry="lemmy" eye="neutral_blush" mouth="neutral">
 	<portrait_r entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ<end_line>
 			そんなこと<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ<end_line>
-			そんなこと<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Huh,<end_line>
     you don't need to<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ<end_line>
+			そんなこと<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Huh,<end_line>
+    you don't need to<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <bigtext>
 	<info box="left" effect="big">
@@ -320,15 +349,15 @@
 	<portrait_l entry="lemmy" eye="decided" mouth="tense">
 	<portrait_r entry="player" eye="happy" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			よかったな、レミィ<end_line>
 		</sjis>
     <ascii>
       And it's settled.<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			どういたしまして<end_line>
 			よかったね、レミィ<end_line>
 		</sjis>
@@ -336,7 +365,7 @@
       You're welcome.<end_line>
       And it's settled.<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -358,21 +387,25 @@
 	<portrait_l entry="lemmy" eye="decided" mouth="talk">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだと<end_line>
 			オレだって<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ！<end_line>
-			わたしだって負けないから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Heh!<end_line>
     Neither will I!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ！<end_line>
+			わたしだって負けないから！<end_line>
+		</sjis>
+    <ascii>
+    Heh!<end_line>
+    Neither will I!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">

--- a/Final Day/25962140_18c269c.xml
+++ b/Final Day/25962140_18c269c.xml
@@ -87,21 +87,21 @@
 	<portrait_l entry="jade" eye="decided" mouth="neutral">
 	<portrait_r entry="player" eye="surprised" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			この世界を救った男と言っても<end_line>
 		</sjis>
     <ascii>
       The man who saved Lindbaum,<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			この世界を救った女と言っても<end_line>
 		</sjis>
     <ascii>
       The woman who saved Lindbaum,<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -134,21 +134,25 @@
 	<portrait_l entry="jade" eye="decided" mouth="serious">
 	<portrait_r entry="player" eye="happy_blush" mouth="stressed">
 	<male>
-		<sjis>
+    <sjis>
 			そんな、アニキ、大げさな<three_dots><end_line>
 			オレが世界を救っただなんて<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そんな、アニキ、大げさな<three_dots><end_line>
-			わたしが世界を救っただなんて<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Brother, you're exaggerating<three_dots><end_line>
     Me saving the world<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そんな、アニキ、大げさな<three_dots><end_line>
+			わたしが世界を救っただなんて<end_line>
+		</sjis>
+    <ascii>
+    Brother, you're exaggerating<three_dots><end_line>
+    Me saving the world<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -183,7 +187,7 @@
 	<portrait_l entry="jade" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="neutral_blush" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			ああ、お前はたいした男だぜ<end_line>
 			今まではロブの弟子<end_line>
 			かわいい弟分とか思っていたが<three_dots><end_line>
@@ -193,9 +197,9 @@
       As Rob's apprentice, you were like<end_line>
       a little brother, but now<three_dots><end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			ああ、お前はたいした女だぜ<end_line>
 			今まではロブの弟子<end_line>
 			かわいい妹分とか思っていたが<three_dots><end_line>
@@ -205,7 +209,7 @@
       As Rob's apprentice, you were like<end_line>
       a little sister, but now<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -236,7 +240,7 @@
 	<portrait_l entry="jade" eye="decided" mouth="neutral">
 	<portrait_r entry="player" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			言っただろ？<end_line>
 			お前はもう弟分じゃないってな<end_line>
 			お前はもう立派な鍛冶師だ<three_dots><end_line>
@@ -246,9 +250,9 @@
       little brother anymore.<end_line>
       You're a Craftknight<three_dots><end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			言っただろ？<end_line>
 			お前はもう妹分じゃないってな<end_line>
 			お前はもう立派な鍛冶師だ<three_dots><end_line>
@@ -258,7 +262,7 @@
       little sister anymore.<end_line>
       You're a Craftknight<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -280,24 +284,29 @@
 	<portrait_l entry="jade" eye="decided" mouth="talk">
 	<portrait_r entry="player" eye="surprised_blush" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			え<three_dots>、でも、そんな<three_dots><end_line>
 			アニキがアニキじゃなくなるなんて<three_dots><end_line>
 			オレ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			え<three_dots>、でも、そんな<three_dots><end_line>
-			アニキがアニキじゃなくなるなんて<three_dots><end_line>
-			わたし<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Eh<three_dots> But<three_dots><end_line>
     If Brother isn't Brother, then<three_dots><end_line>
     What do I<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			え<three_dots>、でも、そんな<three_dots><end_line>
+			アニキがアニキじゃなくなるなんて<three_dots><end_line>
+			わたし<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Eh<three_dots> But<three_dots><end_line>
+    If Brother isn't Brother, then<three_dots><end_line>
+    What do I<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -365,18 +374,21 @@
 	<portrait_l entry="jade" eye="decided" mouth="yell">
 	<portrait_r entry="player" eye="surprised" mouth="stressed">
 	<male>
-		<sjis>
+    <sjis>
 			世界を救った男？　上等だ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			世界を救った女？　上等だ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So you saved the world. Perfect!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			世界を救った女？　上等だ！<end_line>
+		</sjis>
+    <ascii>
+    So you saved the world. Perfect!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">

--- a/Final Day/25963900_18c2d7c.xml
+++ b/Final Day/25963900_18c2d7c.xml
@@ -31,24 +31,29 @@
 	<portrait_l entry="tier" eye="serious" mouth="tense">
 	<portrait_r entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			たしかに大変な目にはあったけど<end_line>
 			悪いことばっかじゃないぜ<end_line>
 			ほら<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			たしかに大変な目にはあったけど<end_line>
-			悪いことばっかじゃないよ<end_line>
-			ほら<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, it's not like<end_line>
     everything was that bad.<end_line>
     You know<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			たしかに大変な目にはあったけど<end_line>
+			悪いことばっかじゃないよ<end_line>
+			ほら<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Well, it's not like<end_line>
+    everything was that bad.<end_line>
+    You know<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -111,7 +116,7 @@
 	<portrait_l entry="tier" eye="special_blush" mouth="neutral">
 	<portrait_r entry="player" eye="happy" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			魔石の件も片付いたことだし<end_line>
 			これでほほえみ亭専属の<end_line>
 			鍛冶師としてしっかりと<three_dots><end_line>
@@ -121,9 +126,9 @@
       I'll have you continue on<end_line>
       as my exclusive Craftknight<three_dots><end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			魔石の件も片付いたことだし<end_line>
 			これでほほえみ亭専属の鍛冶師兼<end_line>
 			カンバン娘としてしっかりと<three_dots><end_line>
@@ -133,14 +138,14 @@
       I'll have you continue on <end_line>
       as my exclusive poster girl<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
 	<portrait_l entry="tier" eye="special_blush" mouth="neutral">
 	<portrait_r entry="player" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			でも、ほら、その前に<end_line>
 			親方との約束の１００万バームを<end_line>
 			なんとかしなきゃな<three_dots><end_line>
@@ -150,9 +155,9 @@
       about that 1 million boam<end_line>
       I promised Master<three_dots><end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			でも、ほら、その前に<end_line>
 			親方との約束の１００万バームを<end_line>
 			なんとかしなきゃ<three_dots><end_line>
@@ -162,7 +167,7 @@
       about that 1 million boam<end_line>
       I promised Master<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -208,18 +213,21 @@
 	<portrait_l entry="tier" eye="sad" mouth="stressed">
 	<portrait_r entry="player" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			スゴイことになってるんだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			スゴイことになってるのね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You're exaggerating<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			スゴイことになってるのね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    You're exaggerating<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -271,21 +279,25 @@
 	<portrait_l entry="tier" eye="decided" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			とにかくふたりでがんばろう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-			とにかくふたりでがんばろう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright then.<end_line>
     We'll do it together!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+			とにかくふたりでがんばろう！<end_line>
+		</sjis>
+    <ascii>
+    Alright then.<end_line>
+    We'll do it together!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">

--- a/Post Game/001_25723004_188807c.xml
+++ b/Post Game/001_25723004_188807c.xml
@@ -7,17 +7,21 @@
       さてと<end_line>
       今日も修行をはじめるか！<end_line>
     </sjis>
+    <ascii>
+    Well then,<end_line>
+    time for training!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       さてと<end_line>
       今日も修行をはじめよっか！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well then,<end_line>
     time for training!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -103,6 +107,11 @@
       召喚獣といっしょのレミィとも<end_line>
       勝負したいし、う～ん<three_dots><end_line>
     </sjis>
+    <ascii>
+    Hmm, I wanted to make a new weapon,<end_line>
+    and also have a match with Lemmy<end_line>
+    and his Summon Beast<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -110,12 +119,12 @@
       召喚獣といっしょのレミィとも<end_line>
       勝負したいし、う～ん<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hmm, I wanted to make a new weapon,<end_line>
     and also have a match with Lemmy<end_line>
     and his Summon Beast<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -190,17 +199,21 @@
       まあ、そうだな<end_line>
       いつも通り、楽しくいこうぜ！<end_line>
     </sjis>
+    <ascii>
+    I guess so.<end_line>
+    Well, let's have fun with it!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       まあ、そうだね<end_line>
       いつも通り、楽しくいこう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I guess so.<end_line>
     Well, let's have fun with it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Post Game/042_25725676_1888aec.xml
+++ b/Post Game/042_25725676_1888aec.xml
@@ -595,6 +595,11 @@
       これからもよろしくな<end_line>
       <partner><end_line>
     </sjis>
+    <ascii>
+    Well<three_dots> I suppose<end_line>
+    I'll be continuing to rely on you,<end_line>
+    <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -602,12 +607,12 @@
       これからもよろしくね<end_line>
       <partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well<three_dots> I suppose<end_line>
     I'll be continuing to rely on you,<end_line>
     <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">


### PR DESCRIPTION
These JE scripts have been autocorrected by FixMaleFemaleTranslation.py script.

It is maybe best to put them on separate branch, since I cannot promise, that some formatting( some possible wrong tabs/whitespace signs) is not broken after this autofix. But if nothing is wrong with it, then it can be merged. Let's discuss.