### PR TITLE
Autocorrected JEScripts by FixMaleFemaleTranslation.py

### DIFF
--- a/Translation/JE Scripts/Day 00/001_24891724_17bd14c.xml
+++ b/Translation/JE Scripts/Day 00/001_24891724_17bd14c.xml
@@ -9,7 +9,7 @@
     <ascii>
       Yes!<end_line>
       Victory!<end_line>
-    </ascii>	
+    </ascii>
   </male>
   <female>
     <sjis>
@@ -19,7 +19,7 @@
     <ascii>
       Yay!<end_line>
       I won!<end_line>
-    </ascii>	
+    </ascii>
   </female>
 </dialogue>
 <dialogue>
@@ -34,7 +34,7 @@
     You've grown strong<three_dots><end_line>
     I could feel your determination<end_line>
     with every blow.<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -44,7 +44,7 @@
   </sjis>
   <ascii>
     You were really cool, you know.<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -58,7 +58,7 @@
     <ascii>
       Ah<three_dots>! <end_line>
       Thank you, Sis V.E!<end_line>
-    </ascii>	
+    </ascii>
   </male>
   <female>
     <sjis>
@@ -79,7 +79,7 @@
   </sjis>
   <ascii>
     Well done, <player_name>!<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -167,7 +167,7 @@
     <ascii>
       Vee<three_dots><end_line>
       Are you crying?<end_line>
-    </ascii>		
+    </ascii>
   </male>
   <female>
     <sjis>
@@ -177,7 +177,7 @@
     <ascii>
       Vee is<three_dots><end_line>
       Crying?<end_line>
-    </ascii>		
+    </ascii>
   </female>
 </dialogue>
 <dialogue>
@@ -192,7 +192,7 @@
     When I found him,<end_line>
     it was already too late<three_dots><end_line>
     He asked me to give this to you<three_dots><end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -203,7 +203,7 @@
   <ascii>
     That's<three_dots><end_line>
     Master Rob's<three_dots>!<end_line>
-  </ascii>			
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -213,7 +213,7 @@
   </sjis>
   <ascii>
     No way<three_dots><end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -225,7 +225,7 @@
   <ascii>
     Rob was<three_dots><end_line>
     A Stray Summon Beast<three_dots><end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <bigtext>
   <info box="nobox">
@@ -234,7 +234,7 @@
   </sjis>
   <ascii>
     Killed him!<end_line>
-  </ascii>	
+  </ascii>
 </bigtext>
 <bigtext>
   <info box="nobox" effect="big">
@@ -243,7 +243,7 @@
   </sjis>
   <ascii>
     Masteer!!<end_line>
-  </ascii>	
+  </ascii>
 </bigtext>
 <dialogue>
   <info box="right">
@@ -253,7 +253,7 @@
   </sjis>
   <ascii>
     What's wrong, <player_nickname>?<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -265,7 +265,7 @@
   <ascii>
     Uh<three_dots><end_line>
     Huh<three_dots>?<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -280,7 +280,7 @@
     You were taking forever<three_dots><end_line>
     To think you were lazing<end_line>
     about at your favorite spot <three_dots><end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -291,7 +291,7 @@
   </sjis>
   <ascii>
     Aren't you easygoing<three_dots><end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -302,17 +302,21 @@
       やっぱ、ひるねをするには<end_line>
       ここに限るね<three_dots><end_line>
     </sjis>
+    <ascii>
+    Yeah, this is a great<end_line>
+    place to relax and<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       やっぱ、おひるねするには<end_line>
       ここに限るわ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, this is a great<end_line>
     place to relax and<three_dots><end_line>
-  </ascii>	
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -340,7 +344,7 @@
     Anyway, you were probably<end_line>
     having some idiotic dream,<end_line>
     weren't you?<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -351,7 +355,7 @@
   </sjis>
   <ascii>
     Like beating me in a fight?<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -366,7 +370,7 @@
     <ascii>
       Uwah!? Wow! <end_line>
       How'd you know, Sis Vee? <end_line>
-    </ascii>	
+    </ascii>
   </male>
   <female>
     <sjis>
@@ -377,7 +381,7 @@
     <ascii>
       Uwah!? Amazing! <end_line>
       How did you know, Sis Vee? <end_line>
-    </ascii>	
+    </ascii>
   </female>
 </dialogue>
 <dialogue>
@@ -392,8 +396,8 @@
     <ascii>
       <three_dots>Ouch!<end_line>
       What was that for!?<end_line>
-    </ascii>	
-  </male> 
+    </ascii>
+  </male>
   <female>
     <sjis>
       <three_dots>ったぁい！<end_line>
@@ -404,7 +408,7 @@
       <three_dots>Oww!<end_line>
       That's mean!<end_line>
       Why'd you do that!?<end_line>
-    </ascii>	
+    </ascii>
   </female>
 </dialogue>
 <dialogue>
@@ -421,7 +425,7 @@
       Sis Vee!?<end_line>
       I've told you to call me Master!<end_line>
       Master Vee!<end_line>
-    </ascii>	
+    </ascii>
   </male>
   <female>
     <sjis>
@@ -433,7 +437,7 @@
       Who's your sis!?<end_line>
       I've told you to call me Master!<end_line>
       Master Vee!<end_line>
-    </ascii>	
+    </ascii>
   </female>
 </dialogue>
 <dialogue>
@@ -448,7 +452,7 @@
     <ascii>
       Sorry, Master!<end_line>
       I just made a little mistake!<end_line>
-    </ascii>	
+    </ascii>
   </male>
   <female>
     <sjis>
@@ -459,7 +463,7 @@
     <ascii>
       I'm sorry, Master!<end_line>
       But it was just a little mistake!<end_line>
-    </ascii>	
+    </ascii>
   </female>
 </dialogue>
 <dialogue>
@@ -502,7 +506,7 @@
     </sjis>
     <ascii>
       I-I didn't mean it like that<three_dots>!<end_line>
-    </ascii>	
+    </ascii>
   </male>
   <female>
     <sjis>
@@ -537,7 +541,7 @@
   </sjis>
   <ascii>
     Th-That's right!<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -567,7 +571,7 @@
     I was summoned to this world as a<end_line>
     Craftknight's partner, even though<end_line>
     I'd never touched a forge before!<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -702,7 +706,7 @@
       Master's imagination is running<end_line>
       wild once again<three_dots><end_line>
       I better leave while I can.<end_line>
-    </ascii>	
+    </ascii>
   </female>
 </dialogue>
 <bigtext>
@@ -750,6 +754,11 @@
       お金だって、ほら！<end_line>
       買い物だってちゃんと！<end_line>
     </sjis>
+    <ascii>
+    Yeah, I already returned the sword!<end_line>
+    I got the money here, look!<end_line>
+    And I even did the shopping too!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -757,12 +766,12 @@
       お金だって、ほら！<end_line>
       お買い物だってちゃんと！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, I already returned the sword!<end_line>
     I got the money here, look!<end_line>
     And I even did the shopping too!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -789,6 +798,11 @@
       いやー、ひと仕事おわったんで<end_line>
       ちょっとひと休みしようと<three_dots><end_line>
     </sjis>
+    <ascii>
+    Hehehe<three_dots><end_line>
+    Well, after all that hard work,<end_line>
+    I deserve a break, right<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -796,12 +810,12 @@
       いやー、ひと仕事おわったんで<end_line>
       ちょっとひと休みしよっかなって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hehehe<three_dots><end_line>
     Well, after all that hard work,<end_line>
     I deserve a break, right<three_dots>?<end_line>
-  </ascii>    
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -828,7 +842,7 @@
   </sjis>
   <ascii>
     Don't call me an amateur!<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <player gender="male">
@@ -1237,7 +1251,7 @@
     <player_nickname> looks motivated.<end_line>
     A great example of the 'carrot and<end_line>
     the stick', if I may say so myself.<end_line>
-  </ascii>	
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -1259,15 +1273,19 @@
       よっし！<end_line>
       オレも出発だ！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Time to get moving!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       わたしも行こう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Time to get moving!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 00/003_24286220_172940c.xml
+++ b/Translation/JE Scripts/Day 00/003_24286220_172940c.xml
@@ -17,15 +17,18 @@
     <sjis>
       外に行く用はないな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Nothing to do out there<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       外に行く用事はないよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Nothing to do out there<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Translation/JE Scripts/Day 00/007_24288044_1729b2c.xml
+++ b/Translation/JE Scripts/Day 00/007_24288044_1729b2c.xml
@@ -29,6 +29,11 @@
       武器を準備してからだな<end_line>
       材料もそろったし、工房に行こう<end_line>
     </sjis>
+    <ascii>
+    I need a weapon if I'm going<end_line>
+    to leave the village. I have the<end_line>
+    materials, I just need to craft it.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -36,12 +41,12 @@
       武器を準備してからだね<end_line>
       材料もそろったし、工房に行こう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I need a weapon if I'm going<end_line>
     to leave the village. I have the<end_line>
     materials, I just need to craft it.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Day 00/008_24898220_17beaac.xml
+++ b/Translation/JE Scripts/Day 00/008_24898220_17beaac.xml
@@ -441,16 +441,19 @@
       なんだよ<end_line>
       その言い方<three_dots><end_line>
     </sjis>
+    <ascii>
+    What's your problem<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ<end_line>
       その言い方<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's your problem<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -470,17 +473,21 @@
       うわ！？<end_line>
       なんだよ！？<end_line>
     </sjis>
+    <ascii>
+    Uwah!?<end_line>
+    What is it!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うわ！？<end_line>
       なによ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uwah!?<end_line>
     What is it!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 00/013_24902220_17bfa4c.xml
+++ b/Translation/JE Scripts/Day 00/013_24902220_17bfa4c.xml
@@ -22,17 +22,21 @@
       初心忘れるべからず！<end_line>
       だろ？<end_line>
     </sjis>
+    <ascii>
+    Never forget the basics!<end_line>
+    Right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       初心忘れるべからず！<end_line>
       でしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Never forget the basics!<end_line>
     Right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -110,7 +114,7 @@
     Shapestone determines weapon type,<end_line>
     while the additional materials<end_line>
     determines strength and appearance.<end_line>
-  </ascii> 
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Translation/JE Scripts/Day 00/014_24903532_17bff6c.xml
+++ b/Translation/JE Scripts/Day 00/014_24903532_17bff6c.xml
@@ -140,18 +140,23 @@
       じゃ、また材料さがしてくる<end_line>
       マニグ採掘場にでも行ってくるよ<end_line>
     </sjis>
+    <ascii>
+    Well, I'm gonna gather<end_line>
+    more materials again.<end_line>
+    Guess I'll go to Manig Mine.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       じゃ、また材料さがしてくる<end_line>
       マニグ採掘場にでも行ってくるね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, I'm gonna gather<end_line>
     more materials again.<end_line>
     Guess I'll go to Manig Mine.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 00/015_24905292_17c064c.xml
+++ b/Translation/JE Scripts/Day 00/015_24905292_17c064c.xml
@@ -36,17 +36,21 @@
       なんだよ！？<end_line>
       どうしたんだ！？<end_line>
     </sjis>
+    <ascii>
+    Master!<end_line>
+    What's wrong!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！？<end_line>
       どうしたの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Master!<end_line>
     What's wrong!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -58,6 +62,11 @@
       ドリルあたま！？<end_line>
       召喚獣！<end_line>
     </sjis>
+    <ascii>
+    What is that!?<end_line>
+    A drill for a head!?<end_line>
+    A Summon Beast!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -65,12 +74,12 @@
       ドリルあたま！？<end_line>
       召喚獣！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is that!?<end_line>
     A drill for a head!?<end_line>
     A Summon Beast!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -82,6 +91,11 @@
       エリマキけもの！？<end_line>
       召喚獣！<end_line>
     </sjis>
+    <ascii>
+    What is that!?<end_line>
+    An animal with a scarf!?<end_line>
+    A Summon Beast!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -89,12 +103,12 @@
       エリマキけもの！？<end_line>
       召喚獣！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is that!?<end_line>
     An animal with a scarf!?<end_line>
     A Summon Beast!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -106,6 +120,11 @@
       ハネはえてる！？<end_line>
       召喚獣！<end_line>
     </sjis>
+    <ascii>
+    What is that!?<end_line>
+    It's got wings!?<end_line>
+    A Summon Beast!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -113,12 +132,12 @@
       ハネはえてる！？<end_line>
       召喚獣！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is that!?<end_line>
     It's got wings!?<end_line>
     A Summon Beast!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -130,6 +149,11 @@
       ばくはつあたま！？<end_line>
       召喚獣！<end_line>
     </sjis>
+    <ascii>
+    What is that!?<end_line>
+    A blown-up hairstyle!?<end_line>
+    A Summon Beast!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -137,12 +161,12 @@
       ばくはつあたま！？<end_line>
       召喚獣！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is that!?<end_line>
     A blown-up hairstyle!?<end_line>
     A Summon Beast!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Translation/JE Scripts/Day 00/016_24906604_17c0b6c.xml
+++ b/Translation/JE Scripts/Day 00/016_24906604_17c0b6c.xml
@@ -17,17 +17,21 @@
       親方、ケガ！？<end_line>
       さっきのヤツが！？<end_line>
     </sjis>
+    <ascii>
+    Master, are you hurt!?<end_line>
+    Was it that Summon Beast!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       親方、ケガしてるの！？<end_line>
       さっきのアイツのせい！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Master, are you hurt!?<end_line>
     Was it that Summon Beast!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -89,6 +93,11 @@
       親方がやられたんだぜ<end_line>
       だまってられるかよ！<end_line>
     </sjis>
+    <ascii>
+    Why!?<end_line>
+    You got beat up, Master!<end_line>
+    I can't stand here and do nothing!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -96,12 +105,12 @@
       親方がやられたんだよ<end_line>
       だまってられないよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Why!?<end_line>
     You got beat up, Master!<end_line>
     I can't stand here and do nothing!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -231,15 +240,18 @@
     <sjis>
       どうしてそんなこと、わかるのさ？<end_line>
     </sjis>
+    <ascii>
+    How do you know that?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしてそんなこと、わかるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How do you know that?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -324,6 +336,11 @@
       ムカつくよな！<end_line>
       どうしよっかな？<end_line>
     </sjis>
+    <ascii>
+    As if I could sit still<three_dots>!<end_line>
+    I'm so mad<three_dots>!<end_line>
+    What do I do?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -331,10 +348,10 @@
       ムカつくよ<three_dots>！<end_line>
       どうしよっかな？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     As if I could sit still<three_dots>!<end_line>
     I'm so mad<three_dots>!<end_line>
     What do I do?<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 00/018_24909036_17c14ec.xml
+++ b/Translation/JE Scripts/Day 00/018_24909036_17c14ec.xml
@@ -6,17 +6,21 @@
       あれ？<end_line>
       あいつ、どこ行った？<end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    Where'd they go?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あれ？<end_line>
       あいつ、どこ行ったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     Where'd they go?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 00/019_24909852_17c181c.xml
+++ b/Translation/JE Scripts/Day 00/019_24909852_17c181c.xml
@@ -179,15 +179,18 @@
     <sjis>
       なんだよ！？<end_line>
     </sjis>
+    <ascii>
+    Huh!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -422,6 +425,11 @@
       お前、そこにいたんだろ？<end_line>
       なにも見てないのか！？<end_line>
     </sjis>
+    <ascii>
+    I'm sure they went that way!<end_line>
+    You were there, right?<end_line>
+    You didn't see anything!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -429,12 +437,12 @@
       あなた、そこにいたんでしょ？<end_line>
       なにも見てないの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm sure they went that way!<end_line>
     You were there, right?<end_line>
     You didn't see anything!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -457,6 +465,11 @@
       じゃあ、さっき光ったのは！？<end_line>
       本当は何してたんだ！？<end_line>
     </sjis>
+    <ascii>
+    What's with you!?<end_line>
+    Then, what was glowing earlier!?<end_line>
+    What are you really up to!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -464,12 +477,12 @@
       じゃあ、さっき光ったのは！？<end_line>
       本当は何してたの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's with you!?<end_line>
     Then, what was glowing earlier!?<end_line>
     What are you really up to!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -531,15 +544,18 @@
     <sjis>
       なんだと！？<end_line>
     </sjis>
+    <ascii>
+    What's your problem!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's your problem!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -563,6 +579,11 @@
       ちゃんと話せよ！<end_line>
       親方がケガしてるんだ！<end_line>
     </sjis>
+    <ascii>
+    What are you trying to say?<end_line>
+    Speak up!<end_line>
+    That Beast hurt my Master, you know!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -570,12 +591,12 @@
       ちゃんと話して！<end_line>
       親方がケガしてるんだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What are you trying to say?<end_line>
     Speak up!<end_line>
     That Beast hurt my Master, you know!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <player gender="male">
@@ -1286,15 +1307,18 @@
     <sjis>
       ちがうみたいだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Well that didn't work<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちがったみたい<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well that didn't work<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -1359,6 +1383,11 @@
       ついでに召喚獣の話も<end_line>
       聞き出してやろう！<end_line>
     </sjis>
+    <ascii>
+    I guess I'll give it back.<end_line>
+    While I'm at it, I'll make her<end_line>
+    tell me about the Summon Beast!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1366,12 +1395,12 @@
       ついでに召喚獣の話も<end_line>
       聞き出してやるんだから！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I guess I'll give it back.<end_line>
     While I'm at it, I'll make her<end_line>
     tell me about the Summon Beast!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <player gender="male">

--- a/Translation/JE Scripts/Day 00/022_24917052_17c343c.xml
+++ b/Translation/JE Scripts/Day 00/022_24917052_17c343c.xml
@@ -55,15 +55,18 @@
     <sjis>
       その子を放せ！<end_line>
     </sjis>
+    <ascii>
+    Let go of the girl!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       その子を放して！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Let go of the girl!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -84,15 +87,18 @@
     <sjis>
       聞こえなかったのか？<end_line>
     </sjis>
+    <ascii>
+    Didn't hear me?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       聞こえなかった？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Didn't hear me?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -102,15 +108,18 @@
     <sjis>
       この子を放せって言ったんだ<end_line>
     </sjis>
+    <ascii>
+    I told you to let her go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       この子を放せって言ったの<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I told you to let her go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -120,15 +129,18 @@
     <sjis>
       用なんてあるわけないだろ？<end_line>
     </sjis>
+    <ascii>
+    Not really.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       用なんてあるわけないじゃない<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Not really.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -159,15 +171,18 @@
     <sjis>
       お前たちにはな<end_line>
     </sjis>
+    <ascii>
+    Not with you guys, anyway.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんたたちにはね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Not with you guys, anyway.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -190,6 +205,11 @@
       大事な用がね<end_line>
       だから放してくれよ？<end_line>
     </sjis>
+    <ascii>
+    Sorry, but I do need to talk to<end_line>
+    the girl. And it's important.<end_line>
+    So could you let her go?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -197,12 +217,12 @@
       大事な用がね<end_line>
       だから放してくれない？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sorry, but I do need to talk to<end_line>
     the girl. And it's important.<end_line>
     So could you let her go?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -229,6 +249,11 @@
       男がよってたかって<end_line>
       女の子にからんで、カッコワリィ！<end_line>
     </sjis>
+    <ascii>
+    You're one to talk!<end_line>
+    Guys ganging up and picking<end_line>
+    on a girl, so lame!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -236,12 +261,12 @@
       男がよってたかって<end_line>
       女の子にからんで、カッコワルイ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're one to talk!<end_line>
     Guys ganging up and picking<end_line>
     on a girl, so lame!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -405,15 +430,18 @@
     <sjis>
       悪いけど、ダメだ<end_line>
     </sjis>
+    <ascii>
+    Sorry, but I can't do that.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       悪いけど、ダメだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sorry, but I can't do that.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -446,17 +474,21 @@
       今あんたを放っておくのは<end_line>
       カッコワルイからだ！<end_line>
     </sjis>
+    <ascii>
+    Because if I didn't step in now,<end_line>
+    that'd be really lame!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今あなたを放っておくのは<end_line>
       カッコワルイもん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Because if I didn't step in now,<end_line>
     that'd be really lame!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -490,15 +522,18 @@
     <sjis>
       あんたはこのオレが守る！<end_line>
     </sjis>
+    <ascii>
+    I'll be the one to protect you!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あなたはこのわたしが守る！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'll be the one to protect you!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Translation/JE Scripts/Day 00/023_24918956_17c3bac.xml
+++ b/Translation/JE Scripts/Day 00/023_24918956_17c3bac.xml
@@ -68,15 +68,18 @@
     <sjis>
       これって大事なものなのか？<end_line>
     </sjis>
+    <ascii>
+    Is this important to you?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       これって大事なものなの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Is this important to you?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -100,17 +103,21 @@
       ああ、悪い悪い<end_line>
       すぐに返すよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah, sorry, sorry.<end_line>
+    I'll give it back right away<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ああ、ごめんごめん<end_line>
       すぐに返すから<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, sorry, sorry.<end_line>
     I'll give it back right away<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -514,17 +521,21 @@
       なに言ってンだ！<end_line>
       そんなこと<three_dots><end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+    You can't<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに言ってるの！<end_line>
       そんなこと<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
     You can't<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -665,6 +676,11 @@
       声が<three_dots><end_line>
       さっきの石から<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    What the<three_dots>?<end_line>
+    A voice<three_dots><end_line>
+    Coming from the stone<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -672,12 +688,12 @@
       声が<three_dots><end_line>
       さっきの石から<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What the<three_dots>?<end_line>
     A voice<three_dots><end_line>
     Coming from the stone<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Translation/JE Scripts/Day 00/024_24921996_17c478c.xml
+++ b/Translation/JE Scripts/Day 00/024_24921996_17c478c.xml
@@ -86,17 +86,21 @@
       名前<three_dots>？<end_line>
       名前か<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Name<three_dots>?<end_line>
+    Your name, huh<three_dots>！<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       名前<three_dots>？<end_line>
       名前ね<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Name<three_dots>?<end_line>
     Your name, huh<three_dots>！<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <partner name="run-dor">
@@ -239,15 +243,18 @@
     <sjis>
       うぉおおおお！！<end_line>
     </sjis>
+    <ascii>
+    Uwaaaah!!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うぁああああ！！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uwaaaah!!<end_line>
   </ascii>
+  </female>
 </bigtext>
 <dialogue>
   <info box="left">
@@ -269,17 +276,21 @@
       こいつは<three_dots><end_line>
       さっきの召喚獣<three_dots>！！！<end_line>
     </sjis>
+    <ascii>
+    That's<three_dots><end_line>
+    The Summon Beast from earlier<three_dots>!!!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       まさか<three_dots><end_line>
       さっきの召喚獣<three_dots>！！！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's<three_dots><end_line>
     The Summon Beast from earlier<three_dots>!!!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -304,17 +315,21 @@
       か<three_dots>、かわった！？<end_line>
       なんでだ？<end_line>
     </sjis>
+    <ascii>
+    It<three_dots>, it changed!?<end_line>
+    Why?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       か<three_dots>、かわった！？<end_line>
       なんで？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It<three_dots>, it changed!?<end_line>
     Why?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -1292,17 +1307,21 @@
       子供になった！？<end_line>
       なんでだよ？<end_line>
     </sjis>
+    <ascii>
+    H-He became a kid!?<end_line>
+    Why?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       こ、子供になっちゃった！？<end_line>
       どうして？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     H-He became a kid!?<end_line>
     Why?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1670,17 +1689,21 @@
       どうしたんだ？<end_line>
       弱そうになったぞ<end_line>
     </sjis>
+    <ascii>
+    What happened?<end_line>
+    You're looking weaker now.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしたの？<end_line>
       弱そうになっちゃった<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What happened?<end_line>
     You're looking weaker now.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Translation/JE Scripts/Day 00/025_24929932_17c668c.xml
+++ b/Translation/JE Scripts/Day 00/025_24929932_17c668c.xml
@@ -146,17 +146,21 @@
       え？<end_line>
       そうなのか？<end_line>
     </sjis>
+    <ascii>
+    Eh?<end_line>
+    Really?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え？<end_line>
       そうなの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh?<end_line>
     Really?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -181,6 +185,11 @@
       けど、よかったな<end_line>
       あんなのにつきあわなくてすんで<end_line>
     </sjis>
+    <ascii>
+    I can't tell<three_dots><end_line>
+    But anyway, it's great that it ended<end_line>
+    without you having to go along!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -188,12 +197,12 @@
       けど、よかったね<end_line>
       あんなのにつきあわなくてすんで<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I can't tell<three_dots><end_line>
     But anyway, it's great that it ended<end_line>
     without you having to go along!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -431,6 +440,11 @@
       まあ、よかったじゃないか<end_line>
       あいつらを追っ払えて<end_line>
     </sjis>
+    <ascii>
+    I don't really get it, but<three_dots><end_line>
+    Well, isn't it fine!<end_line>
+    We managed to chase them off!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -438,12 +452,12 @@
       まあ、よかったじゃない！<end_line>
       あいつらは追っ払えたし<end_line>
     </sjis>
-  </female>	
-  <ascii>
+    <ascii>
     I don't really get it, but<three_dots><end_line>
     Well, isn't it fine!<end_line>
     We managed to chase them off!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -532,17 +546,21 @@
       お前、小さいのに強いんだな！<end_line>
       かっこよかったぜ！<end_line>
     </sjis>
+    <ascii>
+    Hey, you're stronger than you look!<end_line>
+    That was pretty cool!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ボク、小さいのに強いんだね！<end_line>
       かっこよかったよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, you're stronger than you look!<end_line>
     That was pretty cool!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -605,15 +623,18 @@
     <sjis>
       なんだと！<end_line>
     </sjis>
+    <ascii>
+    What!? Why?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!? Why?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -652,6 +673,11 @@
       あいつらは追っ払えたことだし<end_line>
       よかったな<end_line>
     </sjis>
+    <ascii>
+    Well, anyway<three_dots><end_line>
+    We drove them off,<end_line>
+    so it's all good.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -659,12 +685,12 @@
       あいつらは追っ払えたことだし<end_line>
       よかったね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, anyway<three_dots><end_line>
     We drove them off,<end_line>
     so it's all good.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -798,6 +824,11 @@
       最初出たときの方が<end_line>
       強そうだったな<end_line>
     </sjis>
+    <ascii>
+    Yeah,<end_line>
+    you looked much stronger<end_line>
+    when you first showed up.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -805,12 +836,12 @@
       最初出たときの方が<end_line>
       強そうだったよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah,<end_line>
     you looked much stronger<end_line>
     when you first showed up.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -881,6 +912,11 @@
       あいつらを追っ払えたし<end_line>
       まあ、よかったじゃないか<end_line>
     </sjis>
+    <ascii>
+    Besides,<end_line>
+    we drove them off.<end_line>
+    Well, I'd say it's all good!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -888,12 +924,12 @@
       あいつらを追っ払えたし<end_line>
       まあ、よかったじゃない！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Besides,<end_line>
     we drove them off.<end_line>
     Well, I'd say it's all good!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1015,17 +1051,21 @@
       武器作りの名人で<end_line>
       剣の達人さ！<end_line>
     </sjis>
+    <ascii>
+    An expert in crafting weapons<end_line>
+    and a master of the sword!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       武器作りの名人で<end_line>
       剣の達人だよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     An expert in crafting weapons<end_line>
     and a master of the sword!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1121,6 +1161,10 @@
       おそったんだ<three_dots><end_line>
       親方にケガさせたんだ<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    This one attacked my Master<three_dots><end_line>
+    She was injured<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1128,11 +1172,11 @@
       おそったんだよ<three_dots><end_line>
       親方にケガさせたんだ<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This one attacked my Master<three_dots><end_line>
     She was injured<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1225,6 +1269,11 @@
       見つけたぜ<end_line>
       親方にケガさせた召喚獣<end_line>
     </sjis>
+    <ascii>
+    Master!<end_line>
+    I found the Summon Beast<end_line>
+    that hurt you.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1232,12 +1281,12 @@
       見つけたよ<end_line>
       親方にケガさせた召喚獣<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Master!<end_line>
     I found the Summon Beast<end_line>
     that hurt you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1260,15 +1309,18 @@
     <sjis>
       こいつだよ<end_line>
     </sjis>
+    <ascii>
+    Right here.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       この子だよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Right here.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Translation/JE Scripts/Day 00/026_24933404_17c741c.xml
+++ b/Translation/JE Scripts/Day 00/026_24933404_17c741c.xml
@@ -49,15 +49,18 @@
     <sjis>
       さすがオレだろ<end_line>
     </sjis>
+    <ascii>
+    Heh, no problem!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       さすがわたしね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Heh, no problem!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -531,17 +534,21 @@
       オレの？<end_line>
       いっしょに鍛冶をするってこと？<end_line>
     </sjis>
+    <ascii>
+    Assistant?<end_line>
+    So we'll be smithing together?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしの？<end_line>
       いっしょに鍛冶をするってこと？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Assistant?<end_line>
     So we'll be smithing together?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -726,6 +733,10 @@
       ミューノだったら<end_line>
       オレがついてるからさ！<end_line>
     </sjis>
+    <ascii>
+    Hey, don't worry about Murno.<end_line>
+    I'll be with her!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -733,11 +744,11 @@
       ミューノだったら<end_line>
       わたしがついてるから！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, don't worry about Murno.<end_line>
     I'll be with her!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -760,15 +771,18 @@
     <sjis>
       なんだよ！？<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -1342,6 +1356,10 @@
       ミューノだったら<end_line>
       オレがついてるからさ！<end_line>
     </sjis>
+    <ascii>
+    Hey, don't worry about Murno.<end_line>
+    I'll be with her!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1349,11 +1367,11 @@
       ミューノだったら<end_line>
       わたしがついてるから！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, don't worry about Murno.<end_line>
     I'll be with her!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -2054,15 +2072,18 @@
     <sjis>
       やれるもんならやってみろよ！<end_line>
     </sjis>
+    <ascii>
+    Hah! Feel free to try!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       やれるもんならやってみなさい！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hah! Feel free to try!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -2100,6 +2121,11 @@
       たのむから<end_line>
       勝負させてくれ<end_line>
     </sjis>
+    <ascii>
+    I'm sorry, Murno.<end_line>
+    I'm asking you,<end_line>
+    let us fight!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -2107,12 +2133,12 @@
       たのむから<end_line>
       勝負させて<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm sorry, Murno.<end_line>
     I'm asking you,<end_line>
     let us fight!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -2196,17 +2222,21 @@
       オレが勝ったら、か<three_dots><end_line>
       おろかなことを<three_dots><end_line>
     </sjis>
+    <ascii>
+    You think you stand a chance<three_dots>?<end_line>
+    How foolish<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしが勝ったら、か<three_dots><end_line>
       おろかなことを<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You think you stand a chance<three_dots>?<end_line>
     How foolish<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -2233,15 +2263,18 @@
     <sjis>
       約束したからな！<end_line>
     </sjis>
+    <ascii>
+    It's a promise, then!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       約束したからね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's a promise, then!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -2292,6 +2325,10 @@
       ミューノだったら<end_line>
       オレがついてるからさ！<end_line>
     </sjis>
+    <ascii>
+    Hey, don't worry about Murno.<end_line>
+    I'll be with her!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -2299,11 +2336,11 @@
       ミューノだったら<end_line>
       わたしがついてるから！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, don't worry about Murno.<end_line>
     I'll be with her!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -2365,17 +2402,21 @@
       なんだと！？<end_line>
       オレが弱いって言いたいのか！<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+    So you're saying I'm weak!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！？<end_line>
       わたしが弱いって言いたいの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
     So you're saying I'm weak!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Translation/JE Scripts/Day 00/027_24298364_172c37c.xml
+++ b/Translation/JE Scripts/Day 00/027_24298364_172c37c.xml
@@ -32,15 +32,18 @@
     <sjis>
       生きるのが男じゃない？<end_line>
     </sjis>
+    <ascii>
+    is what makes us human, isn't it?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       生きるのが女じゃない？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     is what makes us human, isn't it?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Translation/JE Scripts/Day 00/029_24941068_17c920c.xml
+++ b/Translation/JE Scripts/Day 00/029_24941068_17c920c.xml
@@ -8,6 +8,11 @@
       オレの実力<end_line>
       わかったか！<end_line>
     </sjis>
+    <ascii>
+    How's that!?<end_line>
+    Now do you understand<end_line>
+    my true power?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -15,12 +20,12 @@
       わたしの実力<end_line>
       わかった？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How's that!?<end_line>
     Now do you understand<end_line>
     my true power?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -528,6 +533,11 @@
       鍛冶の手伝いをしてもらうぞ<end_line>
       いいな<end_line>
     </sjis>
+    <ascii>
+    Then, as promised,<end_line>
+    I'll have you help me with smithing.<end_line>
+    Got it?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -535,12 +545,12 @@
       鍛冶の手伝いをしてもらうよ<end_line>
       いいね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Then, as promised,<end_line>
     I'll have you help me with smithing.<end_line>
     Got it?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -751,6 +761,11 @@
       そんなに気にするなって<end_line>
       お前もけっこう強かったよ<end_line>
     </sjis>
+    <ascii>
+    Hey, don't take it too hard.<end_line>
+    I thought you were<end_line>
+    pretty strong too!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -758,12 +773,12 @@
       そんなに気にしないで<end_line>
       あなたもけっこう強かったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, don't take it too hard.<end_line>
     I thought you were<end_line>
     pretty strong too!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -787,6 +802,11 @@
       強さとしては<end_line>
       オレの次ぐらいじゃないの？<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+    I'd say your strength is<end_line>
+    about just below mine!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -794,12 +814,12 @@
       強さとしては<end_line>
       わたしの次ぐらいだと思うよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
     I'd say your strength is<end_line>
     about just below mine!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -934,6 +954,11 @@
       今日からお前は<end_line>
       オレの弟子だ！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    From today on,<end_line>
+    you're my apprentice!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -941,12 +966,12 @@
       今日からあなたは<end_line>
       わたしの弟子だよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     From today on,<end_line>
     you're my apprentice!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -995,15 +1020,18 @@
     <sjis>
       半人前って言うなよ！<end_line>
     </sjis>
+    <ascii>
+    Don't call me an amateur!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       半人前って言わないでよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't call me an amateur!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -1164,15 +1192,18 @@
     <sjis>
       よろしくたのむぜ<end_line>
     </sjis>
+    <ascii>
+    I'm counting on you,<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よろしくたのむね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm counting on you,<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1246,17 +1277,21 @@
       　　　　こうして、オレと<partner>の　　　　<end_line>
       　　　鍛冶師修行が始まったんだ<three_dots>！　<end_line>
     </sjis>
+    <ascii>
+    And so, <partner> and I began<end_line>
+    training together, as Craftknights<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       　　　　こうして、わたしと<partner>の　　  <end_line>
       　　　鍛冶師修行が始まったんだ<three_dots>！　<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And so, <partner> and I began<end_line>
     training together, as Craftknights<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -1265,17 +1300,21 @@
       　　　　こうして、オレと<partner>の　　　<end_line>
       　　　鍛冶師修行が始まったんだ<three_dots>！　<end_line>
     </sjis>
+    <ascii>
+    And so, <partner> and I began<end_line>
+    training together, as Craftknights<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       　　　こうして、わたしと<partner>の　　　<end_line>
       　　　鍛冶師修行が始まったんだ<three_dots>！　<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And so, <partner> and I began<end_line>
     training together, as Craftknights<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -1284,17 +1323,21 @@
       　　　こうして、オレと<partner>の　　　<end_line>
       　　　鍛冶師修行が始まったんだ<three_dots>！　<end_line>
     </sjis>
+    <ascii>
+    And so, <partner> and I began<end_line>
+    training together, as Craftknights<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       　　こうして、わたしと<partner>の　　　<end_line>
       　　鍛冶師修行が始まったんだ<three_dots>！　　<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And so, <partner> and I began<end_line>
     training together, as Craftknights<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -1303,17 +1346,21 @@
       　　こうして、オレと<partner>の　　　<end_line>
       　　鍛冶師修行が始まったんだ<three_dots>！　　<end_line>
     </sjis>
+    <ascii>
+    And so, <partner> and I began<end_line>
+    training together, as Craftknights<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       　　こうして、わたしと<partner>の　　<end_line>
       　　鍛冶師修行が始まったんだ<three_dots>！　　<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And so, <partner> and I began<end_line>
     training together, as Craftknights<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -1322,17 +1369,21 @@
       　　こうして、オレと<partner>の　　<end_line>
       　　鍛冶師修行が始まったんだ<three_dots>！　　<end_line>
     </sjis>
+    <ascii>
+    And so, <partner> and I began<end_line>
+    training together, as Craftknights<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       　こうして、わたしと<partner>の　　<end_line>
       　　鍛冶師修行が始まったんだ<three_dots>！　　<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And so, <partner> and I began<end_line>
     training together, as Craftknights<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -1341,17 +1392,21 @@
       　こうして、オレと<partner>の　　<end_line>
       　　鍛冶師修行が始まったんだ<three_dots>！　　<end_line>
     </sjis>
+    <ascii>
+    And so, <partner> and I began<end_line>
+    training together, as Craftknights<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       　こうして、わたしと<partner>の　<end_line>
       　　鍛冶師修行が始まったんだ<three_dots>！　　<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And so, <partner> and I began<end_line>
     training together, as Craftknights<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 
 

--- a/Translation/JE Scripts/Day 00/030_24944844_17ca0cc.xml
+++ b/Translation/JE Scripts/Day 00/030_24944844_17ca0cc.xml
@@ -411,15 +411,18 @@
     <sjis>
       そんな気にすんなよ<end_line>
     </sjis>
+    <ascii>
+    Don't worry about it too much.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんな気にしないで<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't worry about it too much.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -520,17 +523,21 @@
       仕方ない<end_line>
       行こうぜ、<partner><end_line>
     </sjis>
+    <ascii>
+    It can't be helped.<end_line>
+    Let's go, <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       仕方ない<end_line>
       行こう、<partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It can't be helped.<end_line>
     Let's go, <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Day 00/032_24253308_172137c.xml
+++ b/Translation/JE Scripts/Day 00/032_24253308_172137c.xml
@@ -83,17 +83,21 @@
       　　　これからどこへ行くつもり　　　<end_line>
       　　　　だったんだろうか<three_dots>　　　　　<end_line>
     </sjis>
+    <ascii>
+      Where did they intend	<end_line>
+      to go from here<three_dots>?  　　　　<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       　　　これからどこへ行くつもり　　　<end_line>
       　　　　　だったんだろう<three_dots>　　　　　<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
       Where did they intend	<end_line>
       to go from here<three_dots>?  　　　　<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -102,17 +106,21 @@
       　　薬のせいかどうかはしらないが　　<end_line>
       　　あれからミューノの熱も下がった　<end_line>
     </sjis>
+    <ascii>
+    After that, Murnos' fever went down.<end_line>
+    The medicine probably worked.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       　薬のせいかどうかはしらないけど　　<end_line>
       　あれからミューノの熱も下がった　　<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     After that, Murnos' fever went down.<end_line>
     The medicine probably worked.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -207,6 +215,11 @@
       　　ティエのことをどうするか？　　　<end_line>
       　<three_dots>っていうのが、カッコワルイなぁ<three_dots><end_line>
     </sjis>
+    <ascii>
+    But, for now, the question is,<end_line>
+    what to do about Tier?<end_line>
+    <three_dots>Man, I'm so lame<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -214,12 +227,12 @@
       　　ティエのことをどうしよう？　　　<end_line>
       　<three_dots>っていうのが、カッコワルイなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     But, for now, the question is,<end_line>
     what to do about Tier?<end_line>
     <three_dots>Man, I'm so lame<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">

--- a/Translation/JE Scripts/Day 00/033_24947628_17cabac.xml
+++ b/Translation/JE Scripts/Day 00/033_24947628_17cabac.xml
@@ -7,6 +7,11 @@
       わかるわけないよな<three_dots><end_line>
       もう帰ろっかな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Well, even if I think about it,<end_line>
+    it's not like I'll understand it<three_dots><end_line>
+    Guess I'll head back<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -14,12 +19,12 @@
       わかるわけないよね<three_dots><end_line>
       もう帰ろっかな<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, even if I think about it,<end_line>
     it's not like I'll understand it<three_dots><end_line>
     Guess I'll head back<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -30,6 +35,11 @@
       誰かいるのか？<end_line>
       まさか<three_dots><end_line>
     </sjis>
+    <ascii>
+    Hm?<end_line>
+    Is someone there?<end_line>
+    Could it be<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -37,12 +47,12 @@
       誰かいるの？<end_line>
       まさか<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hm?<end_line>
     Is someone there?<end_line>
     Could it be<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <menu>
   <option>

--- a/Translation/JE Scripts/Day 00/034_24950044_17cb51c.xml
+++ b/Translation/JE Scripts/Day 00/034_24950044_17cb51c.xml
@@ -143,6 +143,11 @@
       今日はいろいろあったんで<end_line>
       アタマを冷やしてたんだよ！<end_line>
     </sjis>
+    <ascii>
+    It wouldn't! Definitely not!<end_line>
+    A lot happened today, so<end_line>
+    I was just cooling my head!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -150,12 +155,12 @@
       今日はいろいろあったから<end_line>
       アタマを冷やしてたのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It wouldn't! Definitely not!<end_line>
     A lot happened today, so<end_line>
     I was just cooling my head!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -235,6 +240,11 @@
       これからよろしくな<end_line>
       <partner>！<end_line>
     </sjis>
+    <ascii>
+    I'll say it anew.<end_line>
+    Let's get along from now on,<end_line>
+    <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -242,12 +252,12 @@
       これからよろしくね<end_line>
       <partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'll say it anew.<end_line>
     Let's get along from now on,<end_line>
     <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -323,15 +333,18 @@
     <sjis>
       <three_dots>ってどうしたんだよ？<end_line>
     </sjis>
+    <ascii>
+    <three_dots>Hey, what's the matter?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>ってどうしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots>Hey, what's the matter?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -382,17 +395,21 @@
       そう、ハラのソコからわきあがる<end_line>
       こう<three_dots><end_line>
     </sjis>
+    <ascii>
+    Yeah, it boils up from the bottom<end_line>
+    of your stomach, like<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そう、お腹のソコからわきあがる<end_line>
       こう<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, it boils up from the bottom<end_line>
     of your stomach, like<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -466,6 +483,10 @@
       あいつにも気合いを<end_line>
       つたえてやるぞ！<end_line>
     </sjis>
+    <ascii>
+    One day, I'll make<end_line>
+    <partner> understand!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -473,11 +494,11 @@
       あの子にも気合いを<end_line>
       つたえてみせる！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     One day, I'll make<end_line>
     <partner> understand!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -582,6 +603,11 @@
       今日はいろいろあったんで<end_line>
       アタマを冷やしてたんだよ！<end_line>
     </sjis>
+    <ascii>
+    I'm sure! Absolutely!<end_line>
+    A lot happened today, so<end_line>
+    I was just cooling my head!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -589,12 +615,12 @@
       今日はいろいろあったんで<end_line>
       アタマを冷やしてたの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm sure! Absolutely!<end_line>
     A lot happened today, so<end_line>
     I was just cooling my head!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -704,6 +730,11 @@
       せっかくパートナーになったんだから<end_line>
       もっと仲良くしようぜ<end_line>
     </sjis>
+    <ascii>
+    Hey, what's that about?<end_line>
+    We finally became partners, so<end_line>
+    let's get along better!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -711,12 +742,12 @@
       せっかくパートナーになったんだから<end_line>
       もっと仲良くしようよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, what's that about?<end_line>
     We finally became partners, so<end_line>
     let's get along better!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -838,15 +869,18 @@
     <sjis>
       <three_dots>ってどうしたんだよ？<end_line>
     </sjis>
+    <ascii>
+      <three_dots>Hey, what's the matter?<end_line>
+    </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>ってどうしたの？<end_line>
     </sjis>
-  </female>
     <ascii>
       <three_dots>Hey, what's the matter?<end_line>
     </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -955,6 +989,10 @@
       もしかしてオレの跡<end_line>
       つけてきたのか？<end_line>
     </sjis>
+    <ascii>
+    What's with the attitude<three_dots><end_line>
+    Did you follow me here?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -962,11 +1000,11 @@
       もしかしてわたしの跡<end_line>
       つけてきたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's with the attitude<three_dots><end_line>
     Did you follow me here?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -991,17 +1029,21 @@
       それは<three_dots><end_line>
       オレのパートナーだから？<end_line>
     </sjis>
+    <ascii>
+    That's<three_dots><end_line>
+    Because you're my partner?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       それは<three_dots><end_line>
       わたしのパートナーだから？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's<three_dots><end_line>
     Because you're my partner?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1030,6 +1072,11 @@
       オレは今日はいろいろあったんで<end_line>
       アタマを冷やしてただけだ！<end_line>
     </sjis>
+    <ascii>
+    What's that!?<end_line>
+    A lot happened today, so<end_line>
+    I was just cooling my head!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1037,12 +1084,12 @@
       わたしは今日はいろいろあったから<end_line>
       アタマを冷やしてただけよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's that!?<end_line>
     A lot happened today, so<end_line>
     I was just cooling my head!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1149,6 +1196,11 @@
       仲良くないと息が合わないから<end_line>
       良い武器が作れないんだぞ<three_dots><end_line>
     </sjis>
+    <ascii>
+    What are you saying?<end_line>
+    We need to work together<end_line>
+    to make good weapons!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1156,12 +1208,12 @@
       仲良くないと息が合わないから<end_line>
       良い武器が作れないのよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What are you saying?<end_line>
     We need to work together<end_line>
     to make good weapons!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1186,6 +1238,11 @@
       あらためてよろしくな<end_line>
       <partner>！<end_line>
     </sjis>
+    <ascii>
+    So! I'll say it once again.<end_line>
+    Let's work together!<end_line>
+    <partner>！<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1193,12 +1250,12 @@
       あらためてよろしく<end_line>
       <partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So! I'll say it once again.<end_line>
     Let's work together!<end_line>
     <partner>！<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1277,15 +1334,18 @@
     <sjis>
       <three_dots>ってどうしたんだよ？<end_line>
     </sjis>
+    <ascii>
+      <three_dots>Hey, what's the matter?<end_line>
+    </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>ってどうしたの？<end_line>
     </sjis>
-  </female>
     <ascii>
       <three_dots>Hey, what's the matter?<end_line>
     </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1313,6 +1373,11 @@
       なんだよ<end_line>
       むずかしい年頃なのか？<end_line>
     </sjis>
+    <ascii>
+    Hmph<three_dots><end_line>
+    What's with him?<end_line>
+    Maybe he's at a rebellious age?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1320,12 +1385,12 @@
       なによ<end_line>
       むずかしい年頃なのかな？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hmph<three_dots><end_line>
     What's with him?<end_line>
     Maybe he's at a rebellious age?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1365,6 +1430,11 @@
       まさか、オレの跡をつけてたのか？<end_line>
       どうして？<end_line>
     </sjis>
+    <ascii>
+    Eh<three_dots>?<end_line>
+    You were following me?<end_line>
+    Why?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1372,12 +1442,12 @@
       まさか、わたしの跡をつけてたの？<end_line>
       どうして？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh<three_dots>?<end_line>
     You were following me?<end_line>
     Why?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1402,6 +1472,11 @@
       オレがミューノになんかするとでも<end_line>
       思ってたのか！？<end_line>
     </sjis>
+    <ascii>
+    Protect Murno<three_dots>?<end_line>
+    You thought I was gonna<end_line>
+    do something to Murno!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1409,12 +1484,12 @@
       わたしがミューノになんかするとでも<end_line>
       思ってたの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Protect Murno<three_dots>?<end_line>
     You thought I was gonna<end_line>
     do something to Murno!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1471,6 +1546,11 @@
       今日はいろいろあったんで<end_line>
       アタマを冷やしてたんだよ！<end_line>
     </sjis>
+    <ascii>
+    I can! Absolutely!<end_line>
+    A lot happened today, so<end_line>
+    I was just cooling my head!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1478,12 +1558,12 @@
       今日はいろいろあったんで<end_line>
       アタマを冷やしてたの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I can! Absolutely!<end_line>
     A lot happened today, so<end_line>
     I was just cooling my head!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1568,6 +1648,11 @@
       せっかくパートナーになったんだから<end_line>
       もっと仲良くしようぜ<end_line>
     </sjis>
+    <ascii>
+    Hey, what's with that!<end_line>
+    We finally became partners, so<end_line>
+    so let's get along better!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1575,12 +1660,12 @@
       せっかくパートナーになったんだから<end_line>
       もっと仲良くしようよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, what's with that!<end_line>
     We finally became partners, so<end_line>
     so let's get along better!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1607,6 +1692,11 @@
       大切なことなんだしさ<end_line>
       な<end_line>
     </sjis>
+    <ascii>
+    It's also important for<end_line>
+    making good weapons!<end_line>
+    Right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1614,12 +1704,12 @@
       大切なことなんだし<end_line>
       ね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's also important for<end_line>
     making good weapons!<end_line>
     Right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1646,6 +1736,11 @@
       これからよろしくな<end_line>
       <partner>！<end_line>
     </sjis>
+    <ascii>
+    Then, I'll say it again!<end_line>
+    Let's work together from now on,<end_line>
+    <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1653,12 +1748,12 @@
       これからよろしくね<end_line>
       <partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Then, I'll say it again!<end_line>
     Let's work together from now on,<end_line>
     <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1729,15 +1824,18 @@
     <sjis>
       <three_dots>ってどうしたんだよ？<end_line>
     </sjis>
+    <ascii>
+    <three_dots>Hey, what's the matter?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>ってどうしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots>Hey, what's the matter?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1763,15 +1861,19 @@
       あ<three_dots><end_line>
       そんなにはずかしいことか？<end_line>
     </sjis>
+    <ascii>
+    Ah<three_dots><end_line>
+    Is it really that embarassing?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ<three_dots><end_line>
       そんなにはずかしいこと？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah<three_dots><end_line>
     Is it really that embarassing?<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 00/035_24948364_17cae8c.xml
+++ b/Translation/JE Scripts/Day 00/035_24948364_17cae8c.xml
@@ -48,6 +48,11 @@
       オレは今日はいろいろあったから<end_line>
       ここでアタマ冷やしてたんだけど<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah, me?<three_dots><end_line>
+    Well, a lot happened today,<end_line>
+    so I was just cooling my head<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -55,12 +60,12 @@
       わたしは今日はいろいろあったから<end_line>
       ここでアタマ冷やしてたんだけど<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, me?<three_dots><end_line>
     Well, a lot happened today,<end_line>
     so I was just cooling my head<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Translation/JE Scripts/Day 00/036_24954300_17cc5bc.xml
+++ b/Translation/JE Scripts/Day 00/036_24954300_17cc5bc.xml
@@ -311,17 +311,21 @@
       そうだね<end_line>
       オレ、がんばるよ！<end_line>
     </sjis>
+    <ascii>
+    That's right!<end_line>
+    I'll do my best!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そうだね<end_line>
       わたし、がんばるよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's right!<end_line>
     I'll do my best!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -372,6 +376,11 @@
       オレも<partner>を信頼する<end_line>
       <three_dots>ってことだよな<end_line>
     </sjis>
+    <ascii>
+    Trusting each other means that<end_line>
+    I need to trust <partner>, too.<end_line>
+    <three_dots>That's how it is, huh.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -379,11 +388,11 @@
       わたしも<partner>を信頼する<end_line>
       <three_dots>ってことだよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Trusting each other means that<end_line>
     I need to trust <partner>, too.<end_line>
     <three_dots>That's how it is, huh.<end_line>
   </ascii>
+  </female>
 </dialogue>
 

--- a/Translation/JE Scripts/Day 01/000_24956700_17ccf1c.xml
+++ b/Translation/JE Scripts/Day 01/000_24956700_17ccf1c.xml
@@ -32,17 +32,21 @@
       おそいって<end_line>
       さっき行ったばっかだろ？<end_line>
     </sjis>
+    <ascii>
+    Late?<end_line>
+    Didn't they leave just a second ago?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       おそいって<end_line>
       さっき行ったばっかじゃない？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Late?<end_line>
     Didn't they leave just a second ago?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -386,6 +390,11 @@
       ごめんごめん<end_line>
       泣くなよ～！<end_line>
     </sjis>
+    <ascii>
+    Uwah!<end_line>
+    Sorry, sorry.<end_line>
+    Don't cry~!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -393,12 +402,12 @@
       ごめんごめん<end_line>
       泣かないでよ～！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uwah!<end_line>
     Sorry, sorry.<end_line>
     Don't cry~!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -646,6 +655,11 @@
       じゃあなんか<end_line>
       おめかしでもすりゃいいだろ<end_line>
     </sjis>
+    <ascii>
+    I said I was sorry!<end_line>
+    Then, how about dressing up<end_line>
+    in something fancy?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -653,12 +667,12 @@
       じゃあなんかおめかしでも<end_line>
       すればいいじゃない<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I said I was sorry!<end_line>
     Then, how about dressing up<end_line>
     in something fancy?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -686,17 +700,21 @@
       え～っと<end_line>
       そうだな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Umm~<end_line>
+    Let's see<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え～っと<end_line>
       そうね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Umm~<end_line>
     Let's see<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -796,15 +814,18 @@
     <sjis>
       悪かったな<end_line>
     </sjis>
+    <ascii>
+    Well, sorry.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       悪かったわね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, sorry.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -1012,6 +1033,11 @@
       お前、見た目はこわくないからさ<end_line>
       何も言われないよ<end_line>
     </sjis>
+    <ascii>
+    It'll be fine.<end_line>
+    You don't look scary,<end_line>
+    the Chief won't have any complaints.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1019,12 +1045,12 @@
       あなた、見た目はこわくないから<end_line>
       何も言われないよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It'll be fine.<end_line>
     You don't look scary,<end_line>
     the Chief won't have any complaints.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1050,16 +1076,19 @@
       なんで怒るんだよ<end_line>
       こわい方がいいのかよ？<end_line>
     </sjis>
+    <ascii>
+    What are you getting angry for?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なんで怒るのよ<end_line>
       こわい方がいいの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What are you getting angry for?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1086,6 +1115,11 @@
       そんなにこわく見せたいんなら<end_line>
       へんな格好でもすりゃいいだろ？<end_line>
     </sjis>
+    <ascii>
+    Well, fine!<end_line>
+    If you wanna stand out so much,<end_line>
+    just wear something weird.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1093,12 +1127,12 @@
       そんなにこわく見せたいんなら<end_line>
       へんな格好でもすりゃいいでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, fine!<end_line>
     If you wanna stand out so much,<end_line>
     just wear something weird.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1213,6 +1247,11 @@
       どこいくんだよ<end_line>
       ミューノのところか<three_dots><end_line>
     </sjis>
+    <ascii>
+    Hey, wait a minute!<end_line>
+    Where are you going?!<end_line>
+    <three_dots>Murno's room, huh?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1220,12 +1259,12 @@
       どこいくの？<end_line>
       ミューノのところ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, wait a minute!<end_line>
     Where are you going?!<end_line>
     <three_dots>Murno's room, huh?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <player gender="male">
@@ -1343,17 +1382,21 @@
       ちゃんとした格好って<three_dots><end_line>
       別にそのままで大丈夫だろ？<end_line>
     </sjis>
+    <ascii>
+    In order<three_dots>?<end_line>
+    You look fine, what's the problem?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちゃんとした格好って<three_dots><end_line>
       別にそのままでいいんじゃないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     In order<three_dots>?<end_line>
     You look fine, what's the problem?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Translation/JE Scripts/Day 01/001_24960652_17cde8c.xml
+++ b/Translation/JE Scripts/Day 01/001_24960652_17cde8c.xml
@@ -110,15 +110,18 @@
     <sjis>
       オレは<three_dots><end_line>
     </sjis>
+    <ascii>
+    I<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしは<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <choice>
   <info box="left">
@@ -148,17 +151,21 @@
       みんな帰ってこないし<end_line>
       なにやってンのかなって<three_dots><end_line>
     </sjis>
+    <ascii>
+    You were taking a while, so I was<end_line>
+    wondering what you were doing<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       みんな帰ってこないし<end_line>
       なにやってるのかなって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You were taking a while, so I was<end_line>
     wondering what you were doing<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -212,17 +219,21 @@
       な、なんだよ！<end_line>
       オレは別に<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    W-What?!<end_line>
+    I wasn't<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な、なによ！<end_line>
       わたしは別に<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     W-What?!<end_line>
     I wasn't<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -378,7 +389,7 @@
   <ascii>
     Uwah~<end_line>
     This is too real~<end_line>
-  </ascii> 
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 01/002_24962924_17ce76c.xml
+++ b/Translation/JE Scripts/Day 01/002_24962924_17ce76c.xml
@@ -68,17 +68,21 @@
       よし、やってみよう<end_line>
       たのむぜ、<partner><end_line>
     </sjis>
+    <ascii>
+    Alright, let's do this.<end_line>
+    I'm counting on you, <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よし、やってみよう<end_line>
       たのむよ、<partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright, let's do this.<end_line>
     I'm counting on you, <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Day 01/004_24965052_17cefbc.xml
+++ b/Translation/JE Scripts/Day 01/004_24965052_17cefbc.xml
@@ -228,17 +228,21 @@
       なんだよ<three_dots>もう<three_dots>！<end_line>
       はりあいのないヤツだな！<end_line>
     </sjis>
+    <ascii>
+    Oh, c'mon<three_dots>!<end_line>
+    You don't get excited for anything!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ<three_dots>もう<three_dots>！<end_line>
       はりあいがないなぁ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, c'mon<three_dots>!<end_line>
     You don't get excited for anything!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -459,6 +463,11 @@
       ハンマーこわがってたのにな<end_line>
       よくがんばったよ<end_line>
     </sjis>
+    <ascii>
+    You were so afraid of<end_line>
+    the hammer yesterday, but you<end_line>
+    worked really hard to overcome it.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -466,12 +475,12 @@
       ハンマーこわがってたのにね<end_line>
       よくがんばったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You were so afraid of<end_line>
     the hammer yesterday, but you<end_line>
     worked really hard to overcome it.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -498,6 +507,11 @@
       いいがかりって<three_dots><end_line>
       昨日はキャーキャー言ってただろ<end_line>
     </sjis>
+    <ascii>
+    Oh, is that true?<end_line>
+    Weren't you screaming<end_line>
+    your head off just yesterday?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -505,12 +519,12 @@
       昨日はキャーキャー<end_line>
       言ってたじゃない<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, is that true?<end_line>
     Weren't you screaming<end_line>
     your head off just yesterday?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -799,15 +813,18 @@
     <sjis>
       オレも！？<end_line>
     </sjis>
+    <ascii>
+    Me too!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしも！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Me too!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -963,15 +980,18 @@
     <sjis>
       オレも！？<end_line>
     </sjis>
+    <ascii>
+    Me too!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしも！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Me too!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -1135,15 +1155,18 @@
     <sjis>
       オレも！？<end_line>
     </sjis>
+    <ascii>
+    Me too!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしも！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Me too!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1295,15 +1318,18 @@
     <sjis>
       オレも！？<end_line>
     </sjis>
+    <ascii>
+      Me too!?<end_line>
+    </ascii>
   </male>
   <female>
     <sjis>
       わたしも！？<end_line>
     </sjis>
-  </female>
     <ascii>
       Me too!?<end_line>
     </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Translation/JE Scripts/Day 01/005_24968700_17cfdfc.xml
+++ b/Translation/JE Scripts/Day 01/005_24968700_17cfdfc.xml
@@ -179,14 +179,17 @@
     <sjis>
       なんだよ！？<end_line>
     </sjis>
+    <ascii>
+    What's going on!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's going on!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 

--- a/Translation/JE Scripts/Day 01/006_24969852_17d027c.xml
+++ b/Translation/JE Scripts/Day 01/006_24969852_17d027c.xml
@@ -1,37 +1,50 @@
-<dialogue>
+<dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			入るぞ<end_line>
 			ミューノ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Murno,<end_line>
+    I'm coming in<three_dots><end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			入るよ<end_line>
 			ミューノ<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>    Murno,<end_line>
+    <ascii>
+    Murno,<end_line>
     I'm coming in<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノ！？<end_line>
 			どうしたんだ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Murno!?<end_line>
+    Are you okay?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			ミューノ！？<end_line>
 			どうしたの？<end_line>
 		</sjis>
-	</female>  <ascii>    Murno!?<end_line>    Are you okay?<end_line>  </ascii>
+    <ascii>
+    Murno!?<end_line>
+    Are you okay?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -41,7 +54,7 @@
 		大丈夫<three_dots><end_line>
 		ちょっと、クラっとしただけで<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'm fine<three_dots><end_line>
 		I'm just a little dizzy.<end_line>
 	</ascii>
@@ -55,7 +68,7 @@
 		みゅーの様ノ体温ガ　異常デス<end_line>
 		普段ヨリ　高クナッテイマス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Lady Murno's Temperature: Abnormal.<end_line>
 		She Is Overheating.<end_line>
 	</ascii>
@@ -69,7 +82,7 @@
 		え～っと<end_line>
 		ようするに<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Uhh~<end_line>
 		So in other words<three_dots><end_line>
 	</ascii>
@@ -82,7 +95,7 @@
 	<sjis>
 		熱があるのね<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I must have a fever<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -95,7 +108,7 @@
 		どうやらミューノは<three_dots><end_line>
 		少し熱があるみたいじゃな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Murno<three_dots><end_line>
 		She must have a fever<three_dots><end_line>
 	</ascii>
@@ -109,7 +122,7 @@
 		ちっ<three_dots><end_line>
 		熱があるじゃないか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Tch<three_dots><end_line>
 		She's got a fever<three_dots><end_line>
 	</ascii>
@@ -123,7 +136,7 @@
 		どうしましょう<end_line>
 		ミューノ様、すごい熱です！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What should we do!?<end_line>
 		Murno has a terrible fever!<end_line>
 	</ascii>
@@ -137,7 +150,7 @@
 		じゃあ、寝てなくちゃ！<end_line>
 		親方呼んでくるよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hm<three_dots><end_line>
 		Then, she should be in bed!<end_line>
 		I'll go get Master!<end_line>
@@ -151,7 +164,7 @@
 		ホントだ<end_line>
 		熱があるね<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You're right.<end_line>
 		It's definitely a fever.<end_line>
 	</ascii>
@@ -166,7 +179,7 @@
 		私ノ冷却水デ<end_line>
 		体ヲ冷ヤシマスカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We Must Perform Maintenance.<end_line>
 		I Will Reduce Her Body Temeprature<end_line>
 		With My Cooling Fluid.<end_line>
@@ -181,7 +194,7 @@
 		何言ってンだい！<end_line>
 		もっと悪くしたいのかい？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Stop right there!<end_line>
 		Are you trying to make it worse!?<end_line>
 	</ascii>
@@ -195,7 +208,7 @@
 		イイエ<three_dots><end_line>
 		デハ　ドウスレバ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I Am Not<three_dots><end_line>
 		Then What Action Should We-<end_line>
 	</ascii>
@@ -210,7 +223,7 @@
 		アンタに出番はないね<end_line>
 		おとなしくしてな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Right now,<end_line>
 		there's nothing you can do.<end_line>
 		Just stay quiet.<end_line>
@@ -224,7 +237,7 @@
 	<sjis>
 		了解デス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Roger.<end_line>
 	</ascii>
 </dialogue>
@@ -236,8 +249,9 @@
 		でも<end_line>
 		急に熱だなんて<three_dots><end_line>
 	</sjis>
-	<ascii>
-		But how could she develop<end_line>		a fever so suddenly<three_dots>?<end_line>
+  <ascii>
+		But how could she develop<end_line>
+		a fever so suddenly<three_dots>?<end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -250,7 +264,11 @@
 		相当ムリしてきたみたいだからね<three_dots><end_line>
 		安心したら一気にきたんだろうね<end_line>
 	</sjis>
-	<ascii>    She's been pushing herself so hard<three_dots><end_line>    All of the pent-up stress<end_line>    must have hit her all at once.<end_line>	</ascii>
+  <ascii>
+    She's been pushing herself so hard<three_dots><end_line>
+    All of the pent-up stress<end_line>
+    must have hit her all at once.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -261,7 +279,7 @@
 		ゆっくり休むのが一番だよ<end_line>
 		今はそっとしておいてやりな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It'll be best if she just rests.<end_line>
 		Leave her alone for now.<end_line>
 	</ascii>
@@ -275,7 +293,7 @@
 		そうだね<end_line>
 		わかった<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Okay.<end_line>
 	</ascii>
 </dialogue>
@@ -289,9 +307,10 @@
 		アンタは<partner>だけでも<end_line>
 		村長に紹介しといで<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Alright, leave this to me.<end_line>
-		You should go introduce <partner><end_line>		to the Chief.<end_line>
+		You should go introduce <partner><end_line>
+		to the Chief.<end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -303,9 +322,10 @@
 		近ごろはぐれもふえてきたし<end_line>
 		まちがわれないようにしなきゃね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There've been more strays lately,<end_line>
-		so we need to make sure<end_line>		<partner> isn't mistaken for one.<end_line>
+		so we need to make sure<end_line>
+		<partner> isn't mistaken for one.<end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -317,7 +337,8 @@
 		でも、紹介って<end_line>
 		なんて言ったらいいんだろ？<end_line>
 	</sjis>
-	<ascii>		Introduce, you say<three_dots><end_line>
+  <ascii>
+		Introduce, you say<three_dots><end_line>
 		What should I even say?<end_line>
 	</ascii>
 </dialogue>
@@ -331,7 +352,11 @@
 		アタシに召喚石をもらったとか<end_line>
 		そんな感じでいいんじゃない？<end_line>
 	</sjis>
-  <ascii>		Say something like,<end_line>	    "Master gave me a Summon Stone.<end_line>		This is my new partner."<end_line>	</ascii>
+  <ascii>
+		Say something like,<end_line>
+	    "Master gave me a Summon Stone.<end_line>
+		This is my new partner."<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -341,7 +366,7 @@
 	<sjis>
 		そんな感じでって<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That'll totally work<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -354,7 +379,7 @@
 		ソレハ真実ト　異ナリマス<end_line>
 		私ハみゅーの様ノ　召喚獣ダッタ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That Differs From The Truth.<end_line>
 		I Am Lady Murno's Summon Beast<three_dots><end_line>
 	</ascii>
@@ -368,8 +393,9 @@
 		本当のことを伝えてもいいのかい？<end_line>
 		ミューノはワケありなんだろ？<end_line>
 	</sjis>
-	<ascii>
-    Or would you rather tell the truth?<end_line>    Murno has her own issues, right?<end_line>
+  <ascii>
+    Or would you rather tell the truth?<end_line>
+    Murno has her own issues, right?<end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -380,7 +406,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -390,44 +416,54 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="vee" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだね<end_line>
 			わかったよ、親方<end_line>
 			行こう、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-			わかった、親方<end_line>
-			行こう、<partner><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You're right.<end_line>
     I understand, Master.<end_line>
     Let's get going, <partner><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+			わかった、親方<end_line>
+			行こう、<partner><end_line>
+		</sjis>
+    <ascii>
+    You're right.<end_line>
+    I understand, Master.<end_line>
+    Let's get going, <partner><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			<partner>？<end_line>
 			何してんだよ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    <partner>?<end_line>
+    Why aren't you saying anything?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			<partner>？<end_line>
 			何してんの？<end_line>
 		</sjis>
-	</female>
-  <ascii>
-    <partner>?<end_line>    Why aren't you saying anything?<end_line>
+    <ascii>
+    <partner>?<end_line>
+    Why aren't you saying anything?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -437,7 +473,7 @@
 		みゅーの様ノ熱ヲ　下ゲルタメニ<end_line>
 		オトナシクシテイマス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I Am Being Quiet<end_line>
 		To Lower Lady Murno's Fever.<end_line>
 	</ascii>
@@ -450,7 +486,7 @@
 	<sjis>
 		アンタ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -462,7 +498,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -476,7 +512,7 @@
 		元気にしたいのは<end_line>
 		よ～くわかったよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I get that you<end_line>
 		reaaallly want Murno<end_line>
 		to feel better.<end_line>
@@ -490,7 +526,7 @@
 	<sjis>
 		でもね、ジャマ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But you're being annoying!<end_line>
 	</ascii>
 </bigtext>
@@ -503,7 +539,10 @@
 		<player_nickname>といっしょに<end_line>
 		早く村長にあいさつしてきな！<end_line>
 	</sjis>
-	<ascii>    Come on, get out of here!<end_line>    Go meet the Chief!<end_line>	</ascii>
+  <ascii>
+    Come on, get out of here!<end_line>
+    Go meet the Chief!<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -514,7 +553,7 @@
 		お、親方！？<end_line>
 		ちょっとしずかに！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		M-Master!?<end_line>
 		You're too loud!<end_line>
 	</ascii>
@@ -526,7 +565,7 @@
 	<sjis>
 		うう<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hn<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -537,7 +576,7 @@
 	<sjis>
 		あ、ごめん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah. Sorry.<end_line>
 	</ascii>
 </dialogue>
@@ -549,7 +588,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -562,7 +601,7 @@
 		なんだい<end_line>
 		その目は<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey, what's up<end_line>
 		with your eyes?<end_line>
 	</ascii>
@@ -575,7 +614,7 @@
 	<sjis>
 		かめらデス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		They Are Cameras.<end_line>
 	</ascii>
 </dialogue>
@@ -587,7 +626,7 @@
 	<sjis>
 		そうじゃなくて<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's not what-<three_dots>!<end_line>
 	</ascii>
 </dialogue>
@@ -600,7 +639,7 @@
 		お、親方！？<end_line>
 		うるさいって<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		M-Master!?<end_line>
 		Keep it down<three_dots>!<end_line>
 	</ascii>
@@ -613,7 +652,7 @@
 	<sjis>
 		あ、ごめん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ahem~<end_line>
 	</ascii>
 </dialogue>
@@ -625,7 +664,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -639,7 +678,11 @@
 		アンタ、ジャマだから<end_line>
 		村長のところに行ってくれないか<end_line>
 	</sjis>
-	<ascii>		<three_dots>Anyway,<end_line>		you two are in the way.<end_line>		Just go and see the Chief already.<end_line>	</ascii>
+  <ascii>
+		<three_dots>Anyway,<end_line>
+		you two are in the way.<end_line>
+		Just go and see the Chief already.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -650,7 +693,7 @@
 		そうすればミューノもじき<end_line>
 		良くなるから、ね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Murno'll feel better in no time.<end_line>
 	</ascii>
 </dialogue>
@@ -664,7 +707,7 @@
 		出カケテイタ方ガ　イイ<end_line>
 		トイウコトデスカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		So You Are Saying<end_line>
 		It Is Better To Go Out<end_line>
 		Than Stay Here?<end_line>
@@ -679,7 +722,12 @@
 		村長へのあいさつ以外にも<end_line>
 		アンタたちには修行があるだろ<end_line>
 		鍛冶師ってのはヒマじゃないよ<end_line>
-	</sjis>	<ascii>		Even if you didn't need to see him,<end_line>		I'd make you train instead.<end_line>		Craftknights are quite busy.<end_line>	</ascii>
+	</sjis>
+  <ascii>
+		Even if you didn't need to see him,<end_line>
+		I'd make you train instead.<end_line>
+		Craftknights are quite busy.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -687,20 +735,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="vee" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			うん、わかったよ、親方<end_line>
 			とりあえず村長のところに行こう<end_line>
 			な、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Alright, Master.<end_line>
+    We'll be on our way.<end_line>
+    Okay <partner>?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			うん、わかったよ、親方<end_line>
 			とりあえず村長のところに行こう<end_line>
 			ね、<partner><end_line>
 		</sjis>
-	</female>
-  <ascii>    Alright, Master.<end_line>    We'll be on our way.<end_line>    Okay <partner>?<end_line>  </ascii>
+    <ascii>
+    Alright, Master.<end_line>
+    We'll be on our way.<end_line>
+    Okay <partner>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -711,7 +768,7 @@
 		<three_dots><end_line>
 		了解デス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 		Roger.<end_line>
 	</ascii>
@@ -726,7 +783,7 @@
 		熱冷ましはないのか？<end_line>
 		ワガハイに何か、できることは<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Then we must cure her quickly.<end_line>
 		Do we have any medicine?<end_line>
 		Is there anything I can do<three_dots>?<end_line>
@@ -741,7 +798,7 @@
 		今アンタがすべきことは<end_line>
 		おとなしくすることだよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What you should do,<end_line>
 		is stay quiet.<end_line>
 	</ascii>
@@ -755,7 +812,7 @@
 		なんじゃとおぬし！<end_line>
 		ワガハイに向かって<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Excuse me!?<end_line>
 		How dare you<three_dots><end_line>
 	</ascii>
@@ -770,7 +827,7 @@
 		今のミューノに必要なのは<end_line>
 		休むことだよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I told you to keep it down.<end_line>
 		What Murno need right now is rest.<end_line>
 	</ascii>
@@ -784,7 +841,7 @@
 		そうなのか<three_dots><end_line>
 		すまぬ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hm, is that so<three_dots><end_line>
 		My apologies<three_dots><end_line>
 	</ascii>
@@ -797,7 +854,10 @@
 		でも<end_line>
 		急に熱だなんて<three_dots><end_line>
 	</sjis>
-	<ascii>		But how could she develop<end_line>		a fever so suddenly<three_dots>?<end_line>	</ascii>
+  <ascii>
+		But how could she develop<end_line>
+		a fever so suddenly<three_dots>?<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -809,7 +869,11 @@
 		相当ムリしてきたみたいだからね<three_dots><end_line>
 		安心したら一気にきたんだろうね<end_line>
 	</sjis>
-  <ascii>    She's been pushing herself so hard<three_dots><end_line>    All of the pent-up stress<end_line>    must have hit her all at once.<end_line>  </ascii>
+  <ascii>
+    She's been pushing herself so hard<three_dots><end_line>
+    All of the pent-up stress<end_line>
+    must have hit her all at once.<end_line>
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -820,7 +884,7 @@
 		ゆっくり休むのが一番だよ<end_line>
 		今はそっとしておいてやりな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It'll be best if she just rests.<end_line>
 		Leave her alone for now.<end_line>
 	</ascii>
@@ -834,7 +898,9 @@
 		そうだね<end_line>
 		わかった<end_line>
 	</sjis>
-	<ascii>		Okay.<end_line>	</ascii>
+  <ascii>
+		Okay.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -846,7 +912,11 @@
 		アンタは<partner>だけでも<end_line>
 		村長に紹介しといで<end_line>
 	</sjis>
-	<ascii>		Alright, leave this to me.<end_line>		You should go introduce <partner><end_line>		to the Chief.<end_line>	</ascii>
+  <ascii>
+		Alright, leave this to me.<end_line>
+		You should go introduce <partner><end_line>
+		to the Chief.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -857,7 +927,11 @@
 		近ごろはぐれもふえてきたし<end_line>
 		まちがわれないようにしなきゃね<end_line>
 	</sjis>
-	<ascii>		There've been more strays lately,<end_line>		so we need to make sure<end_line>		<partner> isn't mistaken for one.<end_line>	</ascii>
+  <ascii>
+		There've been more strays lately,<end_line>
+		so we need to make sure<end_line>
+		<partner> isn't mistaken for one.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -868,7 +942,9 @@
 		でも、紹介って<end_line>
 		なんて言ったらいいんだろ？<end_line>
 	</sjis>
-	<ascii>		What should I even say?<end_line>	</ascii>
+  <ascii>
+		What should I even say?<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -880,7 +956,11 @@
 		アタシに召喚石をもらったとか<end_line>
 		そんな感じでいいんじゃない？<end_line>
 	</sjis>
-  <ascii>		Say something like,<end_line>		"Master gave me a Summon Stone.<end_line>		This is my new partner."<end_line>	</ascii>
+  <ascii>
+		Say something like,<end_line>
+		"Master gave me a Summon Stone.<end_line>
+		This is my new partner."<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -890,7 +970,9 @@
 	<sjis>
 		そんな感じでって<three_dots><end_line>
 	</sjis>
-	<ascii>		That'll totally work<three_dots><end_line>	</ascii>
+  <ascii>
+		That'll totally work<three_dots><end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -901,7 +983,9 @@
 		しかし、本来のワガハイは<end_line>
 		ミューノの召喚獣で<three_dots><end_line>
 	</sjis>
-	<ascii>    But the truth is,<end_line>    I am Murno's Summon Beast<three_dots><end_line>
+  <ascii>
+    But the truth is,<end_line>
+    I am Murno's Summon Beast<three_dots><end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -913,8 +997,9 @@
 		本当のことを伝えてもいいのかい？<end_line>
 		ミューノはワケありなんだろ？<end_line>
 	</sjis>
-	<ascii>
-    Or would you rather tell the truth?<end_line>    Murno has her own issues, right?<end_line>
+  <ascii>
+    Or would you rather tell the truth?<end_line>
+    Murno has her own issues, right?<end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -925,7 +1010,7 @@
 	<sjis>
 		たしかに<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That is true<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -935,20 +1020,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="vee" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだね<end_line>
 			わかったよ、親方<end_line>
 			行こう、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    You're right.<end_line>
+    I understand, Master.<end_line>
+    Let's get going, <partner><end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<end_line>
 			わかった、親方<end_line>
 			行こう、<partner><end_line>
 		</sjis>
-	</female>
-  <ascii>    You're right.<end_line>    I understand, Master.<end_line>    Let's get going, <partner><end_line>  </ascii>
+    <ascii>
+    You're right.<end_line>
+    I understand, Master.<end_line>
+    Let's get going, <partner><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -959,7 +1053,7 @@
 		体の調子の悪いミューノを<end_line>
 		ひとりにしておくわけには<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		However<three_dots><end_line>
 		I cannot leave Murno alone<end_line>
 		when she is in such bad shape<three_dots><end_line>
@@ -974,7 +1068,7 @@
 		安心しな<end_line>
 		ちゃんとアタシがついてるからさ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Relax.<end_line>
 		I'll be here for her.<end_line>
 	</ascii>
@@ -987,7 +1081,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -999,7 +1093,7 @@
 	<sjis>
 		なんだい、その目は？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What's with that look?<end_line>
 	</ascii>
 </dialogue>
@@ -1011,7 +1105,7 @@
 	<sjis>
 		不安じゃ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I'm even more worried<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1023,7 +1117,7 @@
 	<sjis>
 		なんだって！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Excuse me!?<end_line>
 	</ascii>
 </bigtext>
@@ -1036,7 +1130,10 @@
 		お、親方！？<end_line>
 		ちょっとしずかに！<end_line>
 	</sjis>
-	<ascii>		M-Master!?<end_line>		You're too loud!<end_line>	</ascii>
+  <ascii>
+		M-Master!?<end_line>
+		You're too loud!<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1045,7 +1142,7 @@
 	<sjis>
 		うう<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hn<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1056,7 +1153,7 @@
 	<sjis>
 		あ、ごめん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah. Sorry.<end_line>
 	</ascii>
 </dialogue>
@@ -1068,7 +1165,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1082,8 +1179,9 @@
 		さっきはアンタが変なこというから<end_line>
 		ついカッとなっちまって<three_dots><end_line>
 	</sjis>
-	<ascii>
-		Stop looking at me like that.<end_line>		This is all your fault, you know<three_dots><end_line>
+  <ascii>
+		Stop looking at me like that.<end_line>
+		This is all your fault, you know<three_dots><end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -1095,7 +1193,7 @@
 		ワガハイ、なにも変なことなど<end_line>
 		言っておらんがの？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh, I don't recall<end_line>
 		saying anything odd at all.<end_line>
 	</ascii>
@@ -1108,7 +1206,7 @@
 	<sjis>
 		なんだって！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh!?<end_line>
 	</ascii>
 </bigtext>
@@ -1120,7 +1218,7 @@
 	<sjis>
 		だから親方<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Master<three_dots>!<end_line>
 	</ascii>
 </dialogue>
@@ -1134,10 +1232,11 @@
 		アンタ、ジャマだから<end_line>
 		村長のところに行ってくれないか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Anyway,<end_line>
 		you two are in the way.<end_line>
-		Just go and see the Chief already.<end_line>	</ascii>
+		Just go and see the Chief already.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1148,7 +1247,7 @@
 		そうすればミューノもじき<end_line>
 		良くなるから、ね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Murno'll feel better in no time.<end_line>
 	</ascii>
 </dialogue>
@@ -1160,7 +1259,8 @@
 	<sjis>
 		ジャマじゃと<three_dots><end_line>
 	</sjis>
-	<ascii>		In the way<three_dots><end_line>
+  <ascii>
+		In the way<three_dots><end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -1172,7 +1272,12 @@
 		村長へのあいさつ以外にも<end_line>
 		アンタたちには修行があるだろ<end_line>
 		鍛冶師ってのはヒマじゃないよ<end_line>
-	</sjis>	<ascii>		Even if you didn't need to see him,<end_line>		I'd make you train instead.<end_line>		Craftknights are quite busy.<end_line>	</ascii>
+	</sjis>
+  <ascii>
+		Even if you didn't need to see him,<end_line>
+		I'd make you train instead.<end_line>
+		Craftknights are quite busy.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1180,24 +1285,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="vee" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			うん、わかったよ、親方<end_line>
 			とりあえず村長のところに行こう<end_line>
 			な、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん、わかったよ、親方<end_line>
-			とりあえず村長のところに行こう<end_line>
-			ね、<partner><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright, Master.<end_line>
     We'll be on our way.<end_line>
     Okay <partner>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん、わかったよ、親方<end_line>
+			とりあえず村長のところに行こう<end_line>
+			ね、<partner><end_line>
+		</sjis>
+    <ascii>
+    Alright, Master.<end_line>
+    We'll be on our way.<end_line>
+    Okay <partner>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1207,7 +1317,7 @@
 	<sjis>
 		わかった<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Alright.<end_line>
 	</ascii>
 </dialogue>
@@ -1219,7 +1329,7 @@
 	<sjis>
 		なんとかできるのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Is there anything we can do?<end_line>
 	</ascii>
 </dialogue>
@@ -1233,7 +1343,7 @@
 		おとなしく寝てれば<end_line>
 		よくなるよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No need to worry,<end_line>
 		let her get some rest and<end_line>
 		she should get better.<end_line>
@@ -1248,7 +1358,7 @@
 		なんだと<three_dots><end_line>
 		誰が心配など<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What<three_dots><end_line>
 		I didn't say I was worried<three_dots>!<end_line>
 	</ascii>
@@ -1263,7 +1373,7 @@
 		おとなしく寝かせてやれって<end_line>
 		言ってるだろ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Keep it down.<end_line>
 		You'll wake her up.<end_line>
 	</ascii>
@@ -1276,7 +1386,7 @@
 	<sjis>
 		ちっ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Tch<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1288,7 +1398,10 @@
 		でも<end_line>
 		急に熱だなんて<three_dots><end_line>
 	</sjis>
-  <ascii>    But how could she develop<end_line>    a fever so suddenly<three_dots>?<end_line>  </ascii>
+  <ascii>
+    But how could she develop<end_line>
+    a fever so suddenly<three_dots>?<end_line>
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1300,7 +1413,11 @@
 		相当ムリしてきたみたいだからね<three_dots><end_line>
 		安心したら一気にきたんだろうね<end_line>
 	</sjis>
-  <ascii>    She's been pushing herself so hard<three_dots><end_line>    All of the pent-up stress<end_line>    must have hit her all at once.<end_line>  </ascii>
+  <ascii>
+    She's been pushing herself so hard<three_dots><end_line>
+    All of the pent-up stress<end_line>
+    must have hit her all at once.<end_line>
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1311,7 +1428,10 @@
 		ということで、ココにいても<end_line>
 		アンタたちのやることはないよ<end_line>
 	</sjis>
-	<ascii>    There's nothing you two<end_line>    can do about it.<end_line>	</ascii>
+  <ascii>
+    There's nothing you two<end_line>
+    can do about it.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1322,7 +1442,7 @@
 		そっか<three_dots><end_line>
 		わかった<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I suppose so<three_dots><end_line>
 		Okay.<end_line>
 	</ascii>
@@ -1337,7 +1457,11 @@
 		アンタは<partner>だけでも<end_line>
 		村長に紹介しといで<end_line>
 	</sjis>
-  <ascii>		Alright, leave this to me.<end_line>		You should go introduce <partner><end_line>		to the Chief.<end_line>	</ascii>
+  <ascii>
+		Alright, leave this to me.<end_line>
+		You should go introduce <partner><end_line>
+		to the Chief.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1348,7 +1472,11 @@
 		近ごろはぐれもふえてきたし<end_line>
 		まちがわれないようにしなきゃね<end_line>
 	</sjis>
-	<ascii>		There've been more strays lately,<end_line>		so we need to make sure<end_line>		<partner> isn't mistaken for one.<end_line>	</ascii>
+  <ascii>
+		There've been more strays lately,<end_line>
+		so we need to make sure<end_line>
+		<partner> isn't mistaken for one.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1359,7 +1487,9 @@
 		でも、紹介って<end_line>
 		なんて言ったらいいんだろ？<end_line>
 	</sjis>
-  <ascii>		What should I even say?<end_line>	</ascii>
+  <ascii>
+		What should I even say?<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1371,7 +1501,11 @@
 		アタシに召喚石をもらったとか<end_line>
 		そんな感じでいいんじゃない？<end_line>
 	</sjis>
-  <ascii>		Say something like,<end_line>		"Master gave me a Summon Stone.<end_line>		This is my new partner."<end_line>	</ascii>
+  <ascii>
+		Say something like,<end_line>
+		"Master gave me a Summon Stone.<end_line>
+		This is my new partner."<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1381,7 +1515,9 @@
 	<sjis>
 		そんな感じでって<three_dots><end_line>
 	</sjis>
-	<ascii>		That'll totally work<three_dots><end_line>	</ascii>
+  <ascii>
+		That'll totally work<three_dots><end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1391,7 +1527,7 @@
 	<sjis>
 		コイツの相方か<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		This kid's partner, huh<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -1405,7 +1541,10 @@
 		いいのかい？<end_line>
 		ミューノはワケありなんだろ？<end_line>
 	</sjis>
-	<ascii>    Or would you rather tell the truth?<end_line>    Murno has her own issues, right?<end_line>	</ascii>
+  <ascii>
+    Or would you rather tell the truth?<end_line>
+    Murno has her own issues, right?<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1416,7 +1555,7 @@
 		ちっ<three_dots><end_line>
 		好きにしろ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hmph<three_dots><end_line>
 		Suit yourselves.<end_line>
 	</ascii>
@@ -1427,19 +1566,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="vee" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだね<end_line>
 			わかったよ、親方<end_line>
 			行こう、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    You're right.<end_line>
+    Alright, let's go,<end_line>
+    <partner>.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<end_line>
 			わかった、親方<end_line>
 			行こう、<partner><end_line>
 		</sjis>
-	</female>  <ascii>    You're right.<end_line>    Alright, let's go,<end_line>    <partner>.<end_line>  </ascii>
+    <ascii>
+    You're right.<end_line>
+    Alright, let's go,<end_line>
+    <partner>.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1450,8 +1599,9 @@
 		ミューノのメンドウは<end_line>
 		キサマひとりでみるつもりか<three_dots><end_line>
 	</sjis>
-	<ascii>
-		<three_dots><end_line>		Do you intend to take care<end_line>
+  <ascii>
+		<three_dots><end_line>
+		Do you intend to take care<end_line>
 		of her on your own<three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -1464,7 +1614,7 @@
 		キサマじゃなくて、親方だろ？<end_line>
 		まったく、ちゃんとしなよ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Call me "Master", not "you".<end_line>
 		Seriously, show some respect<three_dots><end_line>
 	</ascii>
@@ -1479,7 +1629,9 @@
 		ひとりでも十分メンドウみられるよ<end_line>
 		安心して行ってきなって<end_line>
 	</sjis>
-	<ascii>    I'll be perfectly fine on my won.<end_line>    Hurry up and get out of here.<end_line>
+  <ascii>
+    I'll be perfectly fine on my won.<end_line>
+    Hurry up and get out of here.<end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -1490,7 +1642,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1502,7 +1654,7 @@
 	<sjis>
 		なんだい、その目は？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What's with the look?<end_line>
 	</ascii>
 </dialogue>
@@ -1514,7 +1666,7 @@
 	<sjis>
 		別に<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Nothing<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1528,8 +1680,10 @@
 		文句があるなら<end_line>
 		ハッキリ言いな！<end_line>
 	</sjis>
-	<ascii>
-		Huh<three_dots>?<end_line>		What, you got a problem!?<end_line>	</ascii>
+  <ascii>
+		Huh<three_dots>?<end_line>
+		What, you got a problem!?<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1540,7 +1694,10 @@
 		お、親方！？<end_line>
 		ちょっとしずかに！<end_line>
 	</sjis>
-  <ascii>		M-Master!?<end_line>		You're too loud!<end_line>	</ascii>
+  <ascii>
+		M-Master!?<end_line>
+		You're too loud!<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1549,7 +1706,7 @@
 	<sjis>
 		うう<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hn<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1560,7 +1717,9 @@
 	<sjis>
 		あ、ごめん<end_line>
 	</sjis>
-	<ascii>		Ah. Sorry.<end_line>	</ascii>
+  <ascii>
+		Ah. Sorry.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1570,7 +1729,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1584,7 +1743,10 @@
 		さっきはアンタが変なこというから<end_line>
 		ついカッとなっちまって<three_dots><end_line>
 	</sjis>
-	<ascii>		Stop looking at me like that.<end_line>		This is all your fault, you know<three_dots><end_line>	</ascii>
+  <ascii>
+		Stop looking at me like that.<end_line>
+		This is all your fault, you know<three_dots><end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1594,7 +1756,7 @@
 	<sjis>
 		私は何も言ってないが<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I didn't say anything<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1606,7 +1768,7 @@
 	<sjis>
 		なんだって！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh!?<end_line>
 	</ascii>
 </bigtext>
@@ -1618,7 +1780,9 @@
 	<sjis>
 		だから親方<three_dots>！<end_line>
 	</sjis>
-	<ascii>		Master<three_dots>!<end_line>	</ascii>
+  <ascii>
+		Master<three_dots>!<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1630,7 +1794,11 @@
 		アンタ、ジャマだから<end_line>
 		村長のところに行ってくれないか<end_line>
 	</sjis>
-	<ascii>		<three_dots>Anyway,<end_line>		you two are in the way.<end_line>		Just go and see the Chief already.<end_line>	</ascii>
+  <ascii>
+		<three_dots>Anyway,<end_line>
+		you two are in the way.<end_line>
+		Just go and see the Chief already.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1641,7 +1809,7 @@
 		そうすればミューノもじき<end_line>
 		良くなるから、ね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Murno'll feel better in no time.<end_line>
 	</ascii>
 </dialogue>
@@ -1653,7 +1821,7 @@
 	<sjis>
 		ジャマだと<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hmph<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1667,27 +1835,41 @@
 		アンタたちには修行があるだろ<end_line>
 		鍛冶師ってのはヒマじゃないよ<end_line>
 	</sjis>
-	<ascii>		Even if you didn't need to see him,<end_line>		I'd make you train instead.<end_line>		Craftknights are quite busy.<end_line>	</ascii></dialogue>
+  <ascii>
+		Even if you didn't need to see him,<end_line>
+		I'd make you train instead.<end_line>
+		Craftknights are quite busy.<end_line>
+	</ascii>
+</dialogue>
 <dialogue>
 	<partner name="killfith">
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="vee" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			うん、わかったよ、親方<end_line>
 			とりあえず村長のところに行こう<end_line>
 			な、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Alright, Master.<end_line>
+    We'll be on our way.<end_line>
+    Okay <partner>?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			うん、わかったよ、親方<end_line>
 			とりあえず村長のところに行こう<end_line>
 			ね、<partner><end_line>
 		</sjis>
-	</female>
-  <ascii>    Alright, Master.<end_line>    We'll be on our way.<end_line>    Okay <partner>?<end_line>  </ascii>
+    <ascii>
+    Alright, Master.<end_line>
+    We'll be on our way.<end_line>
+    Okay <partner>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1698,7 +1880,7 @@
 		ちっ<three_dots><end_line>
 		好きにしろ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Yeah, yeah<three_dots><end_line>
 		Whatever<three_dots><end_line>
 	</ascii>
@@ -1712,7 +1894,7 @@
 		どうしましょう？<end_line>
 		はやくなんとかしないと<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What should we do!?<end_line>
 		We have to do something<three_dots>!<end_line>
 	</ascii>
@@ -1727,7 +1909,7 @@
 		私がミューノ様の体を<end_line>
 		あたためて<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh, that's right!<end_line>
 		I'll warm her up<end_line>
 		with my body<three_dots><end_line>
@@ -1741,7 +1923,7 @@
 	<sjis>
 		そんなことしなくていいから<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Y-You don't have to do that.<end_line>
 	</ascii>
 </dialogue>
@@ -1755,7 +1937,8 @@
 		ミューノ様を元気にすることが<end_line>
 		できるのですか？<end_line>
 	</sjis>
-	<ascii>		But what else can I do<end_line>
+  <ascii>
+		But what else can I do<end_line>
 		to make Lady Murno<end_line>
 		feel better?<end_line>
 	</ascii>
@@ -1769,7 +1952,7 @@
 		今のアンタにできることはひとつ<end_line>
 		おとなしくしてることだけだよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The only thing you can do<end_line>
 		now is stay quiet.<end_line>
 	</ascii>
@@ -1782,7 +1965,7 @@
 	<sjis>
 		そうなんですか<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Is that so<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1794,7 +1977,10 @@
 		でも<end_line>
 		急に熱だなんて<three_dots><end_line>
 	</sjis>
-  <ascii>    But how could she develop<end_line>    a fever so suddenly<three_dots>?<end_line>  </ascii>
+  <ascii>
+    But how could she develop<end_line>
+    a fever so suddenly<three_dots>?<end_line>
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1806,7 +1992,11 @@
 		相当ムリしてきたみたいだからね<three_dots><end_line>
 		安心したら一気にきたんだろうね<end_line>
 	</sjis>
-  <ascii>    She's been pushing herself so hard<three_dots><end_line>    All of the pent-up stress<end_line>    must have hit her all at once.<end_line>  </ascii>
+  <ascii>
+    She's been pushing herself so hard<three_dots><end_line>
+    All of the pent-up stress<end_line>
+    must have hit her all at once.<end_line>
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1817,7 +2007,7 @@
 		ゆっくり休むのが一番だよ<end_line>
 		今はそっとしておいてやりな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It'll be best if she just rests.<end_line>
 		Leave her alone for now.<end_line>
 	</ascii>
@@ -1831,7 +2021,9 @@
 		そうだね<end_line>
 		わかった<end_line>
 	</sjis>
-  <ascii>		Okay.<end_line>	</ascii>
+  <ascii>
+		Okay.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1843,7 +2035,11 @@
 		アンタは<partner>だけでも<end_line>
 		村長に紹介しといで<end_line>
 	</sjis>
-  <ascii>		Alright, leave this to me.<end_line>		You should go introduce <partner><end_line>		to the Chief.<end_line>	</ascii>
+  <ascii>
+		Alright, leave this to me.<end_line>
+		You should go introduce <partner><end_line>
+		to the Chief.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1854,7 +2050,11 @@
 		近ごろはぐれもふえてきたし<end_line>
 		まちがわれないようにしなきゃね<end_line>
 	</sjis>
-  <ascii>		There've been more strays lately,<end_line>		so we need to make sure<end_line>		<partner> isn't mistaken for one.<end_line>	</ascii>
+  <ascii>
+		There've been more strays lately,<end_line>
+		so we need to make sure<end_line>
+		<partner> isn't mistaken for one.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1865,7 +2065,9 @@
 		でも、紹介って<end_line>
 		なんて言ったらいいんだろ？<end_line>
 	</sjis>
-  <ascii>		What should I even say?<end_line>	</ascii>
+  <ascii>
+		What should I even say?<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1877,7 +2079,11 @@
 		アタシに召喚石をもらったとか<end_line>
 		そんな感じでいいんじゃない？<end_line>
 	</sjis>
-  <ascii>		Say something like,<end_line>		"Master gave me a Summon Stone.<end_line>		This is my new partner."<end_line>	</ascii>
+  <ascii>
+		Say something like,<end_line>
+		"Master gave me a Summon Stone.<end_line>
+		This is my new partner."<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1887,7 +2093,9 @@
 	<sjis>
 		そんな感じでって<three_dots><end_line>
 	</sjis>
-	<ascii>		That'll totally work<three_dots><end_line>	</ascii>
+  <ascii>
+		That'll totally work<three_dots><end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1899,7 +2107,7 @@
 		私、本当は<end_line>
 		ミューノ様の召喚獣で<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But, that's not<three_dots><end_line>
 		I am really Lady Murno's partner<three_dots><end_line>
 	</ascii>
@@ -1914,7 +2122,10 @@
 		いいのかい？<end_line>
 		ミューノはワケありなんだろ？<end_line>
 	</sjis>
-	<ascii>    Or would you rather tell the truth?<end_line>    Murno has her own issues, right?<end_line>	</ascii>
+  <ascii>
+    Or would you rather tell the truth?<end_line>
+    Murno has her own issues, right?<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1925,7 +2136,8 @@
 		たしかに<three_dots><end_line>
 		そうですわ<three_dots><end_line>
 	</sjis>
-	<ascii>		<three_dots>I suppose you're right.<end_line>
+  <ascii>
+		<three_dots>I suppose you're right.<end_line>
 	</ascii>
 </dialogue>
 <dialogue>
@@ -1934,20 +2146,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだね<end_line>
 			わかったよ、親方<end_line>
 			行こう、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Alright, Master.<end_line>
+    We'll be on our way.<end_line>
+    Okay <partner>?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<end_line>
 			わかった、親方<end_line>
 			行こう、<partner><end_line>
 		</sjis>
-	</female>
-  <ascii>    Alright, Master.<end_line>    We'll be on our way.<end_line>    Okay <partner>?<end_line>  </ascii>
+    <ascii>
+    Alright, Master.<end_line>
+    We'll be on our way.<end_line>
+    Okay <partner>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1958,7 +2179,7 @@
 		ミューノ様は親方さんが<end_line>
 		ひとりでみているのですか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Um<three_dots><end_line>
 		Master, will you be looking after<end_line>
 		Lady Murno by yourself?<end_line>
@@ -1974,8 +2195,9 @@
 		ちゃんとアタシがついてるからさ<end_line>
 		安心しな<end_line>
 	</sjis>
-	<ascii>
-		That's right.<end_line>		I'll be here the whole time,<end_line>
+  <ascii>
+		That's right.<end_line>
+		I'll be here the whole time,<end_line>
 		so don't worry about it.<end_line>
 	</ascii>
 </dialogue>
@@ -1987,7 +2209,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1999,7 +2221,7 @@
 	<sjis>
 		心配ですわ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I am more worried now<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2011,7 +2233,7 @@
 	<sjis>
 		なんだって！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What was that!?<end_line>
 	</ascii>
 </bigtext>
@@ -2024,7 +2246,10 @@
 		お、親方！？<end_line>
 		ちょっとしずかに！<end_line>
 	</sjis>
-  <ascii>		M-Master!?<end_line>		You're too loud!<end_line>	</ascii>
+  <ascii>
+		M-Master!?<end_line>
+		You're too loud!<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2033,7 +2258,7 @@
 	<sjis>
 		うう<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hn<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2044,7 +2269,7 @@
 	<sjis>
 		あ、ごめん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah. Sorry.<end_line>
 	</ascii>
 </dialogue>
@@ -2056,7 +2281,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2070,7 +2295,10 @@
 		さっきはアンタが変なこというから<end_line>
 		ついカッとなっちまって<three_dots><end_line>
 	</sjis>
-	<ascii>		Stop looking at me like that.<end_line>		This is all your fault, you know<three_dots><end_line>	</ascii>
+  <ascii>
+		Stop looking at me like that.<end_line>
+		This is all your fault, you know<three_dots><end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2080,7 +2308,7 @@
 	<sjis>
 		やっぱり心配ですわ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I really am worried<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2092,7 +2320,7 @@
 	<sjis>
 		なんだって！？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Huh!?<end_line>
 	</ascii>
 </bigtext>
@@ -2104,7 +2332,7 @@
 	<sjis>
 		だから親方<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Master<three_dots>!<end_line>
 	</ascii>
 </dialogue>
@@ -2118,7 +2346,11 @@
 		アンタ、ジャマだから<end_line>
 		村長のところに行ってくれないか<end_line>
 	</sjis>
-	<ascii>		<three_dots>Anyway,<end_line>		you two are in the way.<end_line>		Just go and see the Chief already.<end_line>	</ascii>
+  <ascii>
+		<three_dots>Anyway,<end_line>
+		you two are in the way.<end_line>
+		Just go and see the Chief already.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2129,7 +2361,7 @@
 		そうすればミューノもじき<end_line>
 		良くなるから、ね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Murno'll feel better in no time.<end_line>
 	</ascii>
 </dialogue>
@@ -2141,7 +2373,7 @@
 	<sjis>
 		私が、ジャマ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Me? I am not in<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2154,7 +2386,12 @@
 		村長へのあいさつ以外にも<end_line>
 		アンタたちには修行があるだろ<end_line>
 		鍛冶師ってのはヒマじゃないよ<end_line>
-	</sjis>	<ascii>		Even if you didn't need to see him,<end_line>		I'd make you train instead.<end_line>		Craftknights are quite busy.<end_line>	</ascii>
+	</sjis>
+  <ascii>
+		Even if you didn't need to see him,<end_line>
+		I'd make you train instead.<end_line>
+		Craftknights are quite busy.<end_line>
+	</ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2162,20 +2399,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			うん、わかったよ、親方<end_line>
 			とりあえず村長のところに行こう<end_line>
 			な、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Alright, Master.<end_line>
+    We'll be on our way.<end_line>
+    Okay <partner>?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			うん、わかったよ、親方<end_line>
 			とりあえず村長のところに行こう<end_line>
 			ね、<partner><end_line>
 		</sjis>
-	</female>
-  <ascii>    Alright, Master.<end_line>    We'll be on our way.<end_line>    Okay <partner>?<end_line>  </ascii>
+    <ascii>
+    Alright, Master.<end_line>
+    We'll be on our way.<end_line>
+    Okay <partner>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2186,7 +2432,7 @@
 		仕方ありませんわ<three_dots><end_line>
 		わかりました<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Very well<three_dots><end_line>
 		I understand<three_dots><end_line>
 	</ascii>

--- a/Translation/JE Scripts/Day 01/008_24303596_172d7ec.xml
+++ b/Translation/JE Scripts/Day 01/008_24303596_172d7ec.xml
@@ -1,10 +1,10 @@
 <location>
-	<sjis>
+  <sjis>
 		ディックル村<end_line>
 	</sjis>
 </location>
 <location>
-	<sjis>
+  <sjis>
 		ディックル村　住宅地<end_line>
 	</sjis>
 </location>
@@ -12,61 +12,73 @@
 	<info box="simple">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			外に出るより今は<end_line>
 			工房で修行の続きだな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			外に出るより今は<end_line>
-			工房で修行の続きね！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Forget going outside,<end_line>
     I need to continue training!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			外に出るより今は<end_line>
+			工房で修行の続きね！<end_line>
+		</sjis>
+    <ascii>
+    Forget going outside,<end_line>
+    I need to continue training!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			<partner>を紹介しに<end_line>
 			村長のとこに行かないと！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<partner>を紹介しに<end_line>
-			村長のとこに行かなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I need to introduce<end_line>
     <partner> to the Chief!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<partner>を紹介しに<end_line>
+			村長のとこに行かなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    I need to introduce<end_line>
+    <partner> to the Chief!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ザックにハンマーを<end_line>
 			届けてやらないと<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ザックにハンマーを<end_line>
-			届けてあげなくちゃ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I need to return this hammer<three_dots><end_line>
     Where's Zakk<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ザックにハンマーを<end_line>
+			届けてあげなくちゃ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I need to return this hammer<three_dots><end_line>
+    Where's Zakk<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">

--- a/Translation/JE Scripts/Day 01/012_24301996_172d1ac.xml
+++ b/Translation/JE Scripts/Day 01/012_24301996_172d1ac.xml
@@ -15,15 +15,18 @@
     <sjis>
       こっちには用はないな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Nothing to do here<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       こっちの方には用事はないよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Nothing to do here<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Translation/JE Scripts/Day 01/021_24975868_17d19fc.xml
+++ b/Translation/JE Scripts/Day 01/021_24975868_17d19fc.xml
@@ -21,6 +21,10 @@
       オレのパートナー<end_line>
       いっしょに鍛冶をするんだ！<end_line>
     </sjis>
+    <ascii>
+    Uh, this is <partner>, my partner!<end_line>
+    We'll be training together!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -28,11 +32,11 @@
       わたしのパートナー<end_line>
       いっしょに鍛冶をするんだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uh, this is <partner>, my partner!<end_line>
     We'll be training together!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -421,6 +425,11 @@
       お前が問題起こすと<end_line>
       ミューノまで困るんだぞ！<end_line>
     </sjis>
+    <ascii>
+    Cut it out<three_dots><end_line>
+    You'll just cause more<end_line>
+    trouble for Murno!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -428,12 +437,12 @@
       あなたが問題起こすと<end_line>
       ミューノまで困るんだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Cut it out<three_dots><end_line>
     You'll just cause more<end_line>
     trouble for Murno!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">

--- a/Translation/JE Scripts/Day 01/022_24979820_17d296c.xml
+++ b/Translation/JE Scripts/Day 01/022_24979820_17d296c.xml
@@ -15,15 +15,18 @@
     <sjis>
       なんだよ！？<end_line>
     </sjis>
+    <ascii>
+    What was that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なんなの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -33,16 +36,19 @@
       おい<end_line>
       大丈夫か！？<end_line>
     </sjis>
+    <ascii>
+    Hey, are you okay?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ねえ<end_line>
       大丈夫！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, are you okay?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -81,6 +87,11 @@
       はぐれって言うなよ<end_line>
       景気わる男の子分！<end_line>
     </sjis>
+    <ascii>
+    Hey, my name is <player_name>!<end_line>
+    Don't call my Master a Stray,<end_line>
+    when your leader is so unsociable!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -88,12 +99,12 @@
       はぐれって言わないでよ<end_line>
       景気わる男の子分！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, my name is <player_name>!<end_line>
     Don't call my Master a Stray,<end_line>
     when your leader is so unsociable!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -183,6 +194,10 @@
       こいつ、オレのパートナーの<end_line>
       <partner><end_line>
     </sjis>
+    <ascii>
+    Yeah.<end_line>
+    This my partner, <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -190,11 +205,11 @@
       この子、わたしのパートナーよ<end_line>
       <partner>っていうの<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah.<end_line>
     This my partner, <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -233,17 +248,21 @@
       知るかよ<end_line>
       勝手にコケてたんだよ<end_line>
     </sjis>
+    <ascii>
+    How should know?<end_line>
+    You tripped all on your own.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       知らないよ<end_line>
       勝手に転んでたんでしょ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How should know?<end_line>
     You tripped all on your own.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -267,15 +286,18 @@
     <sjis>
       いそがしいヤツだな<end_line>
     </sjis>
+    <ascii>
+    He seems busy.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       いそがしい子ね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     He seems busy.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -418,17 +440,21 @@
       しかたない<end_line>
       届けてやるか！<end_line>
     </sjis>
+    <ascii>
+    We don't have a choice.<end_line>
+    Let's return it!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       しかたない<end_line>
       届けてあげよう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We don't have a choice.<end_line>
     Let's return it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -604,17 +630,21 @@
       うおっ、村長！？<end_line>
       いつからそこに！？<end_line>
     </sjis>
+    <ascii>
+    Uwah, chief!?<end_line>
+    How long have you been there!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うわっ、村長！？<end_line>
       いつからそこに！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uwah, chief!?<end_line>
     How long have you been there!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -707,6 +737,11 @@
       ゴメン、親方<three_dots><end_line>
       オレ、カッコワルかったよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    <three_dots>Yes<end_line>
+    I'm sorry, Chief<three_dots><end_line>
+    I was wrong<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -714,12 +749,12 @@
       ゴメン、親方<three_dots><end_line>
       わたし、カッコワルかったよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots>Yes<end_line>
     I'm sorry, Chief<three_dots><end_line>
     I was wrong<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -765,17 +800,21 @@
       よし！<end_line>
       あいつに届けにいくぞ<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Let's go return his hammer.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       あの子に届けにいこう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Let's go return his hammer.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -800,6 +839,11 @@
       おー！<end_line>
       とか言ってくれないか？<end_line>
     </sjis>
+    <ascii>
+    Hey, at times like these,<end_line>
+    you should say something like,<end_line>
+    "Yes! Let's do this!"<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -807,12 +851,12 @@
       おー！<end_line>
       とか言ってくれない？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, at times like these,<end_line>
     you should say something like,<end_line>
     "Yes! Let's do this!"<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -872,6 +916,11 @@
       今、<partner>笑わなかった？<end_line>
       オレなにか、おかしなことした？<end_line>
     </sjis>
+    <ascii>
+    Eh<three_dots>?<end_line>
+    Did you smile just now, <partner>?<end_line>
+    What's so funny?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -879,12 +928,12 @@
       今、<partner>笑わなかった？<end_line>
       わたしなにか、おかしなことした？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh<three_dots>?<end_line>
     Did you smile just now, <partner>?<end_line>
     What's so funny?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -936,15 +985,18 @@
     <sjis>
       なんだよ？<end_line>
     </sjis>
+    <ascii>
+    What?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">

--- a/Translation/JE Scripts/Day 01/023_24983580_17d381c.xml
+++ b/Translation/JE Scripts/Day 01/023_24983580_17d381c.xml
@@ -6,17 +6,21 @@
       おい<end_line>
       どうかしたのかよ？<end_line>
     </sjis>
+    <ascii>
+    Hey,<end_line>
+    what's wrong?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ねえ<end_line>
       どうかしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey,<end_line>
     what's wrong?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -106,17 +110,21 @@
       悪かったな！<end_line>
       でも、コレを届けにきたんだよ<end_line>
     </sjis>
+    <ascii>
+    Well, sorry!<end_line>
+    Here.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       悪かったわね！<end_line>
       でも、コレを届けにきたんだから<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, sorry!<end_line>
     Here.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -142,18 +150,23 @@
       こんな大事なもん<end_line>
       ２度と落とすなよ！<end_line>
     </sjis>
+    <ascii>
+    Don't lose it again!<end_line>
+    A Craftknight's hammer is their<end_line>
+    livelihood, you know.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       こんな大事なもの<end_line>
       ２度と落としちゃダメだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't lose it again!<end_line>
     A Craftknight's hammer is their<end_line>
     livelihood, you know.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -189,6 +202,10 @@
       <partner>だから<end_line>
       礼なら<partner>に言ってくれよ<end_line>
     </sjis>
+    <ascii>
+    <partner> found it, not me.<end_line>
+    Thank them instead.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -196,11 +213,11 @@
       <partner>だよ<end_line>
       お礼なら<partner>に言ってあげて<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner> found it, not me.<end_line>
     Thank them instead.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -394,6 +411,10 @@
       じゃ、修行に行こうぜ<end_line>
       <partner><end_line>
     </sjis>
+    <ascii>
+    Yeah, sure.<end_line>
+    <partner>, let's go train.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -401,11 +422,11 @@
       じゃ、修行に行こう<end_line>
       <partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, sure.<end_line>
     <partner>, let's go train.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Day 01/024_25739244_188bfec.xml
+++ b/Translation/JE Scripts/Day 01/024_25739244_188bfec.xml
@@ -26,11 +26,11 @@
       さっきの子はなんかあやしいよ<end_line>
       とにかく追いかけてみよう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That girl was way too suspicious.<end_line>
     I need to find her!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -64,17 +64,21 @@
       <partner>との勝負が待ってるし<end_line>
       遠くに行かない方がいいな<end_line>
     </sjis>
+    <ascii>
+    I have a match with <partner>,<end_line>
+    so I shouldn't stray too far.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner>との勝負が待ってるし<end_line>
       遠くに行かない方がいいよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I have a match with <partner>,<end_line>
     so I shouldn't stray too far.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Translation/JE Scripts/Day 01/025_24985468_17d3f7c.xml
+++ b/Translation/JE Scripts/Day 01/025_24985468_17d3f7c.xml
@@ -63,6 +63,11 @@
       鍛冶師は強くなくちゃいけないんだ<end_line>
       もしかしてお前、コワいのか？<end_line>
     </sjis>
+    <ascii>
+    Drive it away, I guess.<end_line>
+    Craftknights gotta be strong.<end_line>
+    You aren't scared, are you?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -70,12 +75,12 @@
       鍛冶師は強くなくちゃいけないの<end_line>
       もしかしてあなた、コワいの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Drive it away, I guess.<end_line>
     Craftknights gotta be strong.<end_line>
     You aren't scared, are you?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -145,16 +150,19 @@
       大丈夫だよ<end_line>
       オレがついてるし<end_line>
     </sjis>
+    <ascii>
+    Don't worry, I'll be here.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       大丈夫だよ<end_line>
       わたしがついてるし<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't worry, I'll be here.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -182,6 +190,11 @@
       んじゃ、今日はふたりだし<end_line>
       いつもより奥まで行ってみるか！<end_line>
     </sjis>
+    <ascii>
+    This is exciting!<end_line>
+    Now that there's two of us,<end_line>
+    let's try going deeper than usual.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -189,12 +202,12 @@
       んじゃ、今日はふたりだし<end_line>
       いつもより奥まで行ってみよう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This is exciting!<end_line>
     Now that there's two of us,<end_line>
     let's try going deeper than usual.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <popup>
   <sjis>

--- a/Translation/JE Scripts/Day 01/026_24987116_17d45ec.xml
+++ b/Translation/JE Scripts/Day 01/026_24987116_17d45ec.xml
@@ -46,6 +46,11 @@
       お前、重そうだもんな<three_dots><end_line>
       この橋わたれるのか？<end_line>
     </sjis>
+    <ascii>
+    I see.<end_line>
+    You look heavy, <partner><three_dots><end_line>
+    Can we even cross this bridge?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -53,12 +58,12 @@
       <partner>、重そうだもんね<three_dots><end_line>
       この橋わたれるかな？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see.<end_line>
     You look heavy, <partner><three_dots><end_line>
     Can we even cross this bridge?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -83,6 +88,10 @@
       オレにはどっちの橋も<end_line>
       かわらないように見えるけどな<end_line>
     </sjis>
+    <ascii>
+    Hmm<three_dots><end_line>
+    They look the same to me.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -90,11 +99,11 @@
       わたしにはどっちの橋も<end_line>
       かわらないように見えるけどなあ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hmm<three_dots><end_line>
     They look the same to me.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -131,6 +140,10 @@
       オレにはどっちの橋も<end_line>
       かわらないように見えるけどな<end_line>
     </sjis>
+    <ascii>
+    Really?<end_line>
+    They look the same to me.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -138,11 +151,11 @@
       わたしにはどっちの橋も<end_line>
       かわらないように見えるけど<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Really?<end_line>
     They look the same to me.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -280,6 +293,10 @@
       オレにはどっちの橋も<end_line>
       かわらないように見えるぜ<end_line>
     </sjis>
+    <ascii>
+    Really?<end_line>
+    They look the same to me.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -287,9 +304,9 @@
       けど、わたしにはどっちの橋も<end_line>
       かわらないように見えるけど<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Really?<end_line>
     They look the same to me.<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 01/027_24993324_17d5e2c.xml
+++ b/Translation/JE Scripts/Day 01/027_24993324_17d5e2c.xml
@@ -83,15 +83,18 @@
     <sjis>
       なんだと！<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -259,6 +262,11 @@
       オレには橋のちがいが<end_line>
       わからなかったからさ<three_dots><end_line>
     </sjis>
+    <ascii>
+    No, it's just that<end_line>
+    I couldn't tell the<end_line>
+    difference, so<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -266,12 +274,12 @@
       わたしにはちがいが<end_line>
       わからなかったから<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No, it's just that<end_line>
     I couldn't tell the<end_line>
     difference, so<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -299,6 +307,11 @@
       しり<three_dots>！？<end_line>
       オレのしりは青くないぞ！<end_line>
     </sjis>
+    <ascii>
+    Wha<three_dots>!?<end_line>
+    Green where!?<end_line>
+    Oh no, am I sick or something!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -306,12 +319,12 @@
       わたしのおしりは<end_line>
       青くなんかないわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wha<three_dots>!?<end_line>
     Green where!?<end_line>
     Oh no, am I sick or something!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -338,15 +351,18 @@
     <sjis>
       半人前っていうな！<end_line>
     </sjis>
+    <ascii>
+    No I'm not!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       半人前っていわないでよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No I'm not!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -387,15 +403,18 @@
     <sjis>
       なんだと！<end_line>
     </sjis>
+    <ascii>
+    What the heck!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What the heck!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -494,17 +513,21 @@
       あぶねー<three_dots><end_line>
       橋が落ちたぞ<end_line>
     </sjis>
+    <ascii>
+    That was dangerous<three_dots><end_line>
+    The bridge collapsed<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あっぶない<three_dots><end_line>
       橋が落ちちゃった<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That was dangerous<three_dots><end_line>
     The bridge collapsed<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -532,6 +555,10 @@
       橋が落ちそうなの<end_line>
       気付いてたのか！<end_line>
     </sjis>
+    <ascii>
+    What?<end_line>
+    You knew that would happen!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -539,11 +566,11 @@
       橋が落ちそうなの<end_line>
       気付いてたの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What?<end_line>
     You knew that would happen!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -578,15 +605,18 @@
     <sjis>
       教えてくれないんだよ？<end_line>
     </sjis>
+    <ascii>
+    why didn't you tell me?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       教えてくれないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     why didn't you tell me?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -612,6 +642,11 @@
       お前、オレのパートナーだってこと<end_line>
       忘れてんのか？<end_line>
     </sjis>
+    <ascii>
+    Huh!?<end_line>
+    We're supposed to be<end_line>
+    partners, remember?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -619,12 +654,12 @@
       あなた、わたしのパートナーに<end_line>
       なったこと忘れてるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh!?<end_line>
     We're supposed to be<end_line>
     partners, remember?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -787,6 +822,10 @@
       あっちが落ちた！<end_line>
       あぶねー<three_dots><end_line>
     </sjis>
+    <ascii>
+    Oh, you were right.<end_line>
+    That was dangerous<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -794,11 +833,11 @@
       あっちが落ちたね！<end_line>
       あっぶなかった<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, you were right.<end_line>
     That was dangerous<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -824,6 +863,11 @@
       オレには橋のちがいが<end_line>
       わからなかったからさ<three_dots><end_line>
     </sjis>
+    <ascii>
+    No, it's just that<end_line>
+    I couldn't tell the<end_line>
+    difference, so<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -831,12 +875,12 @@
       わたしにはちがいが<end_line>
       わからなかったから<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No, it's just that<end_line>
     I couldn't tell the<end_line>
     difference, so<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Translation/JE Scripts/Day 01/028_24996220_17d697c.xml
+++ b/Translation/JE Scripts/Day 01/028_24996220_17d697c.xml
@@ -8,6 +8,11 @@
       はぐれだなんて<three_dots><end_line>
       大丈夫か、<partner>？<end_line>
     </sjis>
+    <ascii>
+    Your attacks didn't work<three_dots><end_line>
+    That was a stray<three_dots>?<end_line>
+    Are you alright, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -15,12 +20,12 @@
       はぐれだなんて<three_dots><end_line>
       大丈夫、<partner>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Your attacks didn't work<three_dots><end_line>
     That was a stray<three_dots>?<end_line>
     Are you alright, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -91,6 +96,11 @@
       お前とはパートナーなんだし<end_line>
       助け合うのは当然だろ！<end_line>
     </sjis>
+    <ascii>
+    You don't have to do that!<end_line>
+    We're partners.<end_line>
+    It's natural we help each other!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -98,12 +108,12 @@
       あなたとはパートナーなんだし<end_line>
       助け合うのは当然でしょ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You don't have to do that!<end_line>
     We're partners.<end_line>
     It's natural we help each other!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -225,17 +235,21 @@
       何だ！？<end_line>
       誰かが橋から落ちたぞ！？<end_line>
     </sjis>
+    <ascii>
+    What was that?<end_line>
+    Did someone fall off the bridge!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       何！？<end_line>
       誰かが橋から落ちた！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that?<end_line>
     Did someone fall off the bridge!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -317,6 +331,11 @@
       お前とはパートナーなんだし<end_line>
       助け合うのは当然だろ！<end_line>
     </sjis>
+    <ascii>
+    There's no need for that<three_dots>!<end_line>
+    We're partners.<end_line>
+    It's natural we help each other!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -324,12 +343,12 @@
       あなたとはパートナーなんだし<end_line>
       助け合うのは当然でしょ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There's no need for that<three_dots>!<end_line>
     We're partners.<end_line>
     It's natural we help each other!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -451,17 +470,21 @@
       何だ！？<end_line>
       誰かが橋から落ちたぞ！？<end_line>
     </sjis>
+    <ascii>
+    What was that?<end_line>
+    Did someone fall off the bridge!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       何！？<end_line>
       誰かが橋から落ちた！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that?<end_line>
     Did someone fall off the bridge!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -500,17 +523,21 @@
       お前<three_dots><end_line>
       まだそんなこと<three_dots><end_line>
     </sjis>
+    <ascii>
+    Oh, come on<three_dots><end_line>
+    You're still like that<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あなた<three_dots><end_line>
       まだそんなこと<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, come on<three_dots><end_line>
     You're still like that<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -534,17 +561,21 @@
       ははははは！<end_line>
       すげぇな、お前<end_line>
     </sjis>
+    <ascii>
+    Ahahahaha!<end_line>
+    You're amazing, you know!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あはははは！<end_line>
       すごいよ、あなた<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ahahahaha!<end_line>
     You're amazing, you know!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -569,6 +600,11 @@
       そんなこと言えるんなら<end_line>
       大丈夫だな、と思ってさ<end_line>
     </sjis>
+    <ascii>
+    Well, I figure<end_line>
+    if you can still say stuff<end_line>
+    like that, you must be fine.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -576,12 +612,12 @@
       そんなこと言えるんなら<end_line>
       大丈夫だな、と思って<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, I figure<end_line>
     if you can still say stuff<end_line>
     like that, you must be fine.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -610,6 +646,10 @@
       お前とはパートナーなんだし<end_line>
       助け合うのは当然だろ！<end_line>
     </sjis>
+    <ascii>
+    Nah, we're partners,<end_line>
+    so helping each other is natural!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -617,11 +657,11 @@
       あなたとはパートナーなんだし<end_line>
       助け合うのは当然でしょ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Nah, we're partners,<end_line>
     so helping each other is natural!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -743,17 +783,21 @@
       何だ！？<end_line>
       誰かが橋から落ちたぞ！？<end_line>
     </sjis>
+    <ascii>
+    What was that?<end_line>
+    Did someone fall off the bridge!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       何！？<end_line>
       誰かが橋から落ちた！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that?<end_line>
     Did someone fall off the bridge!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -794,6 +838,11 @@
       お前とはパートナーなんだし<end_line>
       助け合うのは当然だろ！<end_line>
     </sjis>
+    <ascii>
+    There's no need for that<three_dots>!<end_line>
+    We're partners.<end_line>
+    It's natural we help each other!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -801,12 +850,12 @@
       あなたとはパートナーなんだし<end_line>
       助け合うのは当然でしょ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There's no need for that<three_dots>!<end_line>
     We're partners.<end_line>
     It's natural we help each other!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -938,17 +987,21 @@
       何だ！？<end_line>
       誰かが橋から落ちたぞ！？<end_line>
     </sjis>
+    <ascii>
+    What was that?<end_line>
+    Did someone fall off the bridge!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       何！？<end_line>
       誰かが橋から落ちた！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that?<end_line>
     Did someone fall off the bridge!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -992,15 +1045,19 @@
       橋はもう、くずれていたハズ<end_line>
       それなのに落ちたのか！？<end_line>
     </sjis>
+    <ascii>
+    Couldn't he tell it was broken!?<end_line>
+    Jeez<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       橋はもう、くずれていたハズ<end_line>
       それなのに落ちたの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Couldn't he tell it was broken!?<end_line>
     Jeez<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 01/030_24998780_17d737c.xml
+++ b/Translation/JE Scripts/Day 01/030_24998780_17d737c.xml
@@ -6,16 +6,19 @@
       おい、お前<end_line>
       大丈夫かよ？<end_line>
     </sjis>
+    <ascii>
+    Hey, you okay?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちょっと、あなた<end_line>
       大丈夫なの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, you okay?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -55,6 +58,11 @@
       あの橋、穴が空いてただろ？<end_line>
       なんで落ちるんだよ！？<end_line>
     </sjis>
+    <ascii>	
+    <three_dots>Hey.<end_line>
+    You seriously didn't see the gap<end_line>
+    where the bridge should've been?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -62,12 +70,12 @@
       あの橋、穴が空いてたよね？<end_line>
       なんで落ちるの！？<end_line>
     </sjis>
-  </female>
-  <ascii>	
+    <ascii>	
     <three_dots>Hey.<end_line>
     You seriously didn't see the gap<end_line>
     where the bridge should've been?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -91,17 +99,21 @@
       そんなに急いで<end_line>
       どうしたんだよ<end_line>
     </sjis>
+    <ascii>
+    What's so important you can't<end_line>
+    even look down once in a while?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなに急いで<end_line>
       何があったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's so important you can't<end_line>
     even look down once in a while?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -311,6 +323,11 @@
       あんなカオしてるけど<end_line>
       あいつも結構やるもんだな<end_line>
     </sjis>
+    <ascii>
+    Hmm<three_dots><end_line>
+    Despite how he looks,<end_line>
+    he's actually pretty cool.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -318,12 +335,12 @@
       あんなカオしてるけど<end_line>
       あいつも結構やるもんね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hmm<three_dots><end_line>
     Despite how he looks,<end_line>
     he's actually pretty cool.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -629,6 +646,11 @@
       大丈夫か！？<end_line>
       この先ははぐれ召喚獣も<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah<three_dots>Hey<three_dots>!<end_line>
+    Are you gonna be okay?<end_line>
+    There are Strays ahead<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -636,12 +658,12 @@
       大丈夫なの！？<end_line>
       この先ははぐれ召喚獣も<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah<three_dots>Hey<three_dots>!<end_line>
     Are you gonna be okay?<end_line>
     There are Strays ahead<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -676,6 +698,11 @@
       ミューノにあげたいってことだよな<end_line>
       <partner>？<end_line>
     </sjis>
+    <ascii>
+    So, you're gonna give that<end_line>
+    medicine to Murno to make<end_line>
+    her feel better, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -683,12 +710,12 @@
       ミューノにあげたいってことね<end_line>
       <partner>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So, you're gonna give that<end_line>
     medicine to Murno to make<end_line>
     her feel better, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -751,6 +778,11 @@
       ミューノにあげたいってことだよな<end_line>
       <partner>？<end_line>
     </sjis>
+    <ascii>
+    So, you're gonna give that<end_line>
+    medicine to Murno to make<end_line>
+    her feel better, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -758,12 +790,12 @@
       ミューノにあげたいってことね<end_line>
       <partner>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So, you're gonna give that<end_line>
     medicine to Murno to make<end_line>
     her feel better, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -938,6 +970,11 @@
       ミューノにあげたいってことだよな<end_line>
       <partner>？<end_line>
     </sjis>
+    <ascii>
+    So, you're gonna give that<end_line>
+    medicine to Murno to make<end_line>
+    her feel better, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -945,12 +982,12 @@
       ミューノにあげたいってことね<end_line>
       <partner>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So, you're gonna give that<end_line>
     medicine to Murno to make<end_line>
     her feel better, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Translation/JE Scripts/Day 01/032_25001692_17d7edc.xml
+++ b/Translation/JE Scripts/Day 01/032_25001692_17d7edc.xml
@@ -6,17 +6,21 @@
       あれ<three_dots>？<end_line>
       今度はどうしたんだ？<end_line>
     </sjis>
+    <ascii>
+    Huh<three_dots>?<end_line>
+    What is it this time?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あれ<three_dots>？<end_line>
       今度はどうしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh<three_dots>?<end_line>
     What is it this time?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -43,6 +47,11 @@
       さっきは最初っからくずれてる橋に<end_line>
       落ちたのに<end_line>
     </sjis>
+    <ascii>
+    I see you're being careful now.<end_line>
+    Though last time you fell,<end_line>
+    the bridge was already broken.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -50,12 +59,12 @@
       さっきは最初っからくずれてる橋に<end_line>
       落ちたのに<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see you're being careful now.<end_line>
     Though last time you fell,<end_line>
     the bridge was already broken.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -77,17 +86,21 @@
       どうだ、<partner><end_line>
       今度もわかるか？<end_line>
     </sjis>
+    <ascii>
+    Hey, <partner>.<end_line>
+    Any issues with the bridge?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どう、<partner><end_line>
       今度もわかるかな？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, <partner>.<end_line>
     Any issues with the bridge?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -136,6 +149,9 @@
       教えたくないとは思うんだけど<end_line>
       たのむぜ<three_dots><end_line>
     </sjis>
+    <ascii>
+    You know, don't you<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -143,10 +159,10 @@
       教えたくないとは思うんだけど<end_line>
       そこをなんとか<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You know, don't you<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -246,17 +262,21 @@
       あ、おい<end_line>
       ちょっと！<end_line>
     </sjis>
+    <ascii>
+    Ah, hey,<end_line>
+    wait a second!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、ねえ<end_line>
       ちょっと！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, hey,<end_line>
     wait a second!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="left" effect="big">
@@ -286,17 +306,21 @@
       だ<three_dots><end_line>
       大丈夫か！？<end_line>
     </sjis>
+    <ascii>
+    A<three_dots><end_line>
+    Are you okay!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       だ<three_dots><end_line>
       大丈夫！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     A<three_dots><end_line>
     Are you okay!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -328,17 +352,21 @@
       どういうことだよ！<end_line>
       大丈夫なんじゃなかったのか！？<end_line>
     </sjis>
+    <ascii>
+    What happened there?<end_line>
+    You said it'd be fine!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ねえ、どういうこと？<end_line>
       大丈夫じゃなかったの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What happened there?<end_line>
     You said it'd be fine!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -392,17 +420,21 @@
       お前<three_dots><end_line>
       ザックのせいだって言うのか<three_dots><end_line>
     </sjis>
+    <ascii>
+    <three_dots><end_line>
+    You're saying it's his fault<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あなた<three_dots><end_line>
       ザックのせいだって言うの<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots><end_line>
     You're saying it's his fault<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -592,17 +624,21 @@
       どういうことだよ！<end_line>
       大丈夫なんじゃなかったのか！？<end_line>
     </sjis>
+    <ascii>
+    What happened there?<end_line>
+    You said it'd be fine!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ねえ、どういうこと？<end_line>
       大丈夫じゃなかったの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What happened there?<end_line>
     You said it'd be fine!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -630,17 +666,21 @@
       言い訳かよ！<end_line>
       カッコワルイな！<end_line>
     </sjis>
+    <ascii>
+    I don't want to hear any excuses!<end_line>
+    That's so lame!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       言い訳なんて<end_line>
       カッコワルイわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I don't want to hear any excuses!<end_line>
     That's so lame!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -666,17 +706,21 @@
       あいつはお前の言葉を信じてたんだ<end_line>
       それなのに、なんだよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    He trusted you,<end_line>
+    and despite that<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あの子はあなたの言葉を信じてたのよ<end_line>
       それなのに、なによ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     He trusted you,<end_line>
     and despite that<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -701,6 +745,11 @@
       もういい！<end_line>
       あいつのトコへ行くぞ！<end_line>
     </sjis>
+    <ascii>
+    Ughh!<end_line>
+    Forget it!<end_line>
+    Let's go find him!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -708,12 +757,12 @@
       もういいわ！<end_line>
       あの子のトコへ行きましょう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ughh!<end_line>
     Forget it!<end_line>
     Let's go find him!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -725,16 +774,19 @@
       どういうことだよ！<end_line>
       もしかして、ダマしたのか？<end_line>
     </sjis>
+    <ascii>
+    Did you do that on purpose?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どういうこと？<end_line>
       もしかして、ダマしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Did you do that on purpose?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -760,17 +812,21 @@
       え？<end_line>
       お前、わざとじゃないのか？<end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    You didn't?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え？<end_line>
       わざとじゃないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     You didn't?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -925,17 +981,21 @@
       どういうことだよ！<end_line>
       大丈夫なんじゃなかったのか！？<end_line>
     </sjis>
+    <ascii>
+    What happened there?<end_line>
+    You said it'd be fine!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ねえ、どういうこと？<end_line>
       大丈夫じゃなかったの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What happened there?<end_line>
     You said it'd be fine!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -978,17 +1038,21 @@
       言い訳かよ！<end_line>
       カッコワルイな！<end_line>
     </sjis>
+    <ascii>
+    I don't want to hear any excuses!<end_line>
+    That's so lame!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       言い訳なんて<end_line>
       カッコワルイわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I don't want to hear any excuses!<end_line>
     That's so lame!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1014,17 +1078,21 @@
       あいつはお前の言葉を信じてたんだ<end_line>
       それなのに、なんだよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    He trusted you,<end_line>
+    and despite that<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あの子はあなたの言葉を信じてたのよ<end_line>
       それなのに、なによ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     He trusted you,<end_line>
     and despite that<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1049,6 +1117,11 @@
       もういい！<end_line>
       あいつのトコへ行くぞ！<end_line>
     </sjis>
+    <ascii>
+    Ughh!<end_line>
+    Forget it!<end_line>
+    Let's just go find him!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1056,12 +1129,12 @@
       もういいわ！<end_line>
       あの子のトコへ行きましょう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ughh!<end_line>
     Forget it!<end_line>
     Let's just go find him!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="left" effect="big">
@@ -1070,13 +1143,16 @@
     <sjis>
       うわっ！<end_line>
     </sjis>
+    <ascii>
+    Ah!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       きゃっ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah!<end_line>
   </ascii>
+  </female>
 </bigtext>

--- a/Translation/JE Scripts/Day 01/033_25005052_17d8bfc.xml
+++ b/Translation/JE Scripts/Day 01/033_25005052_17d8bfc.xml
@@ -7,6 +7,11 @@
       <partner>がいなかったら<end_line>
       いまごろオレは<three_dots><end_line>
     </sjis>
+    <ascii>
+    That was close<three_dots><end_line>
+    <partner>, if you weren't here,<end_line>
+    I'd be done for<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -14,12 +19,12 @@
       <partner>がいなかったら<end_line>
       いまごろわたし<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That was close<three_dots><end_line>
     <partner>, if you weren't here,<end_line>
     I'd be done for<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -100,6 +105,11 @@
       それにしても本当に<end_line>
       ブジでよかったぜ<end_line>
     </sjis>
+    <ascii>
+    So that's why you came from there<three_dots><end_line>
+    But more than that,<end_line>
+    I'm glad you're okay.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -107,12 +117,12 @@
       それにしても本当に<end_line>
       ブジでよかったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So that's why you came from there<three_dots><end_line>
     But more than that,<end_line>
     I'm glad you're okay.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -188,15 +198,18 @@
     <sjis>
       悪かったよ<end_line>
     </sjis>
+    <ascii>
+    I'm sorry too.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ごめんね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm sorry too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -223,6 +236,11 @@
       オレの失敗でもあるんだ<end_line>
       いっしょにあやまらなきゃな<end_line>
     </sjis>
+    <ascii>
+    My partner's mistake<end_line>
+    is my mistake too,<end_line>
+    so we apologize together.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -230,12 +248,12 @@
       わたしの失敗でもあるしね<end_line>
       いっしょにあやまらなきゃ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     My partner's mistake<end_line>
     is my mistake too,<end_line>
     so we apologize together.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -284,15 +302,18 @@
     <sjis>
       今度は落ちないみたいだ<end_line>
     </sjis>
+    <ascii>
+    Looks like he'll be okay now.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今度は大丈夫みたいだね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Looks like he'll be okay now.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -316,17 +337,21 @@
       よし！<end_line>
       オレたちも行こう！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Let's go too!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       わたしたちも行こう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Let's go too!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -396,6 +421,11 @@
       それにしても本当に<end_line>
       ブジでよかったぜ<end_line>
     </sjis>
+    <ascii>
+    So that's why you came from there<three_dots><end_line>
+    But more than that,<end_line>
+    I'm glad you're okay.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -403,12 +433,12 @@
       それにしても本当に<end_line>
       ブジでよかったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So that's why you came from there<three_dots><end_line>
     But more than that,<end_line>
     I'm glad you're okay.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -484,15 +514,18 @@
     <sjis>
       悪かったな<end_line>
     </sjis>
+    <ascii>
+    I'm sorry too.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ごめんね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm sorry too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -519,6 +552,11 @@
       オレの失敗でもあるんだ<end_line>
       いっしょにあやまらなきゃな<end_line>
     </sjis>
+    <ascii>
+    My partner's mistake<end_line>
+    is my mistake too,<end_line>
+    so we apologize together.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -526,12 +564,12 @@
       わたしの失敗でもあるしね<end_line>
       いっしょにあやまらなきゃ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     My partner's mistake<end_line>
     is my mistake too,<end_line>
     so we apologize together.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -580,15 +618,18 @@
     <sjis>
       今度は落ちないみたいだ<end_line>
     </sjis>
+    <ascii>
+    Looks like he'll be okay now.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今度は大丈夫みたいだね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Looks like he'll be okay now.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -614,17 +655,21 @@
       よし！<end_line>
       オレたちも行こう！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Let's go too!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       わたしたちも行こう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Let's go too!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -923,15 +968,18 @@
     <sjis>
       今度は落ちないみたいだ<end_line>
     </sjis>
+    <ascii>
+    Looks like he'll be okay now.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今度は大丈夫みたいだね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Looks like he'll be okay now.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -955,17 +1003,21 @@
       よし！<end_line>
       オレたちも行こう！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Let's get going!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       わたしたちも行こう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Let's get going!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1037,6 +1089,11 @@
       それにしても本当に<end_line>
       ブジでよかったぜ<end_line>
     </sjis>
+    <ascii>
+    So that's why you came from there<three_dots><end_line>
+    But more than that,<end_line>
+    I'm glad you're okay.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1044,12 +1101,12 @@
       それにしても本当に<end_line>
       ブジでよかったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So that's why you came from there<three_dots><end_line>
     But more than that,<end_line>
     I'm glad you're okay.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1122,15 +1179,18 @@
     <sjis>
       悪かったな<end_line>
     </sjis>
+    <ascii>
+    I'm sorry too.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ごめんね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm sorry too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1157,6 +1217,11 @@
       オレの失敗でもあるんだ<end_line>
       いっしょにあやまらなきゃな<end_line>
     </sjis>
+    <ascii>	
+    My partner's mistake<end_line>
+    is my mistake too,<end_line>
+    so we apologize together.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1164,12 +1229,12 @@
       わたしの失敗でもあるしね<end_line>
       いっしょにあやまらなきゃ<end_line>
     </sjis>
-  </female>
-  <ascii>	
+    <ascii>	
     My partner's mistake<end_line>
     is my mistake too,<end_line>
     so we apologize together.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1218,15 +1283,18 @@
     <sjis>
       今度は落ちないみたいだ<end_line>
     </sjis>
+    <ascii>
+    Looks like he'll be okay now.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今度は大丈夫みたいだね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Looks like he'll be okay now.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1250,16 +1318,20 @@
       よし！<end_line>
       オレたちも行こう！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Let's go too!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       わたしたちも行こう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Let's go too!<end_line>
   </ascii>
+  </female>
 </dialogue>
 

--- a/Translation/JE Scripts/Day 01/036_25008348_17d98dc.xml
+++ b/Translation/JE Scripts/Day 01/036_25008348_17d98dc.xml
@@ -7,18 +7,23 @@
       ヘンだな<three_dots>？<end_line>
       この辺だけ草が枯れてるぞ？<end_line>
     </sjis>
+    <ascii>
+    That's strange<three_dots><end_line>
+    The grass is withered,<end_line>
+    but only around here, see?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ヘンだね<three_dots>？<end_line>
       この辺だけ草が枯れてるよ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's strange<three_dots><end_line>
     The grass is withered,<end_line>
     but only around here, see?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Day 01/037_25009340_17d9cbc.xml
+++ b/Translation/JE Scripts/Day 01/037_25009340_17d9cbc.xml
@@ -36,6 +36,11 @@
       きっとまだどこかに<end_line>
       残ってるはずだ！<end_line>
     </sjis>
+    <ascii>
+    It's too early to give up.<end_line>
+    There should still be<end_line>
+    some left somewhere!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -43,12 +48,12 @@
       きっとまだどこかに<end_line>
       残ってるって！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's too early to give up.<end_line>
     There should still be<end_line>
     some left somewhere!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -72,6 +77,10 @@
       大丈夫<end_line>
       オレたちが追っ払ってやる<end_line>
     </sjis>
+    <ascii>
+    It's alright.<end_line>
+    We'll drive it away.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -79,11 +88,11 @@
       わたしたちが<end_line>
       追っ払ってあげるわ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's alright.<end_line>
     We'll drive it away.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -107,17 +116,21 @@
       大丈夫だ<end_line>
       鍛冶師は強くなきゃいけないからな！<end_line>
     </sjis>
+    <ascii>
+    We'll be okay.<end_line>
+    A Craftknight must be strong!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       大丈夫<end_line>
       鍛冶師は強くなきゃいけないもん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We'll be okay.<end_line>
     A Craftknight must be strong!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -139,16 +152,19 @@
       よし！　いくぞ<end_line>
       <partner>！<end_line>
     </sjis>
+    <ascii>
+    Okay! Let's do this, <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よし！　いこう<end_line>
       <partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay! Let's do this, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Day 01/038_25010764_17da24c.xml
+++ b/Translation/JE Scripts/Day 01/038_25010764_17da24c.xml
@@ -21,6 +21,10 @@
       オレたちの強さ、思い知ったか！<end_line>
       な、<partner>！<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+    Nice job, <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -28,11 +32,11 @@
       これがわたしたちの強さよ！<end_line>
       ね、<partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
     Nice job, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -56,17 +60,21 @@
       なんだよ<end_line>
       はりあいないなぁ<three_dots><end_line>
     </sjis>
+    <ascii>
+    What's with you?<end_line>
+    You're not into it at all<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ<end_line>
       はりあいないなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's with you?<end_line>
     You're not into it at all<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -201,6 +209,10 @@
       オレのことは<end_line>
       <player_nickname>でいいって<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah<three_dots> You're welcome<three_dots><end_line>
+    You can just call me <player_nickname><three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -208,11 +220,11 @@
       わたしのことは<end_line>
       <player_nickname>でいいよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah<three_dots> You're welcome<three_dots><end_line>
     You can just call me <player_nickname><three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Day 01/039_25012348_17da87c.xml
+++ b/Translation/JE Scripts/Day 01/039_25012348_17da87c.xml
@@ -6,17 +6,21 @@
       あった！<end_line>
       あったぞ、キッカの実！<end_line>
     </sjis>
+    <ascii>
+    There!<end_line>
+    I found some!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あった！<end_line>
       あったよ、キッカの実！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There!<end_line>
     I found some!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -93,15 +97,18 @@
     <sjis>
       よかったな<end_line>
     </sjis>
+    <ascii>
+    That's great!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よかったね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's great!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -152,17 +159,21 @@
       本当か？<end_line>
       いいのか？<end_line>
     </sjis>
+    <ascii>
+    Wow, really?<end_line>
+    Is that okay?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       本当に？<end_line>
       いいの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wow, really?<end_line>
     Is that okay?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -189,6 +200,11 @@
       ありがとな<end_line>
       うれしいよ！<end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    Thank you, too.<end_line>
+    I'm so happy it all worked out!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -196,12 +212,12 @@
       ありがとね<end_line>
       うれしいよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     Thank you, too.<end_line>
     I'm so happy it all worked out!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -249,17 +265,21 @@
       おう！<end_line>
       たのんだぜ！<end_line>
     </sjis>
+    <ascii>	
+    Yeah!<end_line>
+    I'm counting on you!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん！<end_line>
       たのんだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>	
+    <ascii>	
     Yeah!<end_line>
     I'm counting on you!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -294,17 +314,21 @@
       うん<end_line>
       助かったよ<end_line>
     </sjis>
+    <ascii>
+    Yeah.<end_line>
+    He's a big help.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん<end_line>
       助かっちゃった<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah.<end_line>
     He's a big help.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -329,17 +353,21 @@
       そう言われると<end_line>
       なんか心配になってくるな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Now that you've said it,<end_line>
+    I'm kinda worried now<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そう言われると<end_line>
       なんか心配になってくるなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Now that you've said it,<end_line>
     I'm kinda worried now<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -375,17 +403,21 @@
       うん<end_line>
       助かったよ<end_line>
     </sjis>
+    <ascii>
+    Yeah.<end_line>
+    He's a big help.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん<end_line>
       助かっちゃった<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah.<end_line>
     He's a big help.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -412,17 +444,21 @@
       そう言われると<end_line>
       なんか心配になってくるな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Now that you've said it,<end_line>
+    I'm kinda worried now<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そう言われると<end_line>
       なんか心配になってくるなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Now that you've said it,<end_line>
     I'm kinda worried now<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -458,17 +494,21 @@
       え？<end_line>
       それってどういうことだよ？<end_line>
     </sjis>
+    <ascii>
+    Eh?<end_line>
+    About what?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え？<end_line>
       それってどういうこと？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh?<end_line>
     About what?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -509,6 +549,11 @@
       なんか心配になってくるな<three_dots><end_line>
       とにかく駅に行こう<end_line>
     </sjis>
+    <ascii>
+    Now that you've said it,<end_line>
+    I'm kinda worried now<three_dots><end_line>
+    Anyway, let's head to the station.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -516,12 +561,12 @@
       なんか心配になってくるなぁ<three_dots><end_line>
       とにかく駅に行こう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Now that you've said it,<end_line>
     I'm kinda worried now<three_dots><end_line>
     Anyway, let's head to the station.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -545,17 +590,21 @@
       うん<end_line>
       助かったよ<end_line>
     </sjis>
+    <ascii>
+    Yeah.<end_line>
+    He's a big help.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん<end_line>
       助かっちゃった<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah.<end_line>
     He's a big help.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -582,17 +631,21 @@
       そう言われると<end_line>
       なんか心配になってくるな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Now that you've said it,<end_line>
+    I'm kinda worried now<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そう言われると<end_line>
       なんか心配になってくるなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Now that you've said it,<end_line>
     I'm kinda worried now<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Translation/JE Scripts/Day 01/040_25014412_17db08c.xml
+++ b/Translation/JE Scripts/Day 01/040_25014412_17db08c.xml
@@ -108,6 +108,11 @@
       好きでコイツに会ってたんじゃないぞ<end_line>
       薬をうけとりに来ただけだよ<end_line>
     </sjis>
+    <ascii>
+    Yeah, he's right.<end_line>
+    We're only meeting up because<end_line>
+    he wanted to give me medicine.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -115,12 +120,12 @@
       好きでこの子に会ってたんじゃないの<end_line>
       薬をうけとりに来ただけだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, he's right.<end_line>
     We're only meeting up because<end_line>
     he wanted to give me medicine.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -224,6 +229,11 @@
       別にどーだっていいだろ<end_line>
       そんなこと<end_line>
     </sjis>
+    <ascii>
+    Now, now<three_dots><end_line>
+    It's really not as big a deal<end_line>
+    as you're making it out to be.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -231,12 +241,12 @@
       別にどーだっていいじゃない<end_line>
       そんなこと<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Now, now<three_dots><end_line>
     It's really not as big a deal<end_line>
     as you're making it out to be.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -520,15 +530,18 @@
     <sjis>
       なんだと！<end_line>
     </sjis>
+    <ascii>
+    What's that supposed to mean!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's that supposed to mean!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -569,17 +582,21 @@
       お前なぁ<three_dots><end_line>
       言わせておけば<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    You<three_dots><end_line>
+    I gave you an inch and you<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんた<three_dots><end_line>
       言わせておけば<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You<three_dots><end_line>
     I gave you an inch and you<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -619,15 +636,18 @@
     <sjis>
       だめだ！<end_line>
     </sjis>
+    <ascii>
+    No, it's not okay!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       だめだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No, it's not okay!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -650,6 +670,11 @@
       こうなったら絶対その薬を<end_line>
       受け取らせたくなったぜ<three_dots><end_line>
     </sjis>
+    <ascii>
+    This isn't just your problem now.<end_line>
+    He's taking the medicine,<end_line>
+    one way or another.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -657,12 +682,12 @@
       こうなったら絶対その薬を<end_line>
       受け取らせたくなったの<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This isn't just your problem now.<end_line>
     He's taking the medicine,<end_line>
     one way or another.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -712,15 +737,18 @@
     <sjis>
       ち<three_dots>！<end_line>
     </sjis>
+    <ascii>	
+    Tch<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       く<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>	
+    <ascii>	
     Tch<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -861,15 +889,18 @@
     <sjis>
       約束、だからな<end_line>
     </sjis>
+    <ascii>
+    Then it's a deal.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       約束、だからね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Then it's a deal.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 01/041_25018124_17dbf0c.xml
+++ b/Translation/JE Scripts/Day 01/041_25018124_17dbf0c.xml
@@ -40,17 +40,21 @@
       病人には悪いが、この勝負<end_line>
       勝たせてもらうぜ<end_line>
     </sjis>
+    <ascii>
+    I know you're sick,<end_line>
+    but I intend to win.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       病人には悪いけど、この勝負<end_line>
       勝たせてもらうから<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know you're sick,<end_line>
     but I intend to win.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -72,17 +76,21 @@
       よしっ！<end_line>
       いくぜ、<partner>！<end_line>
     </sjis>
+    <ascii>
+    You're on!<end_line>
+    Let's do this <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       いくよ、<partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're on!<end_line>
     Let's do this <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Day 01/042_25019244_17dc36c.xml
+++ b/Translation/JE Scripts/Day 01/042_25019244_17dc36c.xml
@@ -6,15 +6,18 @@
     <sjis>
       まいったか！<end_line>
     </sjis>
+    <ascii>
+    Well, had enough?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どう、まいった！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, had enough?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -61,16 +64,19 @@
       負けたんだから約束通り<end_line>
       ザックの薬、受け取れよな！<end_line>
     </sjis>
+    <ascii>
+    Alright, now take the medicine!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       負けたんだから約束通り<end_line>
       ザックの薬、受け取りなさいよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright, now take the medicine!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -121,6 +127,11 @@
       ザックの気持ちがこもってるんだ<end_line>
       大事に使えよ<end_line>
     </sjis>
+    <ascii>
+    Hey, you know Zakk worked <end_line>
+    hard to get you that medicine.<end_line>
+    You should appreciate it.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -128,12 +139,12 @@
       ザックの気持ちがこもってるんだから<end_line>
       大事に使いなさいよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, you know Zakk worked <end_line>
     hard to get you that medicine.<end_line>
     You should appreciate it.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -180,6 +191,10 @@
       こっちこそありがとな<end_line>
       ザック<end_line>
     </sjis>
+    <ascii>
+    Oh, right.<end_line>
+    You have my thanks too, Zakk.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -187,11 +202,11 @@
       こっちこそありがとね<end_line>
       ザック<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, right.<end_line>
     You have my thanks too, Zakk.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 01/043_25020972_17dca2c.xml
+++ b/Translation/JE Scripts/Day 01/043_25020972_17dca2c.xml
@@ -212,6 +212,11 @@
       ほら、これ<three_dots><end_line>
       ミューノの熱にもきくかな？<end_line>
     </sjis>
+    <ascii>
+    Ah, right.<end_line>
+    Take a look at this.<end_line>
+    Will it work on Murno's fever?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -219,12 +224,12 @@
       はい、これ<end_line>
       ミューノの熱にもきくかな？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, right.<end_line>
     Take a look at this.<end_line>
     Will it work on Murno's fever?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -246,17 +251,21 @@
       <partner>といっしょにとってきた<end_line>
       キッカの実で作ったんだぜ<end_line>
     </sjis>
+    <ascii>
+    Yeah. <partner> and I<end_line>
+    thought it would help.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner>といっしょにとってきた<end_line>
       キッカの実で作ったんだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah. <partner> and I<end_line>
     thought it would help.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -401,17 +410,21 @@
       オレのことは<end_line>
       <player_nickname>でいいから<end_line>
     </sjis>
+    <ascii>
+    You can just<end_line>
+    call me <player_nickname>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしのことは<end_line>
       <player_nickname>でいいよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You can just<end_line>
     call me <player_nickname>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 01/044_25022924_17dd1cc.xml
+++ b/Translation/JE Scripts/Day 01/044_25022924_17dd1cc.xml
@@ -20,17 +20,21 @@
       あれ？<end_line>
       そこにいるのは<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    That looks like<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あれ？<end_line>
       そこにいるのは<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     That looks like<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <menu>
   <option>

--- a/Translation/JE Scripts/Day 01/045_25023628_17dd48c.xml
+++ b/Translation/JE Scripts/Day 01/045_25023628_17dd48c.xml
@@ -46,6 +46,11 @@
       でも、本当によかったよ<end_line>
       元気になって<end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    I really am glad<end_line>
+    you're feeling better.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -53,12 +58,12 @@
       でも、本当によかったよ<end_line>
       元気になって<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     I really am glad<end_line>
     you're feeling better.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -85,6 +90,11 @@
       いいんだよ別に<end_line>
       好きでやったことなんだから<end_line>
     </sjis>
+    <ascii>
+    Don't apologize.<end_line>
+    I don't really mind.<end_line>
+    I just did it cause I wanted to.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -92,12 +102,12 @@
       いいのよ別に<end_line>
       好きでやったことなんだから<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't apologize.<end_line>
     I don't really mind.<end_line>
     I just did it cause I wanted to.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -120,6 +130,11 @@
       親方が看病してて<end_line>
       オレたちはジャマだって<three_dots><end_line>
     </sjis>
+    <ascii>
+    Uh, well<three_dots><end_line>
+    Master said we were in the way,<end_line>
+    and I had nothing to do anyway so<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -127,12 +142,12 @@
       親方が看病してて<end_line>
       わたしたちはジャマだって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uh, well<three_dots><end_line>
     Master said we were in the way,<end_line>
     and I had nothing to do anyway so<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -173,6 +188,11 @@
       ミューノだって熱出るくらい<end_line>
       大変なことがあったんだろ？<end_line>
     </sjis>
+    <ascii>
+    Don't worry about it.<end_line>
+    Murno, you got a fever because<end_line>
+    you wore yourself out, didn't you?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -180,12 +200,12 @@
       ミューノだって熱出るくらい<end_line>
       大変なことがあったんでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't worry about it.<end_line>
     Murno, you got a fever because<end_line>
     you wore yourself out, didn't you?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 01/046_25025260_17ddaec.xml
+++ b/Translation/JE Scripts/Day 01/046_25025260_17ddaec.xml
@@ -77,15 +77,18 @@
     <sjis>
       よかったな、<partner><end_line>
     </sjis>
+    <ascii>
+    That's great!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よかったね、<partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's great!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -111,17 +114,21 @@
       な、なんだよ<end_line>
       あらたまって<three_dots><end_line>
     </sjis>
+    <ascii>
+    Wh-What's up with you?<end_line>
+    You sound almost normal<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な、なによ<end_line>
       あらたまって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wh-What's up with you?<end_line>
     You sound almost normal<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -160,6 +167,11 @@
       <partner>だってがんばったぜ<end_line>
       ザックにも手を貸してもらったし<end_line>
     </sjis>
+    <ascii>
+    Well, it wasn't just me,<end_line>
+    you worked hard too.<end_line>
+    And even Zakk helped out a lot.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -167,12 +179,12 @@
       <partner>だってがんばったよ<end_line>
       ザックにも手を貸してもらったし<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, it wasn't just me,<end_line>
     you worked hard too.<end_line>
     And even Zakk helped out a lot.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -269,17 +281,22 @@
     <sjis>
       そう言われるのもハラ立つけどな<end_line>
     </sjis>
+    <ascii>
+    <three_dots><end_line>
+    You know, sometimes you<end_line>
+    can be very irritating<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そう言われるのもハラ立つけどね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots><end_line>
     You know, sometimes you<end_line>
     can be very irritating<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -332,15 +349,18 @@
     <sjis>
       ああ、バッチリだぜ！<end_line>
     </sjis>
+    <ascii>
+    Yeah, exactly!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん、バッチリだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, exactly!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -364,17 +384,21 @@
       これからもよろしくたのむぜ<end_line>
       <partner><end_line>
     </sjis>
+    <ascii>
+    Let's keep getting along,<end_line>
+    <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       これからもよろしくたのむね<end_line>
       <partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Let's keep getting along,<end_line>
     <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -424,15 +448,18 @@
     <sjis>
       よかったな、<partner><end_line>
     </sjis>
+    <ascii>
+    That's great!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よかったね、<partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's great!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -542,16 +569,19 @@
       なんだよ<end_line>
       ハッキリ言うなぁ<end_line>
     </sjis>
+    <ascii>
+    Way to be blunt about it<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ<end_line>
       ハッキリ言うなぁ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Way to be blunt about it<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -665,17 +695,21 @@
       これからもよろしくたのむぜ<end_line>
       <partner><end_line>
     </sjis>
+    <ascii>
+    Let's keep getting along,<end_line>
+    <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       これからもよろしくたのむね<end_line>
       <partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Let's keep getting along,<end_line>
     <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -754,17 +788,21 @@
       なんだよ？<end_line>
       なんか用か？<end_line>
     </sjis>
+    <ascii>
+    What?<end_line>
+    Need something?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ？<end_line>
       なにか用？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What?<end_line>
     Need something?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -867,6 +905,11 @@
       素直になれよ<end_line>
       子供なんだから<three_dots><end_line>
     </sjis>
+    <ascii>
+    This again<three_dots><end_line>
+    No need to be so embarrassed.<end_line>
+    I guess you're still a kid.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -874,12 +917,12 @@
       素直じゃないんだから<end_line>
       子供なのに<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This again<three_dots><end_line>
     No need to be so embarrassed.<end_line>
     I guess you're still a kid.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -934,17 +977,21 @@
       でも大人だったらよけいに<end_line>
       もっと大人らしくしろよ！<end_line>
     </sjis>
+    <ascii>
+    But hey, if you're an adult,<end_line>
+    then you should act like one!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       でも大人だったらよけいに<end_line>
       もっと大人らしくしてよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     But hey, if you're an adult,<end_line>
     then you should act like one!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -969,6 +1016,11 @@
       <partner>がいてくれて<end_line>
       本当に助かってたんだ！<end_line>
     </sjis>
+    <ascii>
+    I got the Kicca Fruit only<end_line>
+    because you were there.<end_line>
+    You're a big help!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -976,12 +1028,12 @@
       <partner>がいてくれて<end_line>
       本当に助かってたのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I got the Kicca Fruit only<end_line>
     because you were there.<end_line>
     You're a big help!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1010,6 +1062,10 @@
       がんばってた<end_line>
       オレはそう思うぞ<end_line>
     </sjis>
+    <ascii>
+    So I think that you did<end_line>
+    work hard for this too.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1017,11 +1073,11 @@
       がんばってた<end_line>
       わたしはそう思うよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So I think that you did<end_line>
     work hard for this too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1203,15 +1259,18 @@
     <sjis>
       よかったな、<partner><end_line>
     </sjis>
+    <ascii>
+    That's great!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よかったね、<partner><end_line>
     </sjis>
-  </female>
     <ascii>
     That's great!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1237,17 +1296,21 @@
       そんなのいいよ<end_line>
       オレも好きでやったんだからさ<end_line>
     </sjis>
+    <ascii>
+    Don't worry about it,<end_line>
+    I did it cause I wanted to.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなのいいよ<end_line>
       わたしも好きでやったんだからさ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't worry about it,<end_line>
     I did it cause I wanted to.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1313,6 +1376,10 @@
       親方がミューノをみててくれたり<end_line>
       ザックが手伝ってくれたからだぜ<end_line>
     </sjis>
+    <ascii>
+    A-Anyway, Master and Zakk<end_line>
+    were there to help us out too.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1320,11 +1387,11 @@
       親方がミューノをみててくれたり<end_line>
       ザックが手伝ってくれたからだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     A-Anyway, Master and Zakk<end_line>
     were there to help us out too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1362,16 +1429,19 @@
       <partner><three_dots><end_line>
       お前<three_dots><end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner><three_dots><end_line>
       あなた<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1396,15 +1466,18 @@
     <sjis>
       そっちか！？<end_line>
     </sjis>
+    <ascii>
+    THAT'S what you care about!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっちなの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     THAT'S what you care about!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1415,17 +1488,21 @@
       まあ、親方のためにもさ<end_line>
       いっしょに修行をがんばろうぜ<end_line>
     </sjis>
+    <ascii>
+    Well anyway, let's just<end_line>
+    do our best with training.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       まあ、親方のためにもさ<end_line>
       いっしょに修行をがんばろうね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well anyway, let's just<end_line>
     do our best with training.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1448,6 +1525,11 @@
       <partner>がいてくれて<end_line>
       本当に助かってたんだよ！<end_line>
     </sjis>
+    <ascii>
+    You know,<end_line>
+    having you around<end_line>
+    is a huge help!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1455,12 +1537,12 @@
       <partner>がいてくれて<end_line>
       本当に助かってたんだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You know,<end_line>
     having you around<end_line>
     is a huge help!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1498,17 +1580,21 @@
       じゃ、これからもよろしくたのむぜ<end_line>
       <partner><end_line>
     </sjis>
+    <ascii>
+    Then, let's keep getting along,<end_line>
+    <partner><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       じゃ、これからもよろしくたのむね<end_line>
       <partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Then, let's keep getting along,<end_line>
     <partner><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Translation/JE Scripts/Day 01/047_25029148_17dea1c.xml
+++ b/Translation/JE Scripts/Day 01/047_25029148_17dea1c.xml
@@ -117,6 +117,11 @@
       絶対持って行くさ！<end_line>
       看病だってするよ！<end_line>
     </sjis>
+    <ascii>
+    T-That's not true!<end_line>
+    Of course I would!<end_line>
+    I'd even nurse you personally!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -124,12 +129,12 @@
       絶対持って行くって！<end_line>
       看病だってするよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     T-That's not true!<end_line>
     Of course I would!<end_line>
     I'd even nurse you personally!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -156,6 +161,11 @@
       でも、今まで親方が病気になったの<end_line>
       見たことない<three_dots><end_line>
     </sjis>
+    <ascii>
+    Leave it to me!<end_line>
+    You know, I've never actually<end_line>
+    seen you sick before, Master.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -163,12 +173,12 @@
       でも、今まで親方が病気になったの<end_line>
       見たことない<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Leave it to me!<end_line>
     You know, I've never actually<end_line>
     seen you sick before, Master.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -179,17 +189,21 @@
       いった！<end_line>
       なんでだよ！？<end_line>
     </sjis>
+    <ascii>
+    Ow!<end_line>
+    What was that for?!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       いった！<end_line>
       なんでよ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ow!<end_line>
     What was that for?!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 01/048_25030796_17df08c.xml
+++ b/Translation/JE Scripts/Day 01/048_25030796_17df08c.xml
@@ -106,6 +106,11 @@
       ちゃんとザックの薬のんだのか？<end_line>
       約束だぜ？<end_line>
     </sjis>
+    <ascii>
+    It's okay if you're feeling better.<end_line>
+    Did you drink Zakk's medicine?<end_line>
+    You promised, you know.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -113,12 +118,12 @@
       ちゃんとザックの薬のんだ？<end_line>
       約束だよ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's okay if you're feeling better.<end_line>
     Did you drink Zakk's medicine?<end_line>
     You promised, you know.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -140,17 +145,21 @@
       じゃあ、それが効いたんだな<end_line>
       ザックもよろこぶぞ<end_line>
     </sjis>
+    <ascii>
+    I guess it worked then.<end_line>
+    Zakk will be happy to hear that.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       じゃあ、それが効いたんだね<end_line>
       ザックもよろこぶよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I guess it worked then.<end_line>
     Zakk will be happy to hear that.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -172,17 +181,21 @@
       でも、たおれるまで仕事とはね<end_line>
       お前も大変なんだなぁ<three_dots><end_line>
     </sjis>
+    <ascii>
+    But man, you work way too hard<three_dots><end_line>
+    I guess you've got your reasons.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       でも、たおれるまで仕事とは<three_dots><end_line>
       あなたも大変なんだね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     But man, you work way too hard<three_dots><end_line>
     I guess you've got your reasons.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -229,6 +242,10 @@
       なんだよ、その言い方<end_line>
       知らないから聞いただけだろ？<end_line>
     </sjis>
+    <ascii>
+    Hey, calm down.<end_line>
+    I was just curious<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -236,11 +253,11 @@
       なによ、その言い方<end_line>
       知らないから聞いただけでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, calm down.<end_line>
     I was just curious<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 01/24319036_173143c.xml
+++ b/Translation/JE Scripts/Day 01/24319036_173143c.xml
@@ -30,24 +30,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			使い込んだ武器を解体して<end_line>
 			もう一度鍛え直すと<end_line>
 			もっと強い武器ができるんだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			使い込んだ武器を解体して<end_line>
-			もう一度鍛え直すと<end_line>
-			もっと強い武器ができるんだよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     If you disassemble a weapon you've<end_line>
     used for a while and reforge it,<end_line>
     the it'll come out stronger.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			使い込んだ武器を解体して<end_line>
+			もう一度鍛え直すと<end_line>
+			もっと強い武器ができるんだよ<end_line>
+		</sjis>
+    <ascii>
+    If you disassemble a weapon you've<end_line>
+    used for a while and reforge it,<end_line>
+    the it'll come out stronger.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -71,23 +76,27 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そっ、そんなことないぞ！<end_line>
 			お前も修行をつめば<end_line>
 			わかるって！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    U-Uh, this is for practice!<end_line>
+    You'll understand if you just do it!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そっ、そんなことないよ！<end_line>
 			あなたも修行をつめば<end_line>
 			わかるって！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     U-Uh, this is for practice!<end_line>
     You'll understand if you just do it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -121,24 +130,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			使い込んだ武器を解体して<end_line>
 			もう一度鍛え直すと<end_line>
 			もっと強い武器ができるんだぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			使い込んだ武器を解体して<end_line>
-			もう一度鍛え直すと<end_line>
-			もっと強い武器ができるんだよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     If you disassemble a weapon you've<end_line>
     used for a while and reforge it,<end_line>
     the it'll come out stronger.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			使い込んだ武器を解体して<end_line>
+			もう一度鍛え直すと<end_line>
+			もっと強い武器ができるんだよ<end_line>
+		</sjis>
+    <ascii>
+    If you disassemble a weapon you've<end_line>
+    used for a while and reforge it,<end_line>
+    the it'll come out stronger.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -162,23 +176,27 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			そっ、そんなことないぞ！<end_line>
 			お前も修行をつめば<end_line>
 			わかるって！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    U-Uh, this is for practice!<end_line>
+    You'll understand if you just do it!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そっ、そんなことないよ！<end_line>
 			あなたも修行をつめば<end_line>
 			わかるって！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     U-Uh, this is for practice!<end_line>
     You'll understand if you just do it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -212,24 +230,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			でも使い込んだ武器を解体して<end_line>
 			もう一度鍛え直すと<end_line>
 			もっと強い武器ができるんだぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも使い込んだ武器を解体して<end_line>
-			もう一度鍛え直すと<end_line>
-			もっと強い武器ができるんだよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     But if you disassemble a weapon<end_line>
     you've used for a while and <end_line>
     reforge it, it'll come out stronger.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でも使い込んだ武器を解体して<end_line>
+			もう一度鍛え直すと<end_line>
+			もっと強い武器ができるんだよ<end_line>
+		</sjis>
+    <ascii>
+    But if you disassemble a weapon<end_line>
+    you've used for a while and <end_line>
+    reforge it, it'll come out stronger.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -251,23 +274,27 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			じ、十分使い込んでるよ！<end_line>
 			お前も修行をつめば<end_line>
 			わかるって！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    I-It's good enough!<end_line>
+    This is just for practice anyway!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			じ、十分使い込んでますっ！<end_line>
 			あなたも修行をつめば<end_line>
 			わかるって！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I-It's good enough!<end_line>
     This is just for practice anyway!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -300,24 +327,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			でも使い込んだ武器を解体して<end_line>
 			もう一度鍛え直すと<end_line>
 			もっと強い武器ができるんだぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも使い込んだ武器を解体して<end_line>
-			もう一度鍛え直すと<end_line>
-			もっと強い武器ができるんだよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     But if you disassemble a weapon<end_line>
     you've used for a while and <end_line>
     reforge it, it'll come out stronger.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でも使い込んだ武器を解体して<end_line>
+			もう一度鍛え直すと<end_line>
+			もっと強い武器ができるんだよ<end_line>
+		</sjis>
+    <ascii>
+    But if you disassemble a weapon<end_line>
+    you've used for a while and <end_line>
+    reforge it, it'll come out stronger.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -339,19 +371,19 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そっ、そんなことないぞ！<end_line>
 			お前も修行をつめば<end_line>
 			わかるって！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			そっ、そんなことないよ！<end_line>
 			あなたも修行をつめば<end_line>
 			わかるって！<end_line>
 		</sjis>
-	</female>
+  </female>
 </dialogue>
   <ascii>
     U-Uh, this is for practice!<end_line>
@@ -433,21 +465,25 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			まあな<end_line>
 			でも、それが修行だよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			まあね<end_line>
-			でも、それが修行なの<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I guess.<end_line>
     That's practice for you.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			まあね<end_line>
+			でも、それが修行なの<end_line>
+		</sjis>
+    <ascii>
+    I guess.<end_line>
+    That's practice for you.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -493,21 +529,25 @@
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なに言ってんだよ！<end_line>
 			お前もいっしょにやるんだよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なに言ってるの！<end_line>
-			あなたもいっしょにやるの<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey, come on!<end_line>
     You have to help me!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なに言ってるの！<end_line>
+			あなたもいっしょにやるの<end_line>
+		</sjis>
+    <ascii>
+    Hey, come on!<end_line>
+    You have to help me!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -538,18 +578,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			それが修行だよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			それが修行なの<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, we are practicing.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			それが修行なの<end_line>
+		</sjis>
+    <ascii>
+    Well, we are practicing.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -607,18 +650,21 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			素直なんだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			素直なのね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     when it comes to Murno<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			素直なのね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    when it comes to Murno<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -652,24 +698,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			いっしょに行った方が<end_line>
 			ミューノが安心するって<end_line>
 			親方が言ってただろ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いっしょに行った方が<end_line>
-			ミューノが安心するって<end_line>
-			親方が言ってたでしょ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Murno would be more relaxed<end_line>
     if we went together.<end_line>
     Didn't Master say so?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いっしょに行った方が<end_line>
+			ミューノが安心するって<end_line>
+			親方が言ってたでしょ<end_line>
+		</sjis>
+    <ascii>
+    Murno would be more relaxed<end_line>
+    if we went together.<end_line>
+    Didn't Master say so?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -693,18 +744,21 @@
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、それ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     W-What's that supposed to mean?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ<end_line>
+		</sjis>
+    <ascii>
+    W-What's that supposed to mean?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -737,23 +791,27 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ<end_line>
 			そんなカオしてると<end_line>
 			ミューノが心配するぞ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Don't make that face.<end_line>
+    Murno will be worried about you.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			なによ<end_line>
 			そんなカオしてると<end_line>
 			ミューノが心配するよ？<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Don't make that face.<end_line>
     Murno will be worried about you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -776,24 +834,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なるほど<end_line>
 			いつもどおりのカオでミューノを<end_line>
 			安心させようってことだな？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なるほど<end_line>
-			いつもどおりのカオでミューノを<end_line>
-			安心させようってワケね？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I see.<end_line>
     You're trying to act normal<end_line>
     so she can relax, right?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なるほど<end_line>
+			いつもどおりのカオでミューノを<end_line>
+			安心させようってワケね？<end_line>
+		</sjis>
+    <ascii>
+    I see.<end_line>
+    You're trying to act normal<end_line>
+    so she can relax, right?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -849,24 +912,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ちょ、ひっぱるなよ<end_line>
 			あわてなくてもミューノは<end_line>
 			逃げないよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ちょ、ひっぱらないで！<end_line>
-			あわてなくてもミューノは<end_line>
-			逃げないってば！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey, don't pull my arm!<end_line>
     No need to rush,<end_line>
     I'm sure she's fine!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ちょ、ひっぱらないで！<end_line>
+			あわてなくてもミューノは<end_line>
+			逃げないってば！<end_line>
+		</sjis>
+    <ascii>
+    Hey, don't pull my arm!<end_line>
+    No need to rush,<end_line>
+    I'm sure she's fine!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -913,24 +981,29 @@
 	<portrait_l entry="player" eye="happy" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノの事なら<end_line>
 			親方にまかせておけば<end_line>
 			大丈夫だって<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノの事なら<end_line>
-			親方にまかせておけば<end_line>
-			大丈夫だよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm sure Master will<end_line>
     take care of Murno.<end_line>
     Don't worry about it.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノの事なら<end_line>
+			親方にまかせておけば<end_line>
+			大丈夫だよ<end_line>
+		</sjis>
+    <ascii>
+    I'm sure Master will<end_line>
+    take care of Murno.<end_line>
+    Don't worry about it.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -950,21 +1023,25 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			親方はああ見えても<end_line>
 			面倒見はいいから大丈夫だって<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			親方はあんな風だけど<end_line>
-			面倒見はいいから大丈夫だよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Despite how she looks,<end_line>
     she's good at tending to others.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			親方はあんな風だけど<end_line>
+			面倒見はいいから大丈夫だよ<end_line>
+		</sjis>
+    <ascii>
+    Despite how she looks,<end_line>
+    she's good at tending to others.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -984,20 +1061,23 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ<end_line>
 			ジッと見て<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Don't just stare at me<three_dots><end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			なによ<end_line>
 			ジロジロ見ないでよ<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Don't just stare at me<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1019,20 +1099,23 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ど、どういうイミだよ<end_line>
 			それ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    What's that supposed to mean?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			ど、どういうイミよ<end_line>
 			それ？<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What's that supposed to mean?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1064,24 +1147,29 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノの事？<end_line>
 			たしかに、親方は口は悪いけど<end_line>
 			面倒見はいいから大丈夫だって<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノの事？<end_line>
-			まあ、親方って口は悪いけど<end_line>
-			面倒見はいいから大丈夫だよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     About Murno?<end_line>
     Sure, Master can be rude,<end_line>
     but she's good at tending to others.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノの事？<end_line>
+			まあ、親方って口は悪いけど<end_line>
+			面倒見はいいから大丈夫だよ<end_line>
+		</sjis>
+    <ascii>
+    About Murno?<end_line>
+    Sure, Master can be rude,<end_line>
+    but she's good at tending to others.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1105,20 +1193,23 @@
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ど、どういうイミだよ<end_line>
 			それ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    What's that supposed to mean?<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			ど、どういうイミよ<end_line>
 			それ？<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What's that supposed to mean?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1150,18 +1241,21 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノの事が気になるのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノの事が気になる？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Worried about Murno?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノの事が気になる？<end_line>
+		</sjis>
+    <ascii>
+    Worried about Murno?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1183,24 +1277,29 @@
 	<portrait_l entry="player" eye="serious" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			あの女って、親方のこと？<end_line>
 			それって要するに<end_line>
 			ミューノが心配ってことだろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あの女って、親方のこと？<end_line>
-			それって要するに<end_line>
-			ミューノが心配ってことだよね？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You mean Master?<end_line>
     Doesn't that mean you really<end_line>
     are worried about Murno?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あの女って、親方のこと？<end_line>
+			それって要するに<end_line>
+			ミューノが心配ってことだよね？<end_line>
+		</sjis>
+    <ascii>
+    You mean Master?<end_line>
+    Doesn't that mean you really<end_line>
+    are worried about Murno?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1257,18 +1356,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノの事が気になるのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノの事が気になる？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Worried about Murno?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノの事が気になる？<end_line>
+		</sjis>
+    <ascii>
+    Worried about Murno?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1290,24 +1392,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			大丈夫だって<end_line>
 			たしかに、親方はチョット短気だけど<end_line>
 			面倒見はいいから<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			大丈夫だよ<end_line>
-			まあ、親方ってチョット短気だけど<end_line>
-			面倒見はいいんだから<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     It'll be fine.<end_line>
     Yeah, she's a bit short tempered,<end_line>
     but she's good at tending to others.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			大丈夫だよ<end_line>
+			まあ、親方ってチョット短気だけど<end_line>
+			面倒見はいいんだから<end_line>
+		</sjis>
+    <ascii>
+    It'll be fine.<end_line>
+    Yeah, she's a bit short tempered,<end_line>
+    but she's good at tending to others.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1457,18 +1564,21 @@
 	<portrait_l entry="player" eye="happy" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			素直なんだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			素直なのね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     care about, huh<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			素直なのね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    care about, huh<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1516,21 +1626,25 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			言うことはすごく<end_line>
 			カッコイイな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			言うことはすごく<end_line>
-			カッコイイね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     The way you say things<end_line>
     always sounds so cool.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			言うことはすごく<end_line>
+			カッコイイね<end_line>
+		</sjis>
+    <ascii>
+    The way you say things<end_line>
+    always sounds so cool.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1576,24 +1690,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノが心配なのはわかるけどさ<end_line>
 			戻ってもジャマになるだけだし<end_line>
 			今は修行しようぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノが心配なのはわかるけど<end_line>
-			戻ってもジャマになるだけだし<end_line>
-			今は修行しようよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I know you're worried about Murno,<end_line>
     but we'd just be a bother.<end_line>
     Bear with it for now.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノが心配なのはわかるけど<end_line>
+			戻ってもジャマになるだけだし<end_line>
+			今は修行しようよ<end_line>
+		</sjis>
+    <ascii>
+    I know you're worried about Murno,<end_line>
+    but we'd just be a bother.<end_line>
+    Bear with it for now.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1702,21 +1821,25 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ザックにハンマーを届けよう！<end_line>
 			さっき駅に行くって言ってたぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ザックにハンマーを届けよう！<end_line>
-			さっき駅に行くって言ってたよね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I have to return Zakk's hammer!<end_line>
     He said he was going to the station.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ザックにハンマーを届けよう！<end_line>
+			さっき駅に行くって言ってたよね<end_line>
+		</sjis>
+    <ascii>
+    I have to return Zakk's hammer!<end_line>
+    He said he was going to the station.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1800,21 +1923,25 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ザックにハンマーを届けよう！<end_line>
 			さっき駅に行くって言ってたぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ザックにハンマーを届けよう！<end_line>
-			さっき駅に行くって言ってたよね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I have to return Zakk's hammer!<end_line>
     He said he was going to the station.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ザックにハンマーを届けよう！<end_line>
+			さっき駅に行くって言ってたよね<end_line>
+		</sjis>
+    <ascii>
+    I have to return Zakk's hammer!<end_line>
+    He said he was going to the station.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1898,21 +2025,25 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ザックにハンマーを届けよう！<end_line>
 			さっき駅に行くって言ってたぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ザックにハンマーを届けよう！<end_line>
-			さっき駅に行くって言ってたよね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I have to return Zakk's hammer!<end_line>
     He said he was going to the station.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ザックにハンマーを届けよう！<end_line>
+			さっき駅に行くって言ってたよね<end_line>
+		</sjis>
+    <ascii>
+    I have to return Zakk's hammer!<end_line>
+    He said he was going to the station.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1995,21 +2126,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ザックにハンマーを届けよう！<end_line>
 			さっき駅に行くって言ってたぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ザックにハンマーを届けよう！<end_line>
-			さっき駅に行くって言ってたよね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I have to return Zakk's hammer!<end_line>
     He said he was going to the station.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ザックにハンマーを届けよう！<end_line>
+			さっき駅に行くって言ってたよね<end_line>
+		</sjis>
+    <ascii>
+    I have to return Zakk's hammer!<end_line>
+    He said he was going to the station.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2223,21 +2358,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんか素直だな<three_dots><end_line>
 			気味悪いぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			な、なんで素直なの？<end_line>
-			ちょっとこわいよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You didn't complain?<end_line>
     That's a first<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			な、なんで素直なの？<end_line>
+			ちょっとこわいよ<end_line>
+		</sjis>
+    <ascii>
+    You didn't complain?<end_line>
+    That's a first<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2377,21 +2516,25 @@
 	<portrait_l entry="player" eye="serious" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだぞ<end_line>
 			気をつけなきゃ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-			気をつけなきゃ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah<three_dots><end_line>
     We have to be careful<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+			気をつけなきゃ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Yeah<three_dots><end_line>
+    We have to be careful<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -2415,18 +2558,21 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			たのむよ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			たのむね、<partner>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm counting on you!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			たのむね、<partner>！<end_line>
+		</sjis>
+    <ascii>
+    I'm counting on you!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2450,21 +2596,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			へえ、わかるんだ<end_line>
 			やっぱり匂いとかでわかるのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			へえ、わかるんだ<end_line>
-			やっぱり匂いとかでわかるの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Oh, you can tell?<end_line>
     Do they smell or something?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			へえ、わかるんだ<end_line>
+			やっぱり匂いとかでわかるの？<end_line>
+		</sjis>
+    <ascii>
+    Oh, you can tell?<end_line>
+    Do they smell or something?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2550,21 +2700,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうなんだ<end_line>
 			ヒゲとか物音とかじゃないんだな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうなんだ<end_line>
-			ヒゲとか物音とかじゃないんだね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I see. So you're not using<end_line>
     your whiskers or hearing either.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうなんだ<end_line>
+			ヒゲとか物音とかじゃないんだね<end_line>
+		</sjis>
+    <ascii>
+    I see. So you're not using<end_line>
+    your whiskers or hearing either.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2602,21 +2756,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			おお！<end_line>
 			たのもしいな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			へえ！<end_line>
-			たのもしいね！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ohh!<end_line>
     How reliable!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			へえ！<end_line>
+			たのもしいね！<end_line>
+		</sjis>
+    <ascii>
+    Ohh!<end_line>
+    How reliable!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2638,18 +2796,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="stressed">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだって！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Even if they attack us!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ！？<end_line>
+		</sjis>
+    <ascii>
+    Even if they attack us!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2671,18 +2832,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+		</sjis>
+    <ascii>
+    Yeah.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2715,21 +2879,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			わかってるって<end_line>
 			よろしくたのむぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わかってるって<end_line>
-			よろしくたのむよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm sure it will.<end_line>
     I'm counting on you.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わかってるって<end_line>
+			よろしくたのむよ<end_line>
+		</sjis>
+    <ascii>
+    I'm sure it will.<end_line>
+    I'm counting on you.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">

--- a/Translation/JE Scripts/Day 01/24324844_1732aec.xml
+++ b/Translation/JE Scripts/Day 01/24324844_1732aec.xml
@@ -7,7 +7,7 @@
 		えっと<three_dots><end_line>
 		どっちの橋なら渡れそうだっけ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Umm<three_dots><end_line>
 		Which bridge did you say was fine?<end_line>
 	</ascii>
@@ -21,7 +21,7 @@
 		下ノ橋ハ大丈夫デス<end_line>
 		上ノ橋ハ問題ガアルヨウデス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The Bottom Bridge.<end_line>
 		The Upper Bridge Is Problematic.<end_line>
 	</ascii>
@@ -35,7 +35,7 @@
 		えっと<three_dots><end_line>
 		どっちの橋なら渡れそうだっけ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Umm<three_dots><end_line>
 		Which bridge did you say was fine?<end_line>
 	</ascii>
@@ -48,7 +48,7 @@
 	<sjis>
 		下の橋なら大丈夫じゃろう<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The bottom bridge should be fine.<end_line>
 	</ascii>
 </dialogue>
@@ -58,18 +58,21 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			橋に何かあるのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			橋に何かあるの？<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Is there something wrong?<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			橋に何かあるの？<end_line>
+		</sjis>
+    <ascii>
+		Is there something wrong?<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -80,7 +83,7 @@
 		ふ<three_dots><end_line>
 		行けばわかる<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hmph<three_dots><end_line>
 		You'll know soon enough.<end_line>
 	</ascii>
@@ -91,18 +94,21 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、それ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		That's not helpful at all!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ！<end_line>
+		</sjis>
+    <ascii>
+		That's not helpful at all!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -112,7 +118,7 @@
 		えっと<three_dots><end_line>
 		どっちの橋なら渡れそうだっけ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Umm<three_dots><end_line>
 		Which bridge did you say was fine?<end_line>
 	</ascii>
@@ -125,7 +131,7 @@
 		下の橋ですわ<end_line>
 		上の橋はイヤな予感がするんです<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The bottom bridge.<end_line>
 		I don't trust the other one<three_dots><end_line>
 	</ascii>
@@ -138,7 +144,7 @@
 	<sjis>
 		ザックのところへ行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's go find Zakk!<end_line>
 	</ascii>
 </dialogue>
@@ -150,7 +156,7 @@
 	<sjis>
 		了解デス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Roger.<end_line>
 	</ascii>
 </dialogue>
@@ -163,7 +169,7 @@
 		けど、橋はくずれていたのに<end_line>
 		なんで落ちるかな？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Really though, how could he fall in<end_line>
 		when the bridge was clearly broken?<end_line>
 	</ascii>
@@ -177,7 +183,7 @@
 		<three_dots><end_line>
 		アナタモ　落チマシタガ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 		Did You Not Also Fall In?<end_line>
 	</ascii>
@@ -188,24 +194,29 @@
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			オレが渡った時はまだ<end_line>
 			くずれてなかったし<three_dots><end_line>
 			仕方ないだろ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしの時はまだ<end_line>
-			くずれてなかったんだから<end_line>
-			仕方ないでしょ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Well it hadn't collapsed<end_line>
 		when I walked on it!<end_line>
 		What am I supposed to do!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしの時はまだ<end_line>
+			くずれてなかったんだから<end_line>
+			仕方ないでしょ！<end_line>
+		</sjis>
+    <ascii>
+		Well it hadn't collapsed<end_line>
+		when I walked on it!<end_line>
+		What am I supposed to do!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -215,7 +226,7 @@
 	<sjis>
 		落チタ事ニ　変ワリハアリマセン<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		However, You Still Fell In.<end_line>
 	</ascii>
 </dialogue>
@@ -227,7 +238,7 @@
 	<sjis>
 		むっ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ugh<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -239,7 +250,7 @@
 	<sjis>
 		ザックのところへ行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's go find Zakk!<end_line>
 	</ascii>
 </dialogue>
@@ -251,7 +262,7 @@
 	<sjis>
 		うむ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Mhm.<end_line>
 	</ascii>
 </dialogue>
@@ -264,7 +275,7 @@
 		けど、橋はくずれていたのに<end_line>
 		なんで落ちるかな？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Really though, how could he fall in<end_line>
 		when the bridge was clearly broken?<end_line>
 	</ascii>
@@ -278,7 +289,7 @@
 		何を言っておる<end_line>
 		おぬしも落ちたじゃろ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hmm?<end_line>
 		Did you not also fall in?<end_line>
 	</ascii>
@@ -289,24 +300,29 @@
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			オレが渡った時はまだ<end_line>
 			くずれてなかったし<three_dots><end_line>
 			仕方ないだろ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしの時はまだ<end_line>
-			くずれてなかったんだから<end_line>
-			仕方ないでしょ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Well it hadn't collapsed<end_line>
 		when I walked on it!<end_line>
 		What am I supposed to do!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしの時はまだ<end_line>
+			くずれてなかったんだから<end_line>
+			仕方ないでしょ！<end_line>
+		</sjis>
+    <ascii>
+		Well it hadn't collapsed<end_line>
+		when I walked on it!<end_line>
+		What am I supposed to do!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -317,7 +333,7 @@
 		やれやれ、五十歩百歩と言ってな<end_line>
 		落ちた事に変わりは<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Perhaps, but that does not change<end_line>
 		the fact that you did<three_dots><end_line>
 	</ascii>
@@ -328,21 +344,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			はやく行こうぜ、<partner><end_line>
 			置いてくぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			はやく行こうよ、<partner><end_line>
-			置いてっちゃうよ<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Hurry it up, <partner>,<end_line>
 		or I'll leave you behind.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			はやく行こうよ、<partner><end_line>
+			置いてっちゃうよ<end_line>
+		</sjis>
+    <ascii>
+		Hurry it up, <partner>,<end_line>
+		or I'll leave you behind.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -352,7 +372,7 @@
 	<sjis>
 		ザックのところへ行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's go find Zakk!<end_line>
 	</ascii>
 </dialogue>
@@ -364,7 +384,7 @@
 	<sjis>
 		<three_dots>好きにしろ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Whatever you say.<end_line>
 	</ascii>
 </dialogue>
@@ -377,7 +397,7 @@
 		けど、橋はくずれていたのに<end_line>
 		なんで落ちるかな？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Really though, how could he fall in<end_line>
 		when the bridge was clearly broken?<end_line>
 	</ascii>
@@ -392,7 +412,7 @@
 		だが、私としては<end_line>
 		なかなか楽しいぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>No idea.<end_line>
 		But I found it quite entertaining.<end_line>
 	</ascii>
@@ -403,18 +423,21 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、それ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Hey!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ！<end_line>
+		</sjis>
+    <ascii>
+		Hey!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -426,7 +449,7 @@
 		どうした？<end_line>
 		早く行った方がいいんじゃないのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Heh<three_dots><end_line>
 		What's wrong?<end_line>
 		Didn't you want to help him?<end_line>
@@ -438,21 +461,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			待てよ！<end_line>
 			まだ話は終わってないぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			待ってよ！<end_line>
-			まだ話は終わってないってば<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Wait!<end_line>
 		This conversation isn't over!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			待ってよ！<end_line>
+			まだ話は終わってないってば<end_line>
+		</sjis>
+    <ascii>
+		Wait!<end_line>
+		This conversation isn't over!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -461,7 +488,7 @@
 	<sjis>
 		ザックのところへ行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's go find Zakk!<end_line>
 	</ascii>
 </dialogue>
@@ -472,7 +499,7 @@
 	<sjis>
 		そうですね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Okay.<end_line>
 	</ascii>
 </dialogue>
@@ -483,8 +510,8 @@
 	<sjis>
 		けど、橋はくずれていたのに<end_line>
 		なんで落ちるかな？<end_line>
-	</sjis>	
-	<ascii>
+	</sjis>
+  <ascii>
 		Really though, how could he fall in<end_line>
 		when the bridge was clearly broken?<end_line>
 	</ascii>
@@ -497,7 +524,7 @@
 		あなたのように、注意力が<end_line>
 		足りていない証拠ですわ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		He is not aware of his<end_line>
 		surroundings, just like you.<end_line>
 	</ascii>
@@ -507,24 +534,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			オレが渡った時はまだ<end_line>
 			くずれてなかったし<three_dots><end_line>
 			仕方ないだろ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしの時はまだ<end_line>
-			くずれてなかったんだから<end_line>
-			仕方ないでしょ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Well it hadn't collapsed<end_line>
 		when I walked on it!<end_line>
 		What am I supposed to do!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしの時はまだ<end_line>
+			くずれてなかったんだから<end_line>
+			仕方ないでしょ！<end_line>
+		</sjis>
+    <ascii>
+		Well it hadn't collapsed<end_line>
+		when I walked on it!<end_line>
+		What am I supposed to do!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -535,7 +567,7 @@
 		落ちた事に変わりは<end_line>
 		ありませんわ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That does not change<end_line>
 		the fact that you<end_line>
 		also fell in.<end_line>
@@ -550,7 +582,7 @@
 		注意深く行動して下さいね！<end_line>
 		わかりましたか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Take a lesson from me and<end_line>
 		proceed with care!<end_line>
 		Understood?<end_line>
@@ -563,7 +595,7 @@
 	<sjis>
 		<partner>を見習う<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Learn from <partner><three_dots>?<end_line>
 	</ascii>
 </dialogue>
@@ -574,7 +606,7 @@
 	<sjis>
 		わかりましたか！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Understood!?<end_line>
 	</ascii>
 </dialogue>
@@ -585,7 +617,7 @@
 	<sjis>
 		は、はい<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Y-yeah<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -595,24 +627,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			キッカの実はマニグ採掘場の<end_line>
 			奥の森にあるみたいだ<end_line>
 			行ってみよう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			キッカの実はマニグ採掘場の<end_line>
-			奥の森にあるみたい<end_line>
-			行ってみよう<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		We'll find the Kicca Ffuit in<end_line>
 		the forest past Manig Mine.<end_line>
 		Let's go.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			キッカの実はマニグ採掘場の<end_line>
+			奥の森にあるみたい<end_line>
+			行ってみよう<end_line>
+		</sjis>
+    <ascii>
+		We'll find the Kicca Ffuit in<end_line>
+		the forest past Manig Mine.<end_line>
+		Let's go.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -624,7 +661,7 @@
 		アリマセン<end_line>
 		ドンナ果物デスカ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No Data Found On<end_line>
 		Kicca Fruit.<end_line>
 		What Kind Of Fruit Is It?<end_line>
@@ -636,24 +673,29 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだなぁ<three_dots><end_line>
 			甘いのも、しぶいのもあるんだ<end_line>
 			オレはドロドロくらいが好きだな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだなぁ<three_dots><end_line>
-			甘いのも、しぶいのもあるよ<end_line>
-			わたしはドロドロくらいが好き<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Let's see<three_dots><end_line>
 		It's sweet, but also bitter.<end_line>
 		I like how the juice is syrupy.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだなぁ<three_dots><end_line>
+			甘いのも、しぶいのもあるよ<end_line>
+			わたしはドロドロくらいが好き<end_line>
+		</sjis>
+    <ascii>
+		Let's see<three_dots><end_line>
+		It's sweet, but also bitter.<end_line>
+		I like how the juice is syrupy.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -665,7 +707,7 @@
 		どろどろガ　オイシイ<three_dots><end_line>
 		ワカリマセン<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Sweet, Bitter,<end_line>
 		Syrupy, Tasty<three_dots><end_line>
 		I Do Not Understand<three_dots><end_line>
@@ -677,24 +719,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ま、おいしい果物だな<end_line>
 			あれから薬ができるなんて<end_line>
 			知らなかったけど<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ま、おいしい果物だね<end_line>
-			あれから薬ができるなんて<end_line>
-			知らなかったけど<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Anyway, its delicious.<end_line>
 		But I didnt know you could<end_line>
 		make medicine out of it.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			ま、おいしい果物だね<end_line>
+			あれから薬ができるなんて<end_line>
+			知らなかったけど<end_line>
+		</sjis>
+    <ascii>
+		Anyway, its delicious.<end_line>
+		But I didnt know you could<end_line>
+		make medicine out of it.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -702,24 +749,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			キッカの実はマニグ採掘場の<end_line>
 			奥の森にあるみたいだ<end_line>
 			行ってみよう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			キッカの実はマニグ採掘場の<end_line>
-			奥の森にあるみたい<end_line>
-			行ってみよう<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		We'll find the Kicca fruit in<end_line>
 		the forest past Manig Mine.<end_line>
 		Let's go.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			キッカの実はマニグ採掘場の<end_line>
+			奥の森にあるみたい<end_line>
+			行ってみよう<end_line>
+		</sjis>
+    <ascii>
+		We'll find the Kicca fruit in<end_line>
+		the forest past Manig Mine.<end_line>
+		Let's go.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -731,7 +783,7 @@
 		あまりくわしくなくての<three_dots><end_line>
 		一体どんなものなのじゃ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I don't know much<end_line>
 		about fruits<three_dots><end_line>
 		What kind of fruit is it?<end_line>
@@ -743,24 +795,29 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そうだなぁ<three_dots><end_line>
 			甘いのも、しぶいのもあるんだ<end_line>
 			オレはドロドロくらいが好きだな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだなぁ<three_dots><end_line>
-			甘いのも、しぶいのもあるよ<end_line>
-			わたしはドロドロくらいが好き<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Let's see<three_dots><end_line>
 		It's sweet, but also bitter.<end_line>
 		I like how the juice is syrupy.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだなぁ<three_dots><end_line>
+			甘いのも、しぶいのもあるよ<end_line>
+			わたしはドロドロくらいが好き<end_line>
+		</sjis>
+    <ascii>
+		Let's see<three_dots><end_line>
+		It's sweet, but also bitter.<end_line>
+		I like how the juice is syrupy.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -770,7 +827,7 @@
 	<sjis>
 		さっぱりわからん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's not very helpful.<end_line>
 	</ascii>
 </dialogue>
@@ -780,24 +837,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ま、おいしい果物だな<end_line>
 			あれから薬ができるなんて<end_line>
 			知らなかったけど<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ま、おいしい果物だよ<end_line>
-			あれから薬ができるなんて<end_line>
-			知らなかったけど<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Anyway, its delicious.<end_line>
 		But I didnt know you could<end_line>
 		make medicine out of it.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			ま、おいしい果物だよ<end_line>
+			あれから薬ができるなんて<end_line>
+			知らなかったけど<end_line>
+		</sjis>
+    <ascii>
+		Anyway, its delicious.<end_line>
+		But I didnt know you could<end_line>
+		make medicine out of it.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -805,24 +867,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			キッカの実はマニグ採掘場の<end_line>
 			奥の森にあるみたいだから<end_line>
 			さがすの手伝ってくれよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			キッカの実はマニグ採掘場の<end_line>
-			奥の森にあるみたいだから<end_line>
-			さがすの手伝ってね<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		We'll find the Kicca fruit in<end_line>
 		the forest past Manig Mine.<end_line>
 		Let's go.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			キッカの実はマニグ採掘場の<end_line>
+			奥の森にあるみたいだから<end_line>
+			さがすの手伝ってね<end_line>
+		</sjis>
+    <ascii>
+		We'll find the Kicca fruit in<end_line>
+		the forest past Manig Mine.<end_line>
+		Let's go.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -832,7 +899,7 @@
 	<sjis>
 		ムリだ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I can't.<end_line>
 	</ascii>
 </dialogue>
@@ -842,21 +909,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ！<end_line>
 			お前だって本当は<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ！<end_line>
-			あなただって本当は<three_dots><end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		What?<end_line>
 		Come on, I'm sure you really<three_dots><end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ！<end_line>
+			あなただって本当は<three_dots><end_line>
+		</sjis>
+    <ascii>
+		What?<end_line>
+		Come on, I'm sure you really<three_dots><end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -867,7 +938,7 @@
 		知らないからな<end_line>
 		キッカの実なんて<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I don't know what it is,<end_line>
 		this Kicca fruit.<end_line>
 	</ascii>
@@ -883,7 +954,7 @@
 		そうだなぁ<three_dots><end_line>
 		木になってて<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah, right<three_dots><end_line>
 		Let's see<three_dots><end_line>
 		It grows on trees<three_dots><end_line>
@@ -899,7 +970,7 @@
 		甘いのも、しぶいのもあるんだ<end_line>
 		オレはドロドロくらいが好きだな<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's sweet, but also bitter.<end_line>
 		I like how the juice is syrupy.<end_line>
 	</ascii>
@@ -915,7 +986,7 @@
 		そうだなぁ<three_dots><end_line>
 		木になってて<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ah, right<three_dots><end_line>
 		Let's see<three_dots><end_line>
 		It grows on trees<three_dots><end_line>
@@ -931,7 +1002,7 @@
 		甘いのも、しぶいのもあるよ<end_line>
 		わたしはドロドロくらいが好き<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's sweet, but also bitter.<end_line>
 		I like how the juice is syrupy.<end_line>
 	</ascii>
@@ -944,7 +1015,7 @@
 	<sjis>
 		さっぱりわからん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You lost me.<end_line>
 	</ascii>
 </dialogue>
@@ -953,24 +1024,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			キッカの実はマニグ採掘場の<end_line>
 			奥の森にあるみたいだ<end_line>
 			行ってみよう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			キッカの実はマニグ採掘場の<end_line>
-			奥の森にあるみたい<end_line>
-			行ってみよう<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		We'll find the Kicca fruit in<end_line>
 		the forest past Manig Mine.<end_line>
 		Let's go.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			キッカの実はマニグ採掘場の<end_line>
+			奥の森にあるみたい<end_line>
+			行ってみよう<end_line>
+		</sjis>
+    <ascii>
+		We'll find the Kicca fruit in<end_line>
+		the forest past Manig Mine.<end_line>
+		Let's go.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -981,7 +1057,7 @@
 		どんなものなんですか？<end_line>
 		こちらの果物にはくわしくなくて<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		By the way, what<end_line>
 		exactly is a Kicca fruit?<end_line>
 		I'm not familiar with fruits here.<end_line>
@@ -992,24 +1068,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだなぁ<three_dots><end_line>
 			甘いのも、しぶいのもあるんだ<end_line>
 			オレはドロドロくらいが好きだな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだなぁ<three_dots><end_line>
-			甘いのも、しぶいのもあるよ<end_line>
-			わたしはドロドロくらいが好き<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Let's see<three_dots><end_line>
 		It's sweet, but also bitter.<end_line>
 		I like how the juice is syrupy.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだなぁ<three_dots><end_line>
+			甘いのも、しぶいのもあるよ<end_line>
+			わたしはドロドロくらいが好き<end_line>
+		</sjis>
+    <ascii>
+		Let's see<three_dots><end_line>
+		It's sweet, but also bitter.<end_line>
+		I like how the juice is syrupy.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1018,7 +1099,7 @@
 	<sjis>
 		さっぱりわかりませんわ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's not helpful at all.<end_line>
 	</ascii>
 </dialogue>
@@ -1027,24 +1108,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ま、おいしい果物だな<end_line>
 			あれから薬ができるなんて<end_line>
 			知らなかったけど<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ま、おいしい果物だよ<end_line>
-			あれから薬ができるなんて<end_line>
-			知らなかったけど<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Anyway, its delicious.<end_line>
 		But I didnt know you could<end_line>
 		make medicine out of it.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			ま、おいしい果物だよ<end_line>
+			あれから薬ができるなんて<end_line>
+			知らなかったけど<end_line>
+		</sjis>
+    <ascii>
+		Anyway, its delicious.<end_line>
+		But I didnt know you could<end_line>
+		make medicine out of it.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1055,7 +1141,7 @@
 		マニグ採掘場の奥の森に<end_line>
 		大きなはぐれ召喚獣が！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There's a huge Stray in the<end_line>
 		forest past Manig Mine!<end_line>
 	</ascii>
@@ -1069,9 +1155,10 @@
 		ざっくトイウ　少年ガ　オソワレルト<end_line>
 		危険デス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		The Boy Zakk Is In<end_line>
 		Danger Of Being Attacked.<end_line>
+</ascii>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1079,18 +1166,21 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			急ぐぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			急がなきゃ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Let's hurry!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			急がなきゃ！<end_line>
+		</sjis>
+    <ascii>
+		Let's hurry!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1101,7 +1191,7 @@
 		マニグ採掘場の奥の森に<end_line>
 		大きなはぐれ召喚獣が！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There's a huge Stray in the<end_line>
 		forest past Manig Mine!<end_line>
 	</ascii>
@@ -1115,7 +1205,7 @@
 		ザックという少年が<end_line>
 		おそわれるかもしれんぞ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Zakk may<end_line>
 		be in danger!<end_line>
 	</ascii>
@@ -1126,18 +1216,21 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			急ぐぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			急がなきゃ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Let's hurry!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			急がなきゃ！<end_line>
+		</sjis>
+    <ascii>
+		Let's hurry!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1148,7 +1241,7 @@
 		マニグ採掘場の奥の森に<end_line>
 		大きなはぐれ召喚獣が！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There's a huge Stray in the<end_line>
 		forest past Manig Mine!<end_line>
 	</ascii>
@@ -1163,7 +1256,7 @@
 		ザックというニンゲンも<end_line>
 		やられてしまうかもな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hmph<three_dots><end_line>
 		Zakk may not make it out<end_line>
 		if we leave him alone<three_dots><end_line>
@@ -1175,18 +1268,21 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			急ぐぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			急がなきゃ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Let's hurry!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			急がなきゃ！<end_line>
+		</sjis>
+    <ascii>
+		Let's hurry!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1196,7 +1292,7 @@
 		マニグ採掘場の奥の森に<end_line>
 		大きなはぐれ召喚獣が！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There's a huge Stray in the<end_line>
 		forest past Manig Mine!<end_line>
 	</ascii>
@@ -1210,7 +1306,7 @@
 		このままではザックという少年も<end_line>
 		あぶないですわ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Uu<three_dots><end_line>
 		That means Zakk must<end_line>
 		be in danger!<end_line>
@@ -1221,18 +1317,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			急ぐぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			急がなきゃ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Let's hurry!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			急がなきゃ！<end_line>
+		</sjis>
+    <ascii>
+		Let's hurry!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1242,7 +1341,7 @@
 	<sjis>
 		キッカの実をさがそう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now to find the Kicca fruit!<end_line>
 	</ascii>
 </dialogue>
@@ -1256,7 +1355,7 @@
 		私ハ　下ノ方ヲ　サガシマスカラ<end_line>
 		アナタハ　上ノ方ヲ　見テクダサイ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There Must Be A Remaining Tree.<end_line>
 		I Will Search Down Here.<end_line>
 		You Search The Upper Area.<end_line>
@@ -1268,24 +1367,29 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なるほど！<end_line>
 			言いたいことはよくわかった！<end_line>
 			上はオレにまかせておけって！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なるほど！<end_line>
-			言いたいことはよくわかったわ！<end_line>
-			上はわたしにまかせてよ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Got it!<end_line>
 		We're splitting up then!<end_line>
 		Leave it to me!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			なるほど！<end_line>
+			言いたいことはよくわかったわ！<end_line>
+			上はわたしにまかせてよ！<end_line>
+		</sjis>
+    <ascii>
+		Got it!<end_line>
+		We're splitting up then!<end_line>
+		Leave it to me!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1295,7 +1399,7 @@
 	<sjis>
 		キッカの実をさがそう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now to find the Kicca fruit!<end_line>
 	</ascii>
 </dialogue>
@@ -1305,18 +1409,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			たよりにしてるぜ、<partner><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			たよりにしてるよ、<partner><end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		I'm counting on you, <partner>.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			たよりにしてるよ、<partner><end_line>
+		</sjis>
+    <ascii>
+		I'm counting on you, <partner>.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1327,7 +1434,7 @@
 		しかしワガハイは<end_line>
 		どんな実なのか知らんのじゃ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I still don't know what<end_line>
 		this fruit looks like.<end_line>
 	</ascii>
@@ -1340,7 +1447,7 @@
 	<sjis>
 		甘いニオイだよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It smells sweet.<end_line>
 	</ascii>
 </dialogue>
@@ -1353,7 +1460,7 @@
 		ええい、ワガハイはトラじゃ！<end_line>
 		イヌのような扱いをするでない！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hey, I'm a tiger!<end_line>
 		Don't treat me like a dog!<end_line>
 	</ascii>
@@ -1367,7 +1474,7 @@
 		そっか<three_dots><end_line>
 		わからないんだ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Oh<three_dots><end_line>
 		Alright<three_dots><end_line>
 	</ascii>
@@ -1381,7 +1488,7 @@
 		そ、そんなに落ち込む事は無いじゃろ<end_line>
 		一応努力するぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		D-don't get so depressed.<end_line>
 		I'll do what I can.<end_line>
 	</ascii>
@@ -1394,7 +1501,7 @@
 	<sjis>
 		キッカの実をさがそう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now to find the Kicca fruit!<end_line>
 	</ascii>
 </dialogue>
@@ -1407,7 +1514,7 @@
 		私はどんな実か知らないからな<end_line>
 		キサマがさがせ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You still haven't told me<end_line>
 		what kind of fruit it is.<end_line>
 	</ascii>
@@ -1418,24 +1525,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			そっか<end_line>
 			キッカの実はな<end_line>
 			甘いのがウマイんだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そっか<end_line>
-			キッカの実はね<end_line>
-			甘いのがおいしいよ<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Right.<end_line>
 		Kicca fruit is<end_line>
 		sweet and tasty.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そっか<end_line>
+			キッカの実はね<end_line>
+			甘いのがおいしいよ<end_line>
+		</sjis>
+    <ascii>
+		Right.<end_line>
+		Kicca fruit is<end_line>
+		sweet and tasty.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1446,7 +1558,7 @@
 		教えるつもりなら<end_line>
 		せめて色とかにしろ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		At least tell me<end_line>
 		what color it is.<end_line>
 	</ascii>
@@ -1458,7 +1570,7 @@
 	<sjis>
 		キッカの実をさがそう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Now to find the Kicca fruit!<end_line>
 	</ascii>
 </dialogue>
@@ -1470,7 +1582,7 @@
 		私はどんな実か知りませんわ<end_line>
 		教えてください<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I don't know what I'm looking for.<end_line>
 		How can I tell it apart?<end_line>
 	</ascii>
@@ -1480,24 +1592,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 			シブイ実はマズイから<end_line>
 			食べちゃダメだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだな<three_dots><end_line>
-			シブイ実はマズイから<end_line>
-			食べちゃダメだよ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Hmm<three_dots><end_line>
 		Bitter fruits taste bad,<end_line>
 		so don't eat them!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだな<three_dots><end_line>
+			シブイ実はマズイから<end_line>
+			食べちゃダメだよ！<end_line>
+		</sjis>
+    <ascii>
+		Hmm<three_dots><end_line>
+		Bitter fruits taste bad,<end_line>
+		so don't eat them!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1506,7 +1623,7 @@
 	<sjis>
 		私に食べて調べろと？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		You want me to compare the taste?<end_line>
 	</ascii>
 </dialogue>
@@ -1518,7 +1635,7 @@
 	<sjis>
 		薬をもらいに駅まで行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's meet Zakk at the station!<end_line>
 	</ascii>
 </dialogue>
@@ -1531,7 +1648,7 @@
 		最適経路検索中<end_line>
 		<three_dots><three_dots><three_dots><three_dots><three_dots><three_dots><three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Finding Optimal Route.<end_line>	
 		<three_dots><three_dots><three_dots><three_dots><three_dots><three_dots><three_dots><end_line>
 	</ascii>
@@ -1542,21 +1659,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ちょっと、<partner><end_line>
 			どうしたんだ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ちょっと、<partner><end_line>
-			どうしたの？<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Hey, <partner>,<end_line>
 		what are you doing?<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			ちょっと、<partner><end_line>
+			どうしたの？<end_line>
+		</sjis>
+    <ascii>
+		Hey, <partner>,<end_line>
+		what are you doing?<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1568,7 +1689,7 @@
 		みゅーの様ニ　薬ヲ届ケル為ニ<end_line>
 		最適ト思ワレル　道ヲ検索シマシタ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Complete.<end_line>
 		Determined Most Optimal Route To<end_line>
 		Pick Up And Deliver The Medicine.<end_line>
@@ -1582,7 +1703,7 @@
 	<sjis>
 		？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		?<end_line>
 	</ascii>
 </dialogue>
@@ -1592,25 +1713,25 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			おお！<end_line>
 			どうすればいいんだ？<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Ohh!<end_line>
 			So, what now?<end_line>
 		</ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			本当！？<end_line>
 			で、どうすればいいの？<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Really!?<end_line>
 			So, where to next?<end_line>
 		</ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1621,7 +1742,7 @@
 		マズハ駅ニ行キ　薬ヲ受ケ取リマス<end_line>
 		次ニ　みゅーの様ニ薬ヲ届ケマス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		First, Pick Up At The Station.<end_line>
 		Then, Deliver To Lady Murno.<end_line>
 	</ascii>
@@ -1634,7 +1755,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1644,21 +1765,25 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			何というか<three_dots><end_line>
 			その通りだな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			何というか<three_dots><end_line>
-			その通りだね<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Umm<three_dots><end_line>
 		Right<three_dots><end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			何というか<three_dots><end_line>
+			その通りだね<end_line>
+		</sjis>
+    <ascii>
+		Umm<three_dots><end_line>
+		Right<three_dots><end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1668,7 +1793,7 @@
 	<sjis>
 		じゃあ、行こうか<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Okay, let's go then.<end_line>
 	</ascii>
 </dialogue>
@@ -1680,7 +1805,7 @@
 	<sjis>
 		了解デス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Understood.<end_line>
 	</ascii>
 </dialogue>
@@ -1692,7 +1817,7 @@
 	<sjis>
 		薬をもらいに駅まで行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's meet Zakk at the station!<end_line>
 	</ascii>
 </dialogue>
@@ -1706,7 +1831,7 @@
 		何があるかわからんからのう<end_line>
 		気を抜くなよ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It's not over until<end_line>
 		Murno has the medicine.<end_line>
 		Don't lose focus.<end_line>
@@ -1720,7 +1845,7 @@
 	<sjis>
 		たしかにそうだね<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Right.<end_line>
 	</ascii>
 </dialogue>
@@ -1733,7 +1858,7 @@
 		仏作って魂入れず、と言っての<end_line>
 		最後の仕上げを欠いては<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There's a saying,<end_line>
 		"to plow but not to plant"<three_dots><end_line>
 	</ascii>
@@ -1746,7 +1871,7 @@
 	<sjis>
 		ホトケ？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Plant?<end_line>
 	</ascii>
 </dialogue>
@@ -1756,18 +1881,21 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			作ってもらうのは薬だろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			作ってもらうのは薬でしょ？<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Aren't we making medicine?<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			作ってもらうのは薬でしょ？<end_line>
+		</sjis>
+    <ascii>
+		Aren't we making medicine?<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1777,7 +1905,7 @@
 	<sjis>
 		ええい、そういう事ではなく<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		No, that's not what I meant<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -1787,18 +1915,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="surprised" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			そんな事より薬をもらいに行こうぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そんな事より薬をもらいに行こ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Forget it, let's go!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そんな事より薬をもらいに行こ！<end_line>
+		</sjis>
+    <ascii>
+		Forget it, let's go!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1808,7 +1939,7 @@
 	<sjis>
 		薬をもらいに駅まで行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's meet Zakk at the station!<end_line>
 	</ascii>
 </dialogue>
@@ -1822,7 +1953,7 @@
 		来ると思っているのか？<end_line>
 		クズ男たちの仲間だぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Think he's really going<end_line>
 		to make it for us?<end_line>
 		He's friends with that scum.<end_line>
@@ -1834,21 +1965,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			来るよ、絶対！<end_line>
 			オレはあいつを信じてる<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			来るよ、絶対！<end_line>
-			わたしはあの子を信じてる<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		He will, I'm sure!<end_line>
 		I believe in him.<end_line>
 	</ascii>s
+</male>
+  <female>
+    <sjis>
+			来るよ、絶対！<end_line>
+			わたしはあの子を信じてる<end_line>
+		</sjis>
+    <ascii>
+		He will, I'm sure!<end_line>
+		I believe in him.<end_line>
+	</ascii>s
+</female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1860,7 +1995,7 @@
 		やめろ<three_dots><end_line>
 		寒気がする<three_dots>！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Don't say that with<end_line>
 		such a straight face<three_dots><end_line>
 		Ugh<three_dots>!<end_line>
@@ -1872,21 +2007,25 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			行こうぜ！<end_line>
 			オレたちの友情をたしかめに！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			行こう！<end_line>
-			わたしたちの友情をたしかめに！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Let's go!<end_line>
 		This'll be proof for our friendship!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			行こう！<end_line>
+			わたしたちの友情をたしかめに！<end_line>
+		</sjis>
+    <ascii>
+		Let's go!<end_line>
+		This'll be proof for our friendship!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1897,7 +2036,7 @@
 		キ、キサマ<three_dots><end_line>
 		わざとやっているな<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Urgh<three_dots><end_line>
 		You must be doing this on purpose<three_dots><end_line>
 	</ascii>
@@ -1909,7 +2048,7 @@
 	<sjis>
 		薬をもらいに駅まで行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's meet Zakk at the station!<end_line>
 	</ascii>
 </dialogue>
@@ -1922,7 +2061,7 @@
 		無事に薬を作って<end_line>
 		やってくるでしょうか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I wonder if he'll be okay<three_dots><end_line>
 		Will he be able to<end_line>
 		make the medicine?<end_line>
@@ -1936,7 +2075,7 @@
 		<partner>さあ<end_line>
 		ちょっと心配しすぎじゃないの？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<partner>, don't you think<end_line>
 		you're worrying too much?<end_line>
 	</ascii>
@@ -1950,7 +2089,7 @@
 		また橋から落ちて<end_line>
 		大切なキッカの実を<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		What if he fell off<end_line>
 		the bridge again,<end_line>
 		then our Kicca fruit would be<three_dots><end_line>
@@ -1965,7 +2104,7 @@
 		とは言い切れないところが<three_dots><end_line>
 		とにかく駅に行こう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's impossible!<end_line>
 		I hope<three_dots><end_line>
 		Anyways, to the station!<end_line>
@@ -1977,21 +2116,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			レミィのヤツ<three_dots><end_line>
 			絶対、薬を受け取らせてやる！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レミィったら<three_dots><end_line>
-			絶対、薬を受け取らせてやるんだから！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		That Lemmy<three_dots><end_line>
 		I'll make him take the medicine!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			レミィったら<three_dots><end_line>
+			絶対、薬を受け取らせてやるんだから！<end_line>
+		</sjis>
+    <ascii>
+		That Lemmy<three_dots><end_line>
+		I'll make him take the medicine!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -2003,7 +2146,7 @@
 		戦闘能力ニ　大キナ差ガ<end_line>
 		アルヨウデス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		There Is A Large <end_line>
 		Difference In Strength<end_line>
 		Between You And Him.<end_line>
@@ -2017,7 +2160,7 @@
 	<sjis>
 		えっと、それってつまり？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Umm, meaning what?<end_line>
 	</ascii>
 </dialogue>
@@ -2030,7 +2173,7 @@
 		今ノアナタデハ　彼ニ勝利スルノハ<end_line>
 		困難ダ　トイウコトデス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It Would Be Difficult For You<end_line>
 		To Force Him As You Are Now.<end_line>
 	</ascii>
@@ -2041,18 +2184,21 @@
 	<portrait_l entry="player" eye="decided" mouth="stressed">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			お前まで、そんな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あなたまで、そんな<three_dots><end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Even you<three_dots><end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			あなたまで、そんな<three_dots><end_line>
+		</sjis>
+    <ascii>
+		Even you<three_dots><end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -2064,7 +2210,7 @@
 		協力スレバ　勝利デキナイ相手デハ<end_line>
 		アリマセン<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		However, Together,<end_line>
 		There Is No Enemy We<end_line>
 		Cannot Defeat.<end_line>
@@ -2076,24 +2222,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そういうことか<three_dots><end_line>
 			わかったよ<end_line>
 			行くぞ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そういうことね<three_dots><end_line>
-			わかったよ<end_line>
-			行くよ、<partner>！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		So that's what you meant<three_dots><end_line>
 		Okay.<end_line>
 		Let's do it, <partner>!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そういうことね<three_dots><end_line>
+			わかったよ<end_line>
+			行くよ、<partner>！<end_line>
+		</sjis>
+    <ascii>
+		So that's what you meant<three_dots><end_line>
+		Okay.<end_line>
+		Let's do it, <partner>!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2101,21 +2252,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			レミィのヤツ<three_dots><end_line>
 			絶対、薬を受け取らせてやる！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レミィったら<three_dots><end_line>
-			絶対、薬を受け取らせてやるんだから！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		That Lemmy<three_dots><end_line>
 		I'll make him take the medicine!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			レミィったら<three_dots><end_line>
+			絶対、薬を受け取らせてやるんだから！<end_line>
+		</sjis>
+    <ascii>
+		That Lemmy<three_dots><end_line>
+		I'll make him take the medicine!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2127,7 +2282,7 @@
 		そんなに熱くなっては<end_line>
 		勝てる勝負にも勝てんぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Calm down.<end_line>
 		Anger will distract you from<end_line>
 		what you need to do.<end_line>
@@ -2141,7 +2296,7 @@
 	<sjis>
 		うっ<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ugh<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2155,7 +2310,7 @@
 		かなりの使い手のようじゃ！<end_line>
 		今のおぬしでは勝てぬかもしれん<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Also, he is quite the<end_line>
 		formidable opponent!<end_line>
 		You may not be able to win.<end_line>
@@ -2167,21 +2322,25 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだと！<end_line>
 			お前まで、そんな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ！<end_line>
-			あなたまで、そんな<three_dots><end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		What!?<end_line>
 		Even you<three_dots><end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ！<end_line>
+			あなたまで、そんな<three_dots><end_line>
+		</sjis>
+    <ascii>
+		What!?<end_line>
+		Even you<three_dots><end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2192,7 +2351,7 @@
 		案ずるな<end_line>
 		おぬしにはワガハイがおる<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Have no fear.<end_line>
 		I am here to support you.<end_line>
 	</ascii>
@@ -2206,7 +2365,7 @@
 		おぬしとワガハイで力を合わせれば<end_line>
 		勝つこともできようぞ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		With our combined strength,<end_line>
 		we can win!<end_line>
 	</ascii>
@@ -2217,24 +2376,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			そういうことか<three_dots><end_line>
 			わかったよ<end_line>
 			行くぞ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そういうことね<three_dots><end_line>
-			わかったよ<end_line>
-			行くよ、<partner>！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		So that's what you meant<three_dots><end_line>
 		Okay.<end_line>
 		Let's do it, <partner>!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そういうことね<three_dots><end_line>
+			わかったよ<end_line>
+			行くよ、<partner>！<end_line>
+		</sjis>
+    <ascii>
+		So that's what you meant<three_dots><end_line>
+		Okay.<end_line>
+		Let's do it, <partner>!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2242,21 +2406,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			レミィのヤツ<three_dots><end_line>
 			絶対、薬を受け取らせてやる！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レミィったら<three_dots><end_line>
-			絶対、薬を受け取らせてやるんだから！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		That Lemmy<three_dots><end_line>
 		I'll make him take the medicine!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			レミィったら<three_dots><end_line>
+			絶対、薬を受け取らせてやるんだから！<end_line>
+		</sjis>
+    <ascii>
+		That Lemmy<three_dots><end_line>
+		I'll make him take the medicine!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2268,7 +2436,7 @@
 		あいつに勝てるとでも<end_line>
 		考えているのか？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots>Do you<end_line>
 		really think you<end_line>
 		can beat him?<end_line>
@@ -2280,21 +2448,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			勝てるかどうかじゃない<end_line>
 			絶対に勝つんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			勝てるかどうかじゃないよ<end_line>
-			絶対に勝つんだから！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		It's not a question of can or can't.<end_line>
 		I will!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			勝てるかどうかじゃないよ<end_line>
+			絶対に勝つんだから！<end_line>
+		</sjis>
+    <ascii>
+		It's not a question of can or can't.<end_line>
+		I will!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2305,7 +2477,7 @@
 		ふっ<three_dots>、面白い<three_dots><end_line>
 		だがキサマが勝てるかな？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hm<three_dots> Interesting<three_dots><end_line>
 		You? Win against him?<end_line>
 	</ascii>
@@ -2316,18 +2488,21 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			それ、どういうことだよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			それ、どういうこと！？<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		What's that supposed to mean!?<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			それ、どういうこと！？<end_line>
+		</sjis>
+    <ascii>
+		What's that supposed to mean!?<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2338,7 +2513,7 @@
 		私の手にかかれば<end_line>
 		キサマの出番などないぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		With my help, I'll end it<end_line>
 		before you can even move.<end_line>
 	</ascii>
@@ -2348,21 +2523,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			レミィのヤツ<three_dots><end_line>
 			絶対、薬を受け取らせてやる！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			レミィったら<three_dots><end_line>
-			絶対、薬を受け取らせてやるんだから！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		That Lemmy<three_dots><end_line>
 		I'll make him take the medicine!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			レミィったら<three_dots><end_line>
+			絶対、薬を受け取らせてやるんだから！<end_line>
+		</sjis>
+    <ascii>
+		That Lemmy<three_dots><end_line>
+		I'll make him take the medicine!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2372,7 +2551,7 @@
 		そうですわ！<end_line>
 		あんな態度、絶対許せません！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Agreed!<end_line>
 		He can't treat us like that!<end_line>
 	</ascii>
@@ -2386,7 +2565,7 @@
 		一度、イタイ目にあった方が<end_line>
 		いいと思いますわ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Someone as rude as him<end_line>
 		deserves to be punished<end_line>
 		at least once!<end_line>
@@ -2401,7 +2580,7 @@
 		すっごい気合い入ってるけど<end_line>
 		相手は一応病人なんだし<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Ummm<three_dots><end_line>
 		I appreciate the energy,<end_line>
 		but he's sick, you know<three_dots><end_line>
@@ -2416,7 +2595,7 @@
 		でもザックさんのためにも<end_line>
 		やっつけてあげましょう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		I know that.<end_line>
 		But we must defeat him,<end_line>
 		for Zakk's sake too!<end_line>
@@ -2431,7 +2610,7 @@
 		あこがれの人だから<three_dots><end_line>
 		あれ<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		But Zakk looks<end_line>
 		up to Lemmy, so<three_dots><end_line>
 		Huh<three_dots>?<end_line>
@@ -2445,7 +2624,7 @@
 		なんかフクザツな感じに<end_line>
 		なってるような<three_dots>？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		This is getting<end_line>
 		really complicated<three_dots><end_line>
 	</ascii>
@@ -2458,7 +2637,7 @@
 	<sjis>
 		よし、ミューノに薬を届けよう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Okay, let's deliver this to Murno!<end_line>
 	</ascii>
 </dialogue>
@@ -2472,7 +2651,7 @@
 		予想以上ニ　時間ガカカッテイマス<end_line>
 		急ギマショウ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		It Took Longer To Acquire<end_line>
 		The Medicine Than<end_line>
 		I Had Expected.<end_line>
@@ -2484,21 +2663,27 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			たしかにミューノの熱は<end_line>
 			心配だよな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+		Yeah, I hope her fever<end_line>
+		has not gotten worse.<end_line>
+	
+</ascii>
+  </male>
+  <female>
+    <sjis>
 			たしかにミューノの熱は<end_line>
 			心配だよね<end_line>
 		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Yeah, I hope her fever<end_line>
 		has not gotten worse.<end_line>
-	</screen>
+	
+</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -2508,7 +2693,7 @@
 	<sjis>
 		親方モ　デス<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Master Too.<end_line>
 	</ascii>
 </dialogue>
@@ -2518,18 +2703,21 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そこは信用しろよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そこは信用しようよ<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Have some faith in her!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そこは信用しようよ<end_line>
+		</sjis>
+    <ascii>
+		Have some faith in her!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2539,7 +2727,7 @@
 	<sjis>
 		よし、ミューノに薬を届けよう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Okay, let's deliver this to Murno!<end_line>
 	</ascii>
 </dialogue>
@@ -2551,7 +2739,7 @@
 	<sjis>
 		その前に落ち着くのじゃ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Before that, calm down.<end_line>
 	</ascii>
 </dialogue>
@@ -2561,21 +2749,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ！<end_line>
 			置いてくぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ！<end_line>
-			置いてくわよ<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Come on!<end_line>
 		I'll leave you behind.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ！<end_line>
+			置いてくわよ<end_line>
+		</sjis>
+    <ascii>
+		Come on!<end_line>
+		I'll leave you behind.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2586,7 +2778,7 @@
 		急がば回れ、と言っての<end_line>
 		急いでおる時こそゆっくり安全に<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Slow and steady wins the race.<end_line>
 		One can never be too careful<three_dots><end_line>
 	</ascii>
@@ -2599,7 +2791,7 @@
 	<sjis>
 		ん？<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Hm?<end_line>
 	</ascii>
 </dialogue>
@@ -2609,25 +2801,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			急ぐ時は回るのか？<end_line>
 			なんだそれ？<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Slow and steady?<end_line>
 			What's that?<end_line>
 		</ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			急ぐ時は回るの？<end_line>
 			ヘンなの<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Slow and steady?<end_line>
 			How strange.<end_line>
 		</ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -2637,7 +2829,7 @@
 	<sjis>
 		そうではなくて<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's not it<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2650,7 +2842,7 @@
 		まあよい、善は急げ、とも言うからの<end_line>
 		早くミューノに薬を届けるぞ<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Perhaps, strike while the iron<end_line>
 		is hot would be more appropriate.<end_line>
 	</ascii>
@@ -2661,18 +2853,21 @@
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			もう、なんなんだよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			もう、なんなのよ！<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Jeez, come on!<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			もう、なんなのよ！<end_line>
+		</sjis>
+    <ascii>
+		Jeez, come on!<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2694,7 +2889,7 @@
 	<sjis>
 		<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2704,25 +2899,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ちょっと待てよ！<end_line>
 			そんなに急ぐなよ<end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Hold on!<end_line>
 			No need to rush.<end_line>
 		</ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			ちょっと待ってよ！<end_line>
 			そんなに急がなくったって<three_dots><end_line>
 		</sjis>
-		<ascii>
+    <ascii>
 			Hold on!<end_line>
 			No need to rush<three_dots><end_line>
 		</ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2734,7 +2929,7 @@
 		私は急いでなどいない<three_dots><end_line>
 		キサマがおそいだけでは<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Wha<three_dots><end_line>
 		I'm not particularly fast<three_dots><end_line>
 		You're just slow<three_dots><end_line>
@@ -2746,18 +2941,21 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="special" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			はいはい、わかったよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			はいはい、わかりましたよ<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Okay, okay, I know.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			はいはい、わかりましたよ<end_line>
+		</sjis>
+    <ascii>
+		Okay, okay, I know.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -2767,7 +2965,7 @@
 	<sjis>
 		早くミューノのところへ行こう<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Let's go find Murno.<end_line>
 	</ascii>
 </dialogue>
@@ -2780,7 +2978,7 @@
 		ちっ<three_dots><end_line>
 		キサマがそうしたいなら仕方ない<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Tch<three_dots><end_line>
 		If you want to, then fine.<end_line>
 	</ascii>
@@ -2792,7 +2990,7 @@
 	<sjis>
 		よし、ミューノに薬を届けよう！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Okay, let's deliver this to Murno!<end_line>
 	</ascii>
 </dialogue>
@@ -2804,7 +3002,7 @@
 		ちょっと待ってください<end_line>
 		その薬の入れ物が<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Please wait a moment.<end_line>
 		The medicine's container<three_dots><end_line>
 	</ascii>
@@ -2814,18 +3012,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			入れ物がどうかしたのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			入れ物がどうかしたの？<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Container? What about it?<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			入れ物がどうかしたの？<end_line>
+		</sjis>
+    <ascii>
+		Container? What about it?<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2836,7 +3037,7 @@
 		もっとその、上品と言うか<end_line>
 		気品のある入れ物のほうが<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		We should use something more<end_line>
 		refined, more elegant.<end_line>
 		It's only fitting for Lady Murno<three_dots><end_line>
@@ -2847,21 +3048,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そんなこと言ってないで<end_line>
 			早く行こうぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そんなこと言ってないで<end_line>
-			早く行こうよ<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		<three_dots>We don't have time for that.<end_line>
 		Come on.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そんなこと言ってないで<end_line>
+			早く行こうよ<end_line>
+		</sjis>
+    <ascii>
+		<three_dots>We don't have time for that.<end_line>
+		Come on.<end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2870,7 +3075,7 @@
 	<sjis>
 		では、せめて花束をつけて<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Then at least a bouquet<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2883,7 +3088,7 @@
 		ミューノ様に似合う<end_line>
 		花束は<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Umm<three_dots><end_line>
 		Where could we find<end_line>
 		flowers that fit her<three_dots><end_line>
@@ -2894,18 +3099,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そんなことしてる場合かよ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そんなことしてる場合なの<three_dots><end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Seriously, this isn't the time<three_dots><end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			そんなことしてる場合なの<three_dots><end_line>
+		</sjis>
+    <ascii>
+		Seriously, this isn't the time<three_dots><end_line>
+	</ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -2916,7 +3124,7 @@
 		そんな場合じゃありませんわ<end_line>
 		急ぎますよ！<end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		That's right!<end_line>
 		Let us not waste time.<end_line>
 		Let's go!<end_line>
@@ -2929,7 +3137,7 @@
 	<sjis>
 		えーと<three_dots><end_line>
 	</sjis>
-	<ascii>
+  <ascii>
 		Umm<three_dots><end_line>
 	</ascii>
 </dialogue>
@@ -2938,16 +3146,19 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			うん、そうだな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん、そうだね<end_line>
-		</sjis>
-	</female>
-	<ascii>
+    <ascii>
 		Alright, whatever.<end_line>
 	</ascii>
+  </male>
+  <female>
+    <sjis>
+			うん、そうだね<end_line>
+		</sjis>
+    <ascii>
+		Alright, whatever.<end_line>
+	</ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 01/24989612_17d4fac.xml
+++ b/Translation/JE Scripts/Day 01/24989612_17d4fac.xml
@@ -43,17 +43,21 @@
       ああ、大丈夫<end_line>
       すぐもどるよ<end_line>
     </sjis>
+    <ascii>
+    Yeah, I'm fine.<end_line>
+    I'll be right up.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん、大丈夫<end_line>
       すぐもどるよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, I'm fine.<end_line>
     I'll be right up.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -101,17 +105,21 @@
       ああ、大丈夫<end_line>
       すぐもどるよ<end_line>
     </sjis>
+    <ascii>
+    Yeah, I'm fine.<end_line>
+    I'll be right up.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん、大丈夫<end_line>
       すぐもどるよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, I'm fine.<end_line>
     I'll be right up.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -187,15 +195,18 @@
     <sjis>
       どういうことだよ！<end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どういうこと！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -242,15 +253,19 @@
       ああ、大丈夫<end_line>
       すぐもどるよ<end_line>
     </sjis>
+    <ascii>
+    Yeah, I'm fine.<end_line>
+    I'll be right up.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん、大丈夫<end_line>
       すぐもどるよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, I'm fine.<end_line>
     I'll be right up.<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 01/24990556_17d535c.xml
+++ b/Translation/JE Scripts/Day 01/24990556_17d535c.xml
@@ -48,6 +48,11 @@
       聞いてたけど<end_line>
       わからなかったからさ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I was, but<three_dots><end_line>
+    I wasn't sure what you meant,<end_line>
+    so I just kept going<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -55,12 +60,12 @@
       聞いてたけど<end_line>
       わからなかったから<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I was, but<three_dots><end_line>
     I wasn't sure what you meant,<end_line>
     so I just kept going<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -87,15 +92,18 @@
     <sjis>
       なんだと！<end_line>
     </sjis>
+    <ascii>
+    What's that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -258,6 +266,10 @@
       オレには橋のちがいが<end_line>
       わからなかったからさ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I couldn't see any<end_line>
+    differences, so<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -265,11 +277,11 @@
       わたしにはちがいが<end_line>
       わからなかったから<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I couldn't see any<end_line>
     differences, so<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -296,6 +308,11 @@
       しり<three_dots>！？<end_line>
       オレのしりは青くないぞ！<end_line>
     </sjis>
+    <ascii>
+    Wha<three_dots>!?<end_line>
+    I'm green!?<end_line>
+    Where!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -303,12 +320,12 @@
       わたしのおしりは<end_line>
       青くなんかないわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wha<three_dots>!?<end_line>
     I'm green!?<end_line>
     Where!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -335,15 +352,18 @@
     <sjis>
       半人前っていうな！<end_line>
     </sjis>
+    <ascii>
+    I'm not an amateur!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       半人前っていわないでよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm not an amateur!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -384,15 +404,18 @@
     <sjis>
       なんだと！<end_line>
     </sjis>
+    <ascii>
+    No way I'm doing that!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No way I'm doing that!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -505,17 +528,21 @@
       おい<three_dots><end_line>
       どういうことだよ！？<end_line>
     </sjis>
+    <ascii>
+    Hey<three_dots><end_line>
+    What was that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ねぇ<three_dots><end_line>
       どういうこと！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey<three_dots><end_line>
     What was that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -540,6 +567,10 @@
       橋が落ちそうなの<end_line>
       気付いてたのか！？<end_line>
     </sjis>
+    <ascii>
+    You knew I was going to fall,<end_line>
+    didn't you!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -547,11 +578,11 @@
       橋が落ちそうなの気付いてて<end_line>
       だまってたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You knew I was going to fall,<end_line>
     didn't you!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -575,16 +606,19 @@
       だったらどうして<end_line>
       教えてくれないんだよ！？<end_line>
     </sjis>
+    <ascii>
+    So why didn't tell me!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんな<three_dots><end_line>
       なんで教えてくれないのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So why didn't tell me!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -610,6 +644,11 @@
       お前、オレのパートナーだってこと<end_line>
       忘れてんのか？<end_line>
     </sjis>
+    <ascii>
+    Huh!?<end_line>
+    We're supposed to be<end_line>
+    partners, remember?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -617,12 +656,12 @@
       あんた、わたしのパートナーに<end_line>
       なったこと忘れてるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh!?<end_line>
     We're supposed to be<end_line>
     partners, remember?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">

--- a/Translation/JE Scripts/Day 07/001_25360684_182f92c.xml
+++ b/Translation/JE Scripts/Day 07/001_25360684_182f92c.xml
@@ -3,21 +3,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			いよいよトラムとの勝負だ<end_line>
 			絶対に勝つぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いよいよトラムとの勝負だね<end_line>
-			絶対に勝つよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     It's time for our match with Tram.<end_line>
     I'm definitely going to win!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いよいよトラムとの勝負だね<end_line>
+			絶対に勝つよ！<end_line>
+		</sjis>
+    <ascii>
+    It's time for our match with Tram.<end_line>
+    I'm definitely going to win!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -39,7 +43,7 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、心配してくれるのか？<end_line>
 			ありがとう<end_line>
 			大丈夫だって！<end_line>
@@ -49,9 +53,9 @@
       Thanks.<end_line>
       I'll be fine!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			心配してくれるの？<end_line>
 			ありがとう<end_line>
 			大丈夫だよ！<end_line>
@@ -61,7 +65,7 @@
       Thanks.<end_line>
       I'll be fine!<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -179,18 +183,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="talk">
 	<portrait_r entry="partner" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			お前<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あなた<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あなた<three_dots><end_line>
+		</sjis>
+    <ascii>
+    You<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -228,7 +235,7 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、心配してくれるのか？<end_line>
 			ありがとう<end_line>
 			大丈夫だって！<end_line>
@@ -238,9 +245,9 @@
       Thanks.<end_line>
       I'll be fine!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			心配してくれるの？<end_line>
 			ありがとう<end_line>
 			大丈夫だよ！<end_line>
@@ -250,7 +257,7 @@
       Thanks.<end_line>
       I'll be fine!<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -394,21 +401,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよそれ？<end_line>
 			もしかして心配してくれるのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによそれ？<end_line>
-			もしかして心配してくれるの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What's that supposed to mean?<end_line>
     Are you worried about me?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによそれ？<end_line>
+			もしかして心配してくれるの？<end_line>
+		</sjis>
+    <ascii>
+    What's that supposed to mean?<end_line>
+    Are you worried about me?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -558,7 +569,7 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、心配してくれるのか？<end_line>
 			ありがとう<end_line>
 			大丈夫だって！<end_line>
@@ -568,9 +579,9 @@
       Thanks.<end_line>
       I'll be fine!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			心配してくれるの？<end_line>
 			ありがとう<end_line>
 			大丈夫だよ！<end_line>
@@ -580,7 +591,7 @@
       Thanks.<end_line>
       I'll be fine!<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -618,24 +629,29 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			てなわけで<end_line>
 			そろそろオレは行くけど<end_line>
 			<partner>はどうする？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そんなわけで<end_line>
-			そろそろわたしは行くけど<end_line>
-			<partner>はどうする？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Now then,<end_line>
     it's about time for me to go.<end_line>
     What will you do, <partner>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そんなわけで<end_line>
+			そろそろわたしは行くけど<end_line>
+			<partner>はどうする？<end_line>
+		</sjis>
+    <ascii>
+    Now then,<end_line>
+    it's about time for me to go.<end_line>
+    What will you do, <partner>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -669,18 +685,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			お前<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あなた<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あなた<three_dots><end_line>
+		</sjis>
+    <ascii>
+    You<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -703,18 +722,21 @@
 	<portrait_l entry="player" eye="sad" mouth="neutral">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			そういうことか<three_dots><end_line>
 			わかったよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Oh, that's what you meant<three_dots><end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そういうことね<three_dots><end_line>
 			わかったわよ<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Oh, that's what you meant<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 07/003_25362748_183013c.xml
+++ b/Translation/JE Scripts/Day 07/003_25362748_183013c.xml
@@ -29,6 +29,11 @@
       絶対勝ってみせるから<end_line>
       安心してな！<end_line>
     </sjis>
+    <ascii>
+    Don't look so worried.<end_line>
+    I'm going to win.<end_line>
+    Leave it to me!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -36,12 +41,12 @@
       絶対勝ってみせるから<end_line>
       まかせてよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't look so worried.<end_line>
     I'm going to win.<end_line>
     Leave it to me!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -254,15 +259,18 @@
     <sjis>
       おっちゃんも来るの？<end_line>
     </sjis>
+    <ascii>
+    You're coming too?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       おじさんも来るの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're coming too?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -542,6 +550,11 @@
       ヌシのいたところだな<end_line>
       わかった！<end_line>
     </sjis>
+    <ascii>
+    The Rekui Water Ruins<three_dots><end_line>
+    That's where your master was, right?<end_line>
+    Got it!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -549,10 +562,10 @@
       ヌシさまのいたところね<end_line>
       わかった！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The Rekui Water Ruins<three_dots><end_line>
     That's where your master was, right?<end_line>
     Got it!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 07/009_25365420_1830bac.xml
+++ b/Translation/JE Scripts/Day 07/009_25365420_1830bac.xml
@@ -74,6 +74,11 @@
       どうせオレが勝ったら<end_line>
       中を見せてもらえるんだし<end_line>
     </sjis>
+    <ascii>
+    Isn't it fine?<end_line>
+    I mean, once I win, I'm gonna<end_line>
+    have you show us around anyway.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -81,12 +86,12 @@
       どうせわたしが勝ったら<end_line>
       中を見せてくれるんでしょ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Isn't it fine?<end_line>
     I mean, once I win, I'm gonna<end_line>
     have you show us around anyway.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -249,17 +254,21 @@
       まかせとけ<end_line>
       絶対たおしてやる！<end_line>
     </sjis>
+    <ascii>
+    Leave it to me.<end_line>
+    I'm going to win!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       まかせといて<end_line>
       絶対やっつけちゃうから！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Leave it to me.<end_line>
     I'm going to win!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -374,15 +383,18 @@
     <sjis>
       心配すんなって<end_line>
     </sjis>
+    <ascii>
+    Don't worry.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       心配しないで<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't worry.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -473,15 +485,19 @@
       あ<three_dots><end_line>
       お、おう！<end_line>
     </sjis>
+    <ascii>
+    Ah<three_dots><end_line>
+    Y-yeah!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ<three_dots><end_line>
       う、うん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah<three_dots><end_line>
     Y-yeah!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 07/011_25368172_183166c.xml
+++ b/Translation/JE Scripts/Day 07/011_25368172_183166c.xml
@@ -8,6 +8,11 @@
       なんだよ？<end_line>
       今度は暑いなぁ<end_line>
     </sjis>
+    <ascii>
+    Woah<three_dots>!<end_line>
+    What the<three_dots>?<end_line>
+    It's so hot in here.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -15,12 +20,12 @@
       なによ？<end_line>
       今度は暑いなぁ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Woah<three_dots>!<end_line>
     What the<three_dots>?<end_line>
     It's so hot in here.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -133,17 +138,21 @@
       召喚獣が凶暴になるって<three_dots><end_line>
       <partner>は大丈夫か？<end_line>
     </sjis>
+    <ascii>
+    Summon Beasts going berserk<three_dots><end_line>
+    <partner>, are you okay?<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       召喚獣が凶暴になるって<three_dots><end_line>
       <partner>は大丈夫？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Summon Beasts going berserk<three_dots><end_line>
     <partner>, are you okay?<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -216,17 +225,21 @@
       この遺跡にいる召喚獣は<end_line>
       一体なにを守っているんだ？<end_line>
     </sjis>
+    <ascii>
+    What are the Summon Beasts<end_line>
+    here protecting?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       この遺跡にいる召喚獣って<end_line>
       一体なにを守ってるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What are the Summon Beasts<end_line>
     here protecting?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -249,15 +262,18 @@
     <sjis>
       わかってるよ<end_line>
     </sjis>
+    <ascii>
+    I know.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わかったわよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -281,17 +297,21 @@
       ちょっと待て！<end_line>
       なんでだよ！？<end_line>
     </sjis>
+    <ascii>
+    Hey, wait!<end_line>
+    What's with that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちょっと待って！<end_line>
       なによ、それ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, wait!<end_line>
     What's with that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -327,15 +347,18 @@
     <sjis>
       なんだと！<end_line>
     </sjis>
+    <ascii>
+    What was that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -373,6 +396,11 @@
       必ず裁きの間までたどりついて<end_line>
       絶対に勝ってみせるぜ！<end_line>
     </sjis>
+    <ascii>
+    Alright<three_dots><end_line>
+    I'll make it to the Room of<end_line>
+    Judgment on my own, and beat Tram!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -380,12 +408,12 @@
       必ず裁きの間までたどりついて<end_line>
       絶対に勝ってみせるから！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright<three_dots><end_line>
     I'll make it to the Room of<end_line>
     Judgment on my own, and beat Tram!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -424,17 +452,21 @@
       よし<three_dots>！<end_line>
       じゃ、オレたちも行こうぜ！<end_line>
     </sjis>
+    <ascii>
+    Alright<three_dots>!<end_line>
+    Let's get going!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よ～し！<end_line>
       じゃ、わたしたちも行こっ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright<three_dots>!<end_line>
     Let's get going!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Day 07/015_25370572_1831fcc.xml
+++ b/Translation/JE Scripts/Day 07/015_25370572_1831fcc.xml
@@ -95,7 +95,7 @@
   <ascii>
     Many things were decided by<end_line>
     the outcome of matches here.<end_line>
-  </ascii> 
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -184,21 +184,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<portrait_r entry="tram" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			侵入者は負けたら<end_line>
 			溶岩に落とされてたのか<three_dots>？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			侵入者は負けたら<end_line>
-			溶岩に落とされていたの<three_dots>？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Intruders get thrown<end_line>
     into the lava<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			侵入者は負けたら<end_line>
+			溶岩に落とされていたの<three_dots>？<end_line>
+		</sjis>
+    <ascii>
+    Intruders get thrown<end_line>
+    into the lava<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -231,21 +235,25 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			なんだと！？<end_line>
 			オレはコワがってなんかいない！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ！？<end_line>
-			わたしはコワがってなんかないわよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What!?<end_line>
     I'm not scared!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ！？<end_line>
+			わたしはコワがってなんかないわよ！<end_line>
+		</sjis>
+    <ascii>
+    What!?<end_line>
+    I'm not scared!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -314,21 +322,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			そっか<three_dots><end_line>
 			ごめん<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだよね<three_dots><end_line>
-			ごめん<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You're right<three_dots><end_line>
     Sorry.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだよね<three_dots><end_line>
+			ごめん<end_line>
+		</sjis>
+    <ascii>
+    You're right<three_dots><end_line>
+    Sorry.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">

--- a/Translation/JE Scripts/Day 07/017_25374220_1832e0c.xml
+++ b/Translation/JE Scripts/Day 07/017_25374220_1832e0c.xml
@@ -17,15 +17,18 @@
     <sjis>
       やったぞ、ミューノ！<end_line>
     </sjis>
+    <ascii>
+    I did it, Murno!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       やったよ、ミューノ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I did it, Murno!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -300,6 +303,11 @@
       まさか、アニスといっしょにいた<end_line>
       召喚獣のことじゃ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Magdrad<three_dots><end_line>
+    Could that be the Summon Beast<end_line>
+    that was with Anise<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -307,12 +315,12 @@
       まさか、アニスといっしょにいた<end_line>
       召喚獣のこと？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Magdrad<three_dots><end_line>
     Could that be the Summon Beast<end_line>
     that was with Anise<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -366,16 +374,19 @@
       それをあの女が<end_line>
       持ち出してたのか？<end_line>
     </sjis>
+    <ascii>
+    And Anise removed them?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       それをあの人が<end_line>
       持ち出したの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And Anise removed them?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -480,15 +491,18 @@
     <sjis>
       なんだと！？<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -591,17 +605,21 @@
       なんだと！？<end_line>
       そんなこと、あるわけないだろ！<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+    As if!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！？<end_line>
       そんなこと、あるわけないでしょ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
     As if!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -707,14 +725,17 @@
       では、気をつけてな<end_line>
       ボウズ！<end_line>
     </sjis>
+    <ascii>
+    Well then, be careful kid!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       では、気をつけてな<end_line>
       じょうちゃん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well then, be careful kid!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 07/019_25377356_1833a4c.xml
+++ b/Translation/JE Scripts/Day 07/019_25377356_1833a4c.xml
@@ -20,17 +20,21 @@
       迷子になんかなるもんか<end_line>
       な、<partner><end_line>
     </sjis>
+    <ascii>
+    We never get lost,<end_line>
+    right, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       迷子になんかならないわよ<end_line>
       ね、<partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We never get lost,<end_line>
     right, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -93,17 +97,21 @@
       ほーら！<end_line>
       <three_dots>ってオイ！？<end_line>
     </sjis>
+    <ascii>
+    See!<end_line>
+    <three_dots>Wait, what!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ほらね！<end_line>
       <three_dots>ってなんで！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     See!<end_line>
     <three_dots>Wait, what!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -145,15 +153,18 @@
     <sjis>
       何だ！？<end_line>
     </sjis>
+    <ascii>
+    Huh!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       何！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -331,17 +342,21 @@
       それほどまでに<end_line>
       あいつのことを<three_dots><end_line>
     </sjis>
+    <ascii>
+    So Magdrad trusts<end_line>
+    Anise that much<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       それほどまでに<end_line>
       あの人のことを<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So Magdrad trusts<end_line>
     Anise that much<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -609,15 +624,18 @@
     <sjis>
       そうだったのか<three_dots><end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そうだったの<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 07/021_25380268_18345ac.xml
+++ b/Translation/JE Scripts/Day 07/021_25380268_18345ac.xml
@@ -84,17 +84,21 @@
       マグドラドだ<three_dots><end_line>
       やっぱ、スゲェな<three_dots><end_line>
     </sjis>
+    <ascii>
+    So this is Magdrad<three_dots><end_line>
+    Amazing<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       マグドラドだよね<three_dots><end_line>
       やっぱり、スゴイ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So this is Magdrad<three_dots><end_line>
     Amazing<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -208,17 +212,21 @@
       なんだと！？<end_line>
       そんなワケあるか！<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+    Of course not!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！？<end_line>
       そんなことないわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
     Of course not!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Day 07/022_25382156_1834d0c.xml
+++ b/Translation/JE Scripts/Day 07/022_25382156_1834d0c.xml
@@ -90,15 +90,18 @@
     <sjis>
       どういうことだよ？<end_line>
     </sjis>
+    <ascii>
+    Hm?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どういうこと？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hm?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Day 07/024_25385724_1835afc.xml
+++ b/Translation/JE Scripts/Day 07/024_25385724_1835afc.xml
@@ -86,15 +86,18 @@
     <sjis>
       あの、オレたちは<three_dots><end_line>
     </sjis>
+    <ascii>
+    Um, what should we<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あの、わたしたちは<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Um, what should we<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -152,17 +155,21 @@
       そうだな！<end_line>
       行こう、ミューノ！<end_line>
     </sjis>
+    <ascii>
+    You're right!<end_line>
+    Let's go, Murno!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そうだね！<end_line>
       行こう、ミューノ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're right!<end_line>
     Let's go, Murno!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -988,15 +995,18 @@
     <sjis>
       わかった！<end_line>
     </sjis>
+    <ascii>
+    Okay!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わかったわ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1263,6 +1273,11 @@
       このまま逃げるなんてできるかよ！<end_line>
       オレにも何か手伝わせてくれよ<end_line>
     </sjis>
+    <ascii>
+    I'm a Craftknight!<end_line>
+    I can't run away like this!<end_line>
+    Let me help with something!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1270,12 +1285,12 @@
       このまま逃げるなんてできないわ！<end_line>
       わたしにも何か手伝わせて<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm a Craftknight!<end_line>
     I can't run away like this!<end_line>
     Let me help with something!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -1365,6 +1380,11 @@
       オレにだって何かできることが<end_line>
       あるはずだろ？<end_line>
     </sjis>
+    <ascii>
+    No!<end_line>
+    There's got to be something <end_line>
+    even we can do, right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1372,12 +1392,12 @@
       わたしにだって何かできることが<end_line>
       あるはずでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No!<end_line>
     There's got to be something <end_line>
     even we can do, right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -1431,17 +1451,21 @@
       牢屋に行けばいいんだな<end_line>
       わかった！<end_line>
     </sjis>
+    <ascii>
+    To the prison then.<end_line>
+    Got it!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       牢屋に行けばいいのね<end_line>
       わかったわ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     To the prison then.<end_line>
     Got it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 07/026_25389484_18369ac.xml
+++ b/Translation/JE Scripts/Day 07/026_25389484_18369ac.xml
@@ -63,15 +63,18 @@
     <sjis>
       なんだよそれ！<end_line>
     </sjis>
+    <ascii>
+    How could they!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによそれ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How could they!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -243,15 +246,18 @@
     <sjis>
       カギはどこだよ！？<end_line>
     </sjis>
+    <ascii>
+    Is there a key!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       カギはどこにあるの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Is there a key!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -274,13 +280,16 @@
     <sjis>
       わかったよ<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Okay!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わかったわよ<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 07/027_25391036_1836fbc.xml
+++ b/Translation/JE Scripts/Day 07/027_25391036_1836fbc.xml
@@ -344,6 +344,11 @@
       急ごう！<end_line>
       お前も来い<end_line>
     </sjis>
+    <ascii>
+    We don't have time to argue.<end_line>
+    Let's hurry!<end_line>
+    You're coming too.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -351,12 +356,12 @@
       急ぐわよ！<end_line>
       あなたも来てよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We don't have time to argue.<end_line>
     Let's hurry!<end_line>
     You're coming too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 07/028_25393228_183784c.xml
+++ b/Translation/JE Scripts/Day 07/028_25393228_183784c.xml
@@ -15,15 +15,18 @@
     <sjis>
       アニスをつれてきたぞ！<end_line>
     </sjis>
+    <ascii>
+    I brought Anise!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       アニスをつれてきたよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I brought Anise!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -45,15 +48,18 @@
     <sjis>
       今度は何だ！？<end_line>
     </sjis>
+    <ascii>
+    What was that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今度は何！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -457,15 +463,18 @@
     <sjis>
       そう<three_dots>なのか<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Is<three_dots>that so<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そう<three_dots>なの<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Is<three_dots>that so<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Translation/JE Scripts/Day 07/029_25396796_183863c.xml
+++ b/Translation/JE Scripts/Day 07/029_25396796_183863c.xml
@@ -123,17 +123,21 @@
       あいつ、逃げ出したのか！？<end_line>
       追いかけないと！<end_line>
     </sjis>
+    <ascii>
+    She ran away!?<end_line>
+    We have to find her!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あいつ、逃げ出したの！？<end_line>
       追いかけなきゃ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     She ran away!?<end_line>
     We have to find her!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Day 07/030_25398700_1838dac.xml
+++ b/Translation/JE Scripts/Day 07/030_25398700_1838dac.xml
@@ -1,4 +1,3 @@
-#Starts at line 77
 <dialogue>
   <info box="nobox">
   <sjis>
@@ -312,17 +311,21 @@
       とにかくそいつを元に戻せば<end_line>
       全て元通りになるのか？<end_line>
     </sjis>
+    <ascii>
+    So if we put it back,<end_line>
+    will everything return to normal?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       とにかくそいつを元に戻せば<end_line>
       全て元通りになるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So if we put it back,<end_line>
     will everything return to normal?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -361,17 +364,21 @@
       え？<end_line>
       帰ってもいいのか？<end_line>
     </sjis>
+    <ascii>
+    Eh?<end_line>
+    We can leave?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え？<end_line>
       帰ってもいいの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh?<end_line>
     We can leave?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 07/032_25401644_183992c.xml
+++ b/Translation/JE Scripts/Day 07/032_25401644_183992c.xml
@@ -20,17 +20,21 @@
       なんだ、コレ？<end_line>
       ウロコ？<end_line>
     </sjis>
+    <ascii>
+    What's this?<end_line>
+    A scale?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに、コレ？<end_line>
       ウロコ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's this?<end_line>
     A scale?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -55,6 +59,11 @@
       ありがとう<end_line>
       大事にするよ！<end_line>
     </sjis>
+    <ascii>
+    A charm<three_dots><end_line>
+    Thank you.<end_line>
+    I'll take good care of it!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -62,12 +71,12 @@
       ありがとう<end_line>
       大事にするね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     A charm<three_dots><end_line>
     Thank you.<end_line>
     I'll take good care of it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -91,17 +100,21 @@
       おう！<end_line>
       じゃ、元気で！<end_line>
     </sjis>
+    <ascii>
+    Sure!<end_line>
+    Stay healthy!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん！<end_line>
       じゃ、元気で！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sure!<end_line>
     Stay healthy!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -127,10 +140,6 @@
       Farewell!<end_line>
     </ascii>
   </female>
-  <ascii>
-    You too, old man<three_dots><end_line>
-    Goodbye!<end_line>
-  </ascii>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -307,17 +316,21 @@
       おっちゃん<end_line>
       もしかして、泣いてるのか？<end_line>
     </sjis>
+    <ascii>
+    Wait,<end_line>
+    are you<three_dots> crying?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       おじさん<end_line>
       もしかして、泣いてるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wait,<end_line>
     are you<three_dots> crying?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -343,17 +356,21 @@
       わかったよ！<end_line>
       じゃあ！<end_line>
     </sjis>
+    <ascii>
+    I know!<end_line>
+    Bye!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わかったわよ！<end_line>
       じゃあね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know!<end_line>
     Bye!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -387,15 +404,18 @@
     <sjis>
       やっぱり、息子さんのことを<three_dots><end_line>
     </sjis>
+    <ascii>
+    Like I thought, you're still<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       やっぱり、娘さんのことを<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Like I thought, you're still<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Translation/JE Scripts/Day 07/034_25403468_183a04c.xml
+++ b/Translation/JE Scripts/Day 07/034_25403468_183a04c.xml
@@ -52,6 +52,11 @@
       ミューノの村じゃないのか？<end_line>
       魔石を戻しに行くんだろ？<end_line>
     </sjis>
+    <ascii>
+    Where<three_dots><end_line>
+    Murno's village, right?<end_line>
+    Aren't we returning the Demon Stone?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -59,12 +64,12 @@
       ミューノの村じゃないの？<end_line>
       魔石を戻しに行くんでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Where<three_dots><end_line>
     Murno's village, right?<end_line>
     Aren't we returning the Demon Stone?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -107,6 +112,11 @@
       ミューノの村じゃないのか？<end_line>
       魔石を戻しに行くんだろ？<end_line>
     </sjis>
+    <ascii>
+    Where<three_dots><end_line>
+    Murno's village, right?<end_line>
+    Aren't we returning the Demon Stone?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -114,12 +124,12 @@
       ミューノの村じゃないの？<end_line>
       魔石を戻しに行くんでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Where<three_dots><end_line>
     Murno's village, right?<end_line>
     Aren't we returning the Demon Stone?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -162,6 +172,11 @@
       ミューノの村じゃないのか？<end_line>
       魔石を戻しに行くんだろ？<end_line>
     </sjis>
+    <ascii>
+    What<three_dots><end_line>
+    Murno's village, right?<end_line>
+    Aren't we returning the Demon Stone?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -169,12 +184,12 @@
       ミューノの村じゃないの？<end_line>
       魔石を戻しに行くんでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What<three_dots><end_line>
     Murno's village, right?<end_line>
     Aren't we returning the Demon Stone?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -215,6 +230,11 @@
       ミューノの村じゃないのか？<end_line>
       魔石を戻しに行くんだろ？<end_line>
     </sjis>
+    <ascii>
+    What<three_dots><end_line>
+    Murno's village, right?<end_line>
+    Aren't we returning the Demon Stone?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -222,12 +242,12 @@
       ミューノの村じゃないの？<end_line>
       魔石を戻しに行くんでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What<three_dots><end_line>
     Murno's village, right?<end_line>
     Aren't we returning the Demon Stone?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -365,15 +385,18 @@
     <sjis>
       オレ、なんかヘンなこと言った？<end_line>
     </sjis>
+    <ascii>
+    Did I say something strange?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたし、なんかヘンなこと言った？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Did I say something strange?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -424,15 +447,18 @@
     <sjis>
       そんなにほめるなよ～<end_line>
     </sjis>
+    <ascii>
+    Don't praise me so much~<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなにほめないでよ～<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't praise me so much~<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -481,15 +507,18 @@
     <sjis>
       そんなにほめるなよ～<end_line>
     </sjis>
+    <ascii>
+    Don't praise me so much~<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなにほめないでよ～<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't praise me so much~<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -538,15 +567,18 @@
     <sjis>
       そんなにほめるなよ～<end_line>
     </sjis>
+    <ascii>
+    Don't praise me so much~<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなにほめないでよ～<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't praise me so much~<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -595,15 +627,18 @@
     <sjis>
       そんなにほめるなよ～<end_line>
     </sjis>
+    <ascii>
+    Don't praise me so much~<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなにほめないでよ～<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't praise me so much~<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Translation/JE Scripts/Day 07/038_25412396_183c32c.xml
+++ b/Translation/JE Scripts/Day 07/038_25412396_183c32c.xml
@@ -195,6 +195,10 @@
       この人たちの言ってること<end_line>
       信じてるんですか？<end_line>
     </sjis>
+    <ascii>
+    Do all of you seriously believe<end_line>
+    what <player_nickname> just said?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -202,11 +206,11 @@
       この人たちの言ってること<end_line>
       信じてるんですか？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Do all of you seriously believe<end_line>
     what <player_nickname> just said?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -218,6 +222,10 @@
       オレたちがウソついてるって<end_line>
       言うのかよ！<end_line>
     </sjis>
+    <ascii>
+    What was that!?<end_line>
+    Are you calling me a liar!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -225,11 +233,11 @@
       わたしたちがウソついてるって<end_line>
       言うの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that!?<end_line>
     Are you calling me a liar!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -414,6 +422,10 @@
       オレたちは絶対<end_line>
       ウソなんかついてない！<end_line>
     </sjis>
+    <ascii>
+    But<three_dots>!<end_line>
+    I'm not lying!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -421,11 +433,11 @@
       わたしたちは絶対<end_line>
       ウソなんかついてないわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     But<three_dots>!<end_line>
     I'm not lying!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 07/039_25415004_183cd5c.xml
+++ b/Translation/JE Scripts/Day 07/039_25415004_183cd5c.xml
@@ -90,15 +90,18 @@
     <sjis>
       お前、何を<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    What are you<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんた、何を<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What are you<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -211,15 +214,18 @@
     <sjis>
       で、どうしたらいいんだろ？<end_line>
     </sjis>
+    <ascii>
+    So, what should we do?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       で、どうしたらいいの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So, what should we do?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 07/041_25416956_183d4fc.xml
+++ b/Translation/JE Scripts/Day 07/041_25416956_183d4fc.xml
@@ -70,17 +70,21 @@
       ごめん<end_line>
       心配かけたみたいで<end_line>
     </sjis>
+    <ascii>
+    Sorry.<end_line>
+    We've made you worry.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ごめんね<end_line>
       心配かけちゃって<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sorry.<end_line>
     We've made you worry.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 07/043_25418508_183db0c.xml
+++ b/Translation/JE Scripts/Day 07/043_25418508_183db0c.xml
@@ -161,13 +161,16 @@
     <sjis>
       <three_dots>さっぱりわからん<end_line>
     </sjis>
+    <ascii>
+    <three_dots>I can't tell at all<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>全然わかんないよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots>I can't tell at all<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 07/046_25420316_183e21c.xml
+++ b/Translation/JE Scripts/Day 07/046_25420316_183e21c.xml
@@ -26,24 +26,29 @@
 	<portrait_l entry="player" eye="sad" mouth="neutral">
 	<portrait_r entry="murno" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			うん<three_dots><end_line>
 			オレも何かしないとって思うんだけど<end_line>
 			どうしていいのかわからなくて<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん<three_dots><end_line>
-			わたしも何かしないとって思うんだけど<end_line>
-			どうしていいのかわからなくて<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah<three_dots><end_line>
     I know I have to do something,<end_line>
     but I don't know what<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん<three_dots><end_line>
+			わたしも何かしないとって思うんだけど<end_line>
+			どうしていいのかわからなくて<end_line>
+		</sjis>
+    <ascii>
+    Yeah<three_dots><end_line>
+    I know I have to do something,<end_line>
+    but I don't know what<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -63,24 +68,29 @@
 	<portrait_l entry="player" eye="serious" mouth="serious">
 	<portrait_r entry="murno" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			たしかにルイーズ村では<end_line>
 			色々あったもんなぁ<three_dots><end_line>
 			幻龍鬼まで召喚したし<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			たしかにルイーズ村では<end_line>
-			色々あったもんね<end_line>
-			幻龍鬼まで召喚したし<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     A lot of stuff did happen while<end_line>
     we were in Louise Village.<end_line>
     I even summoned a dragon!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			たしかにルイーズ村では<end_line>
+			色々あったもんね<end_line>
+			幻龍鬼まで召喚したし<end_line>
+		</sjis>
+    <ascii>
+    A lot of stuff did happen while<end_line>
+    we were in Louise Village.<end_line>
+    I even summoned a dragon!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -205,24 +215,29 @@
 	<portrait_l entry="player" eye="happy" mouth="neutral">
 	<portrait_r entry="murno" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			明日、ちゃんとみんなに説明すれば<end_line>
 			悪いのはアイツらだって<end_line>
 			みんなわかってくれるさ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			明日、ちゃんとみんなに説明すれば<end_line>
-			悪いのはアイツらだって<end_line>
-			みんなわかってくれるよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Once I get the chance to explain,<end_line>
     everyone will understand<end_line>
     that Anise is a villain!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			明日、ちゃんとみんなに説明すれば<end_line>
+			悪いのはアイツらだって<end_line>
+			みんなわかってくれるよ！<end_line>
+		</sjis>
+    <ascii>
+    Once I get the chance to explain,<end_line>
+    everyone will understand<end_line>
+    that Anise is a villain!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -244,23 +259,27 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="murno" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なに言ってるんだよ<end_line>
 			ミューノの言うことならみんな聞くさ<end_line>
 			だって、ミューノだもん<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Of course they will.<end_line>
+    You're Murno!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			なに言ってるの<end_line>
 			ミューノの言うことならみんな聞くよ<end_line>
 			だって、ミューノだもん<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Of course they will.<end_line>
     You're Murno!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">

--- a/Translation/JE Scripts/Day 07/047_25421900_183e84c.xml
+++ b/Translation/JE Scripts/Day 07/047_25421900_183e84c.xml
@@ -65,24 +65,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			でもさぁ、アニスたちは今でも<end_line>
 			どこかでミューノを狙ってるんだぜ<end_line>
 			ジッとしてられなくてさ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でもさ、アニスたちは今でも<end_line>
-			どこかでミューノを狙ってるんだよ<end_line>
-			ジッとしてられなくて<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I know, but Anise is still out<end_line>
     somewhere, aiming for Murno.<end_line>
     I can't just sit still<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でもさ、アニスたちは今でも<end_line>
+			どこかでミューノを狙ってるんだよ<end_line>
+			ジッとしてられなくて<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I know, but Anise is still out<end_line>
+    somewhere, aiming for Murno.<end_line>
+    I can't just sit still<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -202,24 +207,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			これからが、本番ってワケだな<three_dots><end_line>
 			初心に返って、気合い入れるか！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よおーし！<end_line>
-			これからが、本番ってワケだね<three_dots><end_line>
-			初心に返って、気合い入れよっか！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     We're finally at the main act<three_dots><end_line>
     For starters, let's get fired up!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よおーし！<end_line>
+			これからが、本番ってワケだね<three_dots><end_line>
+			初心に返って、気合い入れよっか！<end_line>
+		</sjis>
+    <ascii>
+    Alright!<end_line>
+    We're finally at the main act<three_dots><end_line>
+    For starters, let's get fired up!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -231,7 +241,7 @@
 	</sjis>
   <ascii>
     Fired<three_dots> Up?<end_line>
-  </ascii> 
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -239,24 +249,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="surprised" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだよ<end_line>
 			覚えてるだろ？<end_line>
 			最初に叫んだアレだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだよ<end_line>
-			覚えてるでしょ？<end_line>
-			最初に叫んだアレよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yep.<end_line>
     You remember, don't you?<end_line>
     The Craftknight's mantra!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだよ<end_line>
+			覚えてるでしょ？<end_line>
+			最初に叫んだアレよ！<end_line>
+		</sjis>
+    <ascii>
+    Yep.<end_line>
+    You remember, don't you?<end_line>
+    The Craftknight's mantra!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -300,18 +315,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>ってどうしたんだよ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots>ってどうしたの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots>Hey, what's wrong?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots>ってどうしたの？<end_line>
+		</sjis>
+    <ascii>
+    <three_dots>Hey, what's wrong?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -335,24 +353,29 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			だから<end_line>
 			叫ぶと、こう<end_line>
 			ハラの中から<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			だから<end_line>
-			叫ぶと、こう<end_line>
-			おなかの中から<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I told you,<end_line>
     the power comes<end_line>
     from your stomach<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			だから<end_line>
+			叫ぶと、こう<end_line>
+			おなかの中から<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I told you,<end_line>
+    the power comes<end_line>
+    from your stomach<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -404,24 +427,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			でもさぁ、アニスたちは今でも<end_line>
 			どこかでミューノを狙ってるんだぜ<end_line>
 			ジッとしてられなくてさ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でもさ、アニスたちは今でも<end_line>
-			どこかでミューノを狙ってるんだよ<end_line>
-			ジッとしてられなくて<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I know, but Anise is still out<end_line>
     somewhere, aiming for Murno.<end_line>
     I can't just sit still<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でもさ、アニスたちは今でも<end_line>
+			どこかでミューノを狙ってるんだよ<end_line>
+			ジッとしてられなくて<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I know, but Anise is still out<end_line>
+    somewhere, aiming for Murno.<end_line>
+    I can't just sit still<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -539,24 +567,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			これからが、本番ってワケだな<three_dots><end_line>
 			初心に返って、気合い入れるか！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よおーし！<end_line>
-			これからが、本番ってワケだね<three_dots><end_line>
-			初心に返って、気合い入れよっか！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     We're finally at the main act<three_dots><end_line>
     For starters, let's get fired up!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よおーし！<end_line>
+			これからが、本番ってワケだね<three_dots><end_line>
+			初心に返って、気合い入れよっか！<end_line>
+		</sjis>
+    <ascii>
+    Alright!<end_line>
+    We're finally at the main act<three_dots><end_line>
+    For starters, let's get fired up!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -578,24 +611,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			そうだよ<end_line>
 			覚えてるだろ？<end_line>
 			最初に叫んだアレだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだよ<end_line>
-			覚えてるでしょ？<end_line>
-			最初に叫んだアレよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yep.<end_line>
     You remember, don't you?<end_line>
     The Craftknight's mantra!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだよ<end_line>
+			覚えてるでしょ？<end_line>
+			最初に叫んだアレよ！<end_line>
+		</sjis>
+    <ascii>
+    Yep.<end_line>
+    You remember, don't you?<end_line>
+    The Craftknight's mantra!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -639,18 +677,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>ってどうしたんだよ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots>ってどうしたの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots>Hey, what's wrong?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots>ってどうしたの？<end_line>
+		</sjis>
+    <ascii>
+    <three_dots>Hey, what's wrong?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -732,24 +773,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			だけどアニスたちは今でも<end_line>
 			どこかでミューノを狙ってるんだぜ<end_line>
 			ジッとしてられなくてさ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でもアニスたちは今でも<end_line>
-			どこかでミューノを狙ってるんだよ<end_line>
-			ジッとしてられなくて<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I know, but Anise is still out<end_line>
     somewhere, aiming for Murno.<end_line>
     I can't just sit still<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でもアニスたちは今でも<end_line>
+			どこかでミューノを狙ってるんだよ<end_line>
+			ジッとしてられなくて<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I know, but Anise is still out<end_line>
+    somewhere, aiming for Murno.<end_line>
+    I can't just sit still<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -867,24 +913,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なに言ってんだよ<end_line>
 			これからが本番ってことだろ？<end_line>
 			初心に返って、気合い入れるか！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なに言ってるのよ<end_line>
-			これからが本番ってことでしょ？<end_line>
-			初心に返って、気合い入れよっか！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We're just getting started!<end_line>
     It's finally time for the main act!<end_line>
     For starters, let's get fired up!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なに言ってるのよ<end_line>
+			これからが本番ってことでしょ？<end_line>
+			初心に返って、気合い入れよっか！<end_line>
+		</sjis>
+    <ascii>
+    We're just getting started!<end_line>
+    It's finally time for the main act!<end_line>
+    For starters, let's get fired up!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -906,24 +957,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="surprised" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そうだよ<end_line>
 			覚えてるだろ？<end_line>
 			最初に叫んだアレだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだよ<end_line>
-			覚えてるでしょ？<end_line>
-			最初に叫んだアレよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yep.<end_line>
     You remember, don't you?<end_line>
     The Craftknight's mantra!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだよ<end_line>
+			覚えてるでしょ？<end_line>
+			最初に叫んだアレよ！<end_line>
+		</sjis>
+    <ascii>
+    Yep.<end_line>
+    You remember, don't you?<end_line>
+    The Craftknight's mantra!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -967,18 +1023,21 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>ってどうしたんだよ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots>ってどうしたの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots>Hey, what's wrong?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots>ってどうしたの？<end_line>
+		</sjis>
+    <ascii>
+    <three_dots>Hey, what's wrong?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1000,24 +1059,29 @@
 	<portrait_l entry="player" eye="surprised" mouth="stressed">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			え<three_dots>！？<end_line>
 			<partner>がオレにお願いなんて<three_dots><end_line>
 			そんなにイヤなのか<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			え<three_dots>！？<end_line>
-			<partner>がわたしにお願いなんて<three_dots><end_line>
-			そんなにイヤなの<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Eh<three_dots>!?<end_line>
     <partner> is begging me<three_dots><end_line>
     Do you hate it that much<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			え<three_dots>！？<end_line>
+			<partner>がわたしにお願いなんて<three_dots><end_line>
+			そんなにイヤなの<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Eh<three_dots>!?<end_line>
+    <partner> is begging me<three_dots><end_line>
+    Do you hate it that much<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1039,24 +1103,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			でもさぁ、アニスたちは今でも<end_line>
 			どこかでミューノを狙ってるんだぜ<end_line>
 			ジッとしてられなくてさ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でもさ、アニスたちは今でも<end_line>
-			どこかでミューノを狙ってるんだよ<end_line>
-			ジッとしてられなくて<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I know, but Anise is still out<end_line>
     somewhere, aiming for Murno.<end_line>
     I can't just sit still<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でもさ、アニスたちは今でも<end_line>
+			どこかでミューノを狙ってるんだよ<end_line>
+			ジッとしてられなくて<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I know, but Anise is still out<end_line>
+    somewhere, aiming for Murno.<end_line>
+    I can't just sit still<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1166,24 +1235,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			これからが、本番ってワケだな<three_dots><end_line>
 			初心に返って、気合い入れるか！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よおーし！<end_line>
-			これからが、本番ってワケだね<three_dots><end_line>
-			初心に返って、気合い入れよっか！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     We're finally at the main act<three_dots><end_line>
     For starters, let's get fired up!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よおーし！<end_line>
+			これからが、本番ってワケだね<three_dots><end_line>
+			初心に返って、気合い入れよっか！<end_line>
+		</sjis>
+    <ascii>
+    Alright!<end_line>
+    We're finally at the main act<three_dots><end_line>
+    For starters, let's get fired up!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1203,24 +1277,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだよ<end_line>
 			覚えてるだろ？<end_line>
 			最初に叫んだアレだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだよ<end_line>
-			覚えてるでしょ？<end_line>
-			最初に叫んだアレよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yep.<end_line>
     You remember, don't you?<end_line>
     The Craftknight's mantra!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだよ<end_line>
+			覚えてるでしょ？<end_line>
+			最初に叫んだアレよ！<end_line>
+		</sjis>
+    <ascii>
+    Yep.<end_line>
+    You remember, don't you?<end_line>
+    The Craftknight's mantra!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1260,18 +1339,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>ってどうしたんだよ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots>ってどうしたの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots>Hey, what's wrong?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots>ってどうしたの？<end_line>
+		</sjis>
+    <ascii>
+    <three_dots>Hey, what's wrong?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">

--- a/Translation/JE Scripts/Day 07/048_25425324_183f5ac.xml
+++ b/Translation/JE Scripts/Day 07/048_25425324_183f5ac.xml
@@ -33,6 +33,11 @@
       元気いっぱいだぜ！<end_line>
       やっぱ親方のシチューは最高だぜ！<end_line>
     </sjis>
+    <ascii>
+    Master's stew has<end_line>
+    got me all fired up!<end_line>
+    It really is the best!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -40,12 +45,12 @@
       元気いっぱいだよ！<end_line>
       やっぱ親方のシチューは最高だね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Master's stew has<end_line>
     got me all fired up!<end_line>
     It really is the best!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -83,6 +88,11 @@
       それにやる気も出てきたから<end_line>
       こうやって見回りを<three_dots><end_line>
     </sjis>
+    <ascii>
+    It's fine, it's for Murno.<end_line>
+    It's thanks to that energy<end_line>
+    I can patrol like this<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -90,12 +100,12 @@
       それにやる気も出てきたから<end_line>
       こうやって見回りを<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's fine, it's for Murno.<end_line>
     It's thanks to that energy<end_line>
     I can patrol like this<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -122,6 +132,11 @@
       あいつら絶対に今も<end_line>
       ミューノのことねらってるぜ！<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+    I'm sure they're<end_line>
+    still going after Murno!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -129,12 +144,12 @@
       あいつら絶対に今も<end_line>
       ミューノのことねらってるよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
     I'm sure they're<end_line>
     still going after Murno!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -160,17 +175,21 @@
       えー<end_line>
       でも、オレだって<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ehhh?<end_line>
+    But, even I<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       えー<end_line>
       でも、わたしだって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ehhh?<end_line>
     But, even I<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -195,15 +214,18 @@
     <sjis>
       ネコといっしょにすんな！<end_line>
     </sjis>
+    <ascii>
+    Don't compare me to a cat!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ネコといっしょにしないでよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't compare me to a cat!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -258,6 +280,11 @@
       そんなこと考えてたら<end_line>
       寝られなくなりそうだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Uu<three_dots><end_line>
+    I feel like I won't be able<end_line>
+    to fall asleep if I do that<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -265,12 +292,12 @@
       そんなこと考えてたら<end_line>
       寝られなくなりそう<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uu<three_dots><end_line>
     I feel like I won't be able<end_line>
     to fall asleep if I do that<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -296,15 +323,19 @@
       うー<three_dots><end_line>
       それはそれで寝られなくなりそうだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ugh<three_dots><end_line>
+    That's just make it worse<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うー<three_dots><end_line>
       それはそれで寝られなくなりそう<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ugh<three_dots><end_line>
     That's just make it worse<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 07/049_25427132_183fcbc.xml
+++ b/Translation/JE Scripts/Day 07/049_25427132_183fcbc.xml
@@ -32,17 +32,21 @@
       なんだよ、それ！<end_line>
       オレはただ、この辺りの見回りを<three_dots><end_line>
     </sjis>
+    <ascii>
+    What? No!<end_line>
+    I was just patrolling around here<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！<end_line>
       わたしはただ、この辺りの見回りを<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What? No!<end_line>
     I was just patrolling around here<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -96,6 +100,11 @@
       仲間だと思っているのか？<end_line>
       ボスタフさんがそう言ったのか！？<end_line>
     </sjis>
+    <ascii>
+    Do you still think<end_line>
+    they're on our side?<end_line>
+    Did Bostaph say that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -103,12 +112,12 @@
       仲間だと思っているの？<end_line>
       ボスタフさんがそう言ったから！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Do you still think<end_line>
     they're on our side?<end_line>
     Did Bostaph say that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -132,17 +141,21 @@
       なんだよ<three_dots><end_line>
       さっきはあんなに<three_dots><end_line>
     </sjis>
+    <ascii>
+    What's with that<three_dots><end_line>
+    Why haven't you<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ<three_dots><end_line>
       さっきはあんなに<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's with that<three_dots><end_line>
     Why haven't you<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 07/050_25428556_184024c.xml
+++ b/Translation/JE Scripts/Day 07/050_25428556_184024c.xml
@@ -46,15 +46,18 @@
     <sjis>
       オレもなんかできないかなって<three_dots><end_line>
     </sjis>
+    <ascii>
+    I thought I could do something<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしもなんかできないかなって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I thought I could do something<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -91,17 +94,21 @@
       なんだよ<end_line>
       そんな言い方ないだろ？<end_line>
     </sjis>
+    <ascii>
+    Come on,<end_line>
+    is that really enough?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ<end_line>
       そんな言い方ないでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Come on,<end_line>
     is that really enough?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -169,6 +176,11 @@
       あれはアニキが悪いんじゃないよ！<end_line>
       オレがミューノを支えられてたら<three_dots><end_line>
     </sjis>
+    <ascii>
+    Come on!<end_line>
+    That wasn't your fault!<end_line>
+    If I had supported Murno<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -176,12 +188,12 @@
       あれはアニキが悪いんじゃないよ！<end_line>
       わたしがミューノを支えられてたら<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Come on!<end_line>
     That wasn't your fault!<end_line>
     If I had supported Murno<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -244,17 +256,21 @@
       わ、わかったよ<three_dots><end_line>
       帰るよ<end_line>
     </sjis>
+    <ascii>
+    O-okay, fine<three_dots><end_line>
+    I'm going then.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わ、わかったわよ<three_dots><end_line>
       帰るよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     O-okay, fine<three_dots><end_line>
     I'm going then.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 07/051_25430172_184089c.xml
+++ b/Translation/JE Scripts/Day 07/051_25430172_184089c.xml
@@ -46,15 +46,18 @@
     <sjis>
       じっとしてらんないよ<end_line>
     </sjis>
+    <ascii>
+    I can't just sit still.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       じっとしてられないよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I can't just sit still.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -145,15 +148,18 @@
     <sjis>
       な、なんだよ！？<end_line>
     </sjis>
+    <ascii>
+    W-what!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な、なによ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     W-what!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 07/24523404_176328c.xml
+++ b/Translation/JE Scripts/Day 07/24523404_176328c.xml
@@ -4,18 +4,21 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いよいよトラムとの勝負だぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いよいよトラムとの勝負だね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     It's time for our match with Tram.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いよいよトラムとの勝負だね<end_line>
+		</sjis>
+    <ascii>
+    It's time for our match with Tram.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -37,7 +40,7 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			おう！<end_line>
 			行くぜ！<end_line>
 		</sjis>
@@ -45,9 +48,9 @@
       Yeah!<end_line>
       Let's go!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			うん！<end_line>
 			行こう！<end_line>
 		</sjis>
@@ -55,7 +58,7 @@
       I will!<end_line>
       Let's go!<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -63,18 +66,21 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いよいよトラムとの勝負だぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いよいよトラムとの勝負だね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     It's time for our match with Tram.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いよいよトラムとの勝負だね<end_line>
+		</sjis>
+    <ascii>
+    It's time for our match with Tram.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -98,7 +104,7 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			おう！<end_line>
 			誓うぜ！<end_line>
 		</sjis>
@@ -106,17 +112,17 @@
       Yeah!<end_line>
       I swear!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			うん！<end_line>
 			誓うわ！<end_line>
 		</sjis>
-	</female>
     <ascii>
       I will!<end_line>
       I swear!<end_line>
     </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -124,18 +130,21 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いよいよトラムとの勝負だぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いよいよトラムとの勝負だね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     It's time for our match with Tram.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いよいよトラムとの勝負だね<end_line>
+		</sjis>
+    <ascii>
+    It's time for our match with Tram.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -157,39 +166,46 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			はいはい、ミューノのためだろ？<end_line>
 			がんばるよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			はいはい、ミューノのためでしょ？<end_line>
-			がんばるよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     For Murno, right? I know, I know.<end_line>
     I'll do my best.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			はいはい、ミューノのためでしょ？<end_line>
+			がんばるよ<end_line>
+		</sjis>
+    <ascii>
+    For Murno, right? I know, I know.<end_line>
+    I'll do my best.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			いよいよトラムとの勝負だぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いよいよトラムとの勝負だね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     It's time for our match with Tram.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いよいよトラムとの勝負だね<end_line>
+		</sjis>
+    <ascii>
+    It's time for our match with Tram.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -209,7 +225,7 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			おう！<end_line>
 			行くぜ！<end_line>
 		</sjis>
@@ -217,17 +233,17 @@
       Yeah!<end_line>
       Let's go!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			うん！<end_line>
 			行こう！<end_line>
 		</sjis>
-	</female>
     <ascii>
       I will!<end_line>
       Let's go!<end_line>
     </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -235,24 +251,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			トラムとの勝負の準備を調えて<end_line>
 			遺跡前の広場に行こう<end_line>
 			みんな待ってるぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			トラムとの勝負の準備を調えて<end_line>
-			遺跡前の広場に行こう<end_line>
-			みんな待ってるよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Everyone's waiting at the<end_line>
     plaza in front of the ruins.<end_line>
     I have to make sure I'm ready.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			トラムとの勝負の準備を調えて<end_line>
+			遺跡前の広場に行こう<end_line>
+			みんな待ってるよ<end_line>
+		</sjis>
+    <ascii>
+    Everyone's waiting at the<end_line>
+    plaza in front of the ruins.<end_line>
+    I have to make sure I'm ready.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -276,21 +297,25 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いきおいで決まった勝負だ<end_line>
 			細かいことは気にするな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いきおいで決まった勝負だよ<end_line>
-			細かいことは気にしちゃダメ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, that was decided for us.<end_line>
     Nothing we can do about it now!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いきおいで決まった勝負だよ<end_line>
+			細かいことは気にしちゃダメ！<end_line>
+		</sjis>
+    <ascii>
+    Well, that was decided for us.<end_line>
+    Nothing we can do about it now!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -298,24 +323,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			トラムとの勝負の準備を調えて<end_line>
 			遺跡前の広場に行こう<end_line>
 			みんな待ってるぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			トラムとの勝負の準備を調えて<end_line>
-			遺跡前の広場に行こう<end_line>
-			みんな待ってるよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Everyone's waiting at the<end_line>
     plaza in front of the ruins.<end_line>
     I have to make sure I'm ready.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			トラムとの勝負の準備を調えて<end_line>
+			遺跡前の広場に行こう<end_line>
+			みんな待ってるよ<end_line>
+		</sjis>
+    <ascii>
+    Everyone's waiting at the<end_line>
+    plaza in front of the ruins.<end_line>
+    I have to make sure I'm ready.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -339,21 +369,25 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			いきおいで決まった勝負だ<end_line>
 			細かいことは気にするな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いきおいで決まった勝負だよ<end_line>
-			細かいことは気にしちゃダメ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, that was decided for us.<end_line>
     Nothing we can do about it now!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いきおいで決まった勝負だよ<end_line>
+			細かいことは気にしちゃダメ！<end_line>
+		</sjis>
+    <ascii>
+    Well, that was decided for us.<end_line>
+    Nothing we can do about it now!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -361,24 +395,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			トラムとの勝負の準備を調えて<end_line>
 			遺跡前の広場に行こう<end_line>
 			みんな待ってるぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			トラムとの勝負の準備を調えて<end_line>
-			遺跡前の広場に行こう<end_line>
-			みんな待ってるよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Everyone's waiting at the<end_line>
     plaza in front of the ruins.<end_line>
     I have to make sure I'm ready.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			トラムとの勝負の準備を調えて<end_line>
+			遺跡前の広場に行こう<end_line>
+			みんな待ってるよ<end_line>
+		</sjis>
+    <ascii>
+    Everyone's waiting at the<end_line>
+    plaza in front of the ruins.<end_line>
+    I have to make sure I'm ready.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -402,45 +441,54 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			いきおいで決まった勝負だ<end_line>
 			細かいことは気にするな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いきおいで決まった勝負だよ<end_line>
-			細かいことは気にしちゃダメ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, that was decided for us.<end_line>
     Nothing we can do about it now!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いきおいで決まった勝負だよ<end_line>
+			細かいことは気にしちゃダメ！<end_line>
+		</sjis>
+    <ascii>
+    Well, that was decided for us.<end_line>
+    Nothing we can do about it now!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			トラムとの勝負の準備を調えて<end_line>
 			遺跡前の広場に行こう<end_line>
 			みんな待ってるぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			トラムとの勝負の準備を調えて<end_line>
-			遺跡前の広場に行こう<end_line>
-			みんな待ってるよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Everyone's waiting at the<end_line>
     plaza in front of the ruins.<end_line>
     I have to make sure I'm ready.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			トラムとの勝負の準備を調えて<end_line>
+			遺跡前の広場に行こう<end_line>
+			みんな待ってるよ<end_line>
+		</sjis>
+    <ascii>
+    Everyone's waiting at the<end_line>
+    plaza in front of the ruins.<end_line>
+    I have to make sure I'm ready.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -462,21 +510,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			いきおいで決まった勝負だ<end_line>
 			細かいことは気にするな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いきおいで決まった勝負だよ<end_line>
-			細かいことは気にしちゃダメ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, that was decided for us.<end_line>
     Nothing we can do about it now!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いきおいで決まった勝負だよ<end_line>
+			細かいことは気にしちゃダメ！<end_line>
+		</sjis>
+    <ascii>
+    Well, that was decided for us.<end_line>
+    Nothing we can do about it now!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -512,18 +564,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<portrait_r entry="partner" eye="surprised" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			お、おう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    R-right.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			う、うん<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     R-right.<end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -559,18 +614,21 @@
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			お、おう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    R-right.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			う、うん<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     R-right.<end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -606,21 +664,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<portrait_r entry="partner" eye="special" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノのことになると<end_line>
 			やっぱちがうなぁ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノのことになると<end_line>
-			やっぱちがうなぁ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     He really is different<end_line>
     when it comes to Murno<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノのことになると<end_line>
+			やっぱちがうなぁ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    He really is different<end_line>
+    when it comes to Murno<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -653,18 +715,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			お、おう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    R-right.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			う、うん<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     R-right.<end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -672,24 +737,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			裁きの間まで行かなきゃならないけど<end_line>
 			グマグの炎遺跡ってすごく暑いぞ<end_line>
 			<partner>、大丈夫か？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			裁きの間まで行かなきゃならないけど<end_line>
-			グマグの炎遺跡ってすごく暑いよ<end_line>
-			<partner>、大丈夫？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Do we really have to go in there?<end_line>
     Those ruins are ridiculously hot<three_dots><end_line>
     <partner>, how are you doing?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			裁きの間まで行かなきゃならないけど<end_line>
+			グマグの炎遺跡ってすごく暑いよ<end_line>
+			<partner>、大丈夫？<end_line>
+		</sjis>
+    <ascii>
+    Do we really have to go in there?<end_line>
+    Those ruins are ridiculously hot<three_dots><end_line>
+    <partner>, how are you doing?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -739,24 +809,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			裁きの間まで行かなきゃならないけど<end_line>
 			グマグの炎遺跡ってすごく暑いぞ<end_line>
 			<partner>、大丈夫か？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			裁きの間まで行かなきゃならないけど<end_line>
-			グマグの炎遺跡ってすごく暑いよ<end_line>
-			<partner>、大丈夫？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Do we really have to go in there?<end_line>
     Those ruins are ridiculously hot<three_dots><end_line>
     <partner>, how are you doing?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			裁きの間まで行かなきゃならないけど<end_line>
+			グマグの炎遺跡ってすごく暑いよ<end_line>
+			<partner>、大丈夫？<end_line>
+		</sjis>
+    <ascii>
+    Do we really have to go in there?<end_line>
+    Those ruins are ridiculously hot<three_dots><end_line>
+    <partner>, how are you doing?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -780,24 +855,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			へぇ、スゴイな<end_line>
 			<partner>ってモサモサしてるから<end_line>
 			暑いのには弱いかと思った<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			へぇ、スゴイね<end_line>
-			<partner>ってモサモサしてるから<end_line>
-			暑いのには弱いかと思った<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Huh, that's cool.<end_line>
     You're really hairy,<end_line>
     so I thought you'd be weak to heat.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			へぇ、スゴイね<end_line>
+			<partner>ってモサモサしてるから<end_line>
+			暑いのには弱いかと思った<end_line>
+		</sjis>
+    <ascii>
+    Huh, that's cool.<end_line>
+    You're really hairy,<end_line>
+    so I thought you'd be weak to heat.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -817,24 +897,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			裁きの間まで行かなきゃならないけど<end_line>
 			グマグの炎遺跡ってすごく暑いぞ<end_line>
 			<partner>、大丈夫か？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			裁きの間まで行かなきゃならないけど<end_line>
-			グマグの炎遺跡ってすごく暑いよ<end_line>
-			<partner>、大丈夫？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Do we really have to go in there?<end_line>
     Those ruins are ridiculously hot<three_dots><end_line>
     <partner>, how are you doing?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			裁きの間まで行かなきゃならないけど<end_line>
+			グマグの炎遺跡ってすごく暑いよ<end_line>
+			<partner>、大丈夫？<end_line>
+		</sjis>
+    <ascii>
+    Do we really have to go in there?<end_line>
+    Those ruins are ridiculously hot<three_dots><end_line>
+    <partner>, how are you doing?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -858,21 +943,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="stressed">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ちょっと、<partner><three_dots>？<end_line>
 			お前、ホント大丈夫か？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ちょっと、<partner><three_dots>？<end_line>
-			あなた、ホントに大丈夫？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Umm, <partner><three_dots>?<end_line>
     Are you okay?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ちょっと、<partner><three_dots>？<end_line>
+			あなた、ホントに大丈夫？<end_line>
+		</sjis>
+    <ascii>
+    Umm, <partner><three_dots>?<end_line>
+    Are you okay?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -909,24 +998,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			裁きの間まで行かなきゃならないけど<end_line>
 			グマグの炎遺跡ってすごく暑いぞ<end_line>
 			<partner>、大丈夫か？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			裁きの間まで行かなきゃならないけど<end_line>
-			グマグの炎遺跡ってすごく暑いよ<end_line>
-			<partner>、大丈夫？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Do we really have to go in there?<end_line>
     Those ruins are ridiculously hot<three_dots><end_line>
     <partner>, how are you doing?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			裁きの間まで行かなきゃならないけど<end_line>
+			グマグの炎遺跡ってすごく暑いよ<end_line>
+			<partner>、大丈夫？<end_line>
+		</sjis>
+    <ascii>
+    Do we really have to go in there?<end_line>
+    Those ruins are ridiculously hot<three_dots><end_line>
+    <partner>, how are you doing?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -984,24 +1078,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いよいよトラムと１対１の勝負だ！<end_line>
 			最強の武器をひとつ<end_line>
 			バッチリ装備して行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いよいよトラムと１対１の勝負だ！<end_line>
-			最強の武器をひとつ<end_line>
-			シッカリ装備して行かなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Time for my one on one with Tram!<end_line>
     Gotta make sure I've got<end_line>
     my best weapon ready to go!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いよいよトラムと１対１の勝負だ！<end_line>
+			最強の武器をひとつ<end_line>
+			シッカリ装備して行かなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    Time for my one on one with Tram!<end_line>
+    Gotta make sure I've got<end_line>
+    my best weapon ready to go!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1023,24 +1122,29 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			おう！<end_line>
 			<partner>が応援してくれるんだ<end_line>
 			絶対に勝つぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん！<end_line>
-			<partner>が応援してくれるんだ<end_line>
-			絶対に勝つよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
     With you cheering me on,<end_line>
     I'm sure to win!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん！<end_line>
+			<partner>が応援してくれるんだ<end_line>
+			絶対に勝つよ！<end_line>
+		</sjis>
+    <ascii>
+    Yeah!<end_line>
+    With you cheering me on,<end_line>
+    I'm sure to win!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1048,24 +1152,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いよいよトラムと１対１の勝負だ！<end_line>
 			最強の武器をひとつ<end_line>
 			バッチリ装備して行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いよいよトラムと１対１の勝負だ！<end_line>
-			最強の武器をひとつ<end_line>
-			シッカリ装備して行かなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Time for my one on one with Tram!<end_line>
     Gotta make sure I've got<end_line>
     my best weapon ready to go!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いよいよトラムと１対１の勝負だ！<end_line>
+			最強の武器をひとつ<end_line>
+			シッカリ装備して行かなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    Time for my one on one with Tram!<end_line>
+    Gotta make sure I've got<end_line>
+    my best weapon ready to go!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1089,24 +1198,29 @@
 	<portrait_l entry="player" eye="decided" mouth="talk">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			おう！<end_line>
 			<partner>が応援してくれるんだ<end_line>
 			絶対に勝つぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん！<end_line>
-			<partner>が応援してくれるんだ<end_line>
-			絶対に勝つよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
     With you cheering me on,<end_line>
     I'm sure to win!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん！<end_line>
+			<partner>が応援してくれるんだ<end_line>
+			絶対に勝つよ！<end_line>
+		</sjis>
+    <ascii>
+    Yeah!<end_line>
+    With you cheering me on,<end_line>
+    I'm sure to win!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1114,24 +1228,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			いよいよトラムと１対１の勝負だ！<end_line>
 			最強の武器をひとつ<end_line>
 			バッチリ装備して行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いよいよトラムと１対１の勝負だ！<end_line>
-			最強の武器をひとつ<end_line>
-			シッカリ装備して行かなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Time for my one on one with Tram!<end_line>
     Gotta make sure I've got<end_line>
     my best weapon ready to go!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いよいよトラムと１対１の勝負だ！<end_line>
+			最強の武器をひとつ<end_line>
+			シッカリ装備して行かなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    Time for my one on one with Tram!<end_line>
+    Gotta make sure I've got<end_line>
+    my best weapon ready to go!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1167,48 +1286,58 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			言ってることはブッソウだけど<end_line>
 			オレを心配してくれていると<end_line>
 			思いたい！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			言ってることはブッソウだけど<end_line>
-			わたしを心配してくれていると<end_line>
-			思いたい！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What you're saying is disturbing,<end_line>
     so I'll just take it as your<end_line>
     way of worrying about me!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			言ってることはブッソウだけど<end_line>
+			わたしを心配してくれていると<end_line>
+			思いたい！<end_line>
+		</sjis>
+    <ascii>
+    What you're saying is disturbing,<end_line>
+    so I'll just take it as your<end_line>
+    way of worrying about me!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			いよいよトラムと１対１の勝負だ！<end_line>
 			最強の武器をひとつ<end_line>
 			バッチリ装備して行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いよいよトラムと１対１の勝負だ！<end_line>
-			最強の武器をひとつ<end_line>
-			シッカリ装備して行かなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Time for my one on one with Tram!<end_line>
     Gotta make sure I've got<end_line>
     my best weapon ready to go!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いよいよトラムと１対１の勝負だ！<end_line>
+			最強の武器をひとつ<end_line>
+			シッカリ装備して行かなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    Time for my one on one with Tram!<end_line>
+    Gotta make sure I've got<end_line>
+    my best weapon ready to go!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1230,21 +1359,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			あ、うん<end_line>
 			ありがとう、わかったよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あ、うん<end_line>
-			ありがとう、わかった<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ah, right.<end_line>
     Thanks, I got it.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あ、うん<end_line>
+			ありがとう、わかった<end_line>
+		</sjis>
+    <ascii>
+    Ah, right.<end_line>
+    Thanks, I got it.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1268,24 +1401,29 @@
 	<portrait_l entry="player" eye="sad" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			いいけどさ、よく考えたら<end_line>
 			オレが行っても魔晶柱を調べるのに<end_line>
 			ジャマになったりしないかな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いいけどさ、よく考えたら<end_line>
-			わたしが行っても魔晶柱を調べるのに<end_line>
-			ジャマになったりしないかな<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm all for it, but really,<end_line>
     won't we just be getting<end_line>
     in the way if we do<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いいけどさ、よく考えたら<end_line>
+			わたしが行っても魔晶柱を調べるのに<end_line>
+			ジャマになったりしないかな<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I'm all for it, but really,<end_line>
+    won't we just be getting<end_line>
+    in the way if we do<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1335,24 +1473,29 @@
 	<portrait_l entry="player" eye="sad" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			いいけどさ、よく考えたら<end_line>
 			オレが行っても魔晶柱を調べるのに<end_line>
 			ジャマになったりしないかな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いいけどさ、よく考えたら<end_line>
-			わたしが行っても魔晶柱を調べるのに<end_line>
-			ジャマになったりしないかな<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm all for it, but really,<end_line>
     won't we just be getting<end_line>
     in the way if we do<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いいけどさ、よく考えたら<end_line>
+			わたしが行っても魔晶柱を調べるのに<end_line>
+			ジャマになったりしないかな<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I'm all for it, but really,<end_line>
+    won't we just be getting<end_line>
+    in the way if we do<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1376,7 +1519,7 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そんなことあるか！<end_line>
 			行くぞ！<end_line>
 		</sjis>
@@ -1384,9 +1527,9 @@
       O-of course not!<end_line>
       Let's go!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			なに言ってるのよ！<end_line>
 			もう、行くわよ！<end_line>
 		</sjis>
@@ -1394,7 +1537,7 @@
       What's that mean!?<end_line>
       Ugh, let's just go!<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1418,24 +1561,29 @@
 	<portrait_l entry="player" eye="sad" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			でもさ、よく考えたら<end_line>
 			オレが行っても魔晶柱を調べるのに<end_line>
 			ジャマになったりしないかな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも、よく考えたら<end_line>
-			わたしが行っても魔晶柱を調べるのに<end_line>
-			ジャマになったりしないかな<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Now that I think about it,<end_line>
     won't we just be getting<end_line>
     in the way if we do<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でも、よく考えたら<end_line>
+			わたしが行っても魔晶柱を調べるのに<end_line>
+			ジャマになったりしないかな<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Now that I think about it,<end_line>
+    won't we just be getting<end_line>
+    in the way if we do<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1483,24 +1631,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			いいけどさ、よく考えたら<end_line>
 			オレが行っても魔晶柱を調べるのに<end_line>
 			ジャマになったりしないかな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			いいけどさ、よく考えたら<end_line>
-			わたしが行っても魔晶柱を調べるのに<end_line>
-			ジャマになったりしないかな<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I'm all for it, but really,<end_line>
     won't we just be getting<end_line>
     in the way if we do<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			いいけどさ、よく考えたら<end_line>
+			わたしが行っても魔晶柱を調べるのに<end_line>
+			ジャマになったりしないかな<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I'm all for it, but really,<end_line>
+    won't we just be getting<end_line>
+    in the way if we do<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1522,7 +1675,7 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			うっわ！<end_line>
 			ヒデェ！<end_line>
 		</sjis>
@@ -1530,9 +1683,9 @@
       Uwah!<end_line>
       That hurts!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			なにそれ！<end_line>
 			ひっどーい！<end_line>
 		</sjis>
@@ -1540,7 +1693,7 @@
       What!?<end_line>
       You're terrible!<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1548,24 +1701,29 @@
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間たちって<end_line>
 			本当にヒドイことを<end_line>
 			やってたんだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間たちって<end_line>
-			本当にヒドイことを<end_line>
-			やってたんだね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise and her goons<end_line>
     are really terrible<end_line>
     aren't they<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間たちって<end_line>
+			本当にヒドイことを<end_line>
+			やってたんだね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Anise and her goons<end_line>
+    are really terrible<end_line>
+    aren't they<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1589,24 +1747,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 			今はとにかく遺跡の奥の<end_line>
 			魔晶柱を調べに行こう<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Right<three_dots><end_line>
+    For now we still need to find<end_line>
+    the Crystal Pillar in the ruins.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<three_dots><end_line>
 			今はとにかく遺跡の奥の<end_line>
 			魔晶柱を調べに行こう<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
     For now we still need to find<end_line>
     the Crystal Pillar in the ruins.<end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1614,24 +1777,29 @@
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間たちって<end_line>
 			本当にヒドイことを<end_line>
 			やってたんだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間たちって<end_line>
-			本当にヒドイことを<end_line>
-			やってたんだね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise and her goons<end_line>
     are really terrible<end_line>
     aren't they<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間たちって<end_line>
+			本当にヒドイことを<end_line>
+			やってたんだね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Anise and her goons<end_line>
+    are really terrible<end_line>
+    aren't they<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1655,24 +1823,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 			今はとにかく遺跡の奥の<end_line>
 			魔晶柱を調べに行こう<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Right<three_dots><end_line>
+    For now we still need to find<end_line>
+    the Crystal Pillar in the ruins.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<three_dots><end_line>
 			今はとにかく遺跡の奥の<end_line>
 			魔晶柱を調べに行こう<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
     For now we still need to find<end_line>
     the Crystal Pillar in the ruins.<end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1680,24 +1853,29 @@
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間たちって<end_line>
 			本当にヒドイことを<end_line>
 			やってたんだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間たちって<end_line>
-			本当にヒドイことを<end_line>
-			やってたんだね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise and her goons<end_line>
     are really terrible<end_line>
     aren't they<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間たちって<end_line>
+			本当にヒドイことを<end_line>
+			やってたんだね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Anise and her goons<end_line>
+    are really terrible<end_line>
+    aren't they<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1721,48 +1899,58 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 			今はとにかく遺跡の奥の<end_line>
 			魔晶柱を調べに行こう<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Right<three_dots><end_line>
+    For now we still need to find<end_line>
+    the Crystal Pillar in the ruins.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<three_dots><end_line>
 			今はとにかく遺跡の奥の<end_line>
 			魔晶柱を調べに行こう<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
     For now we still need to find<end_line>
     the Crystal Pillar in the ruins.<end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間たちって<end_line>
 			本当にヒドイことを<end_line>
 			やってたんだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間たちって<end_line>
-			本当にヒドイことを<end_line>
-			やってたんだね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise and her goons<end_line>
     are really terrible<end_line>
     aren't they<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間たちって<end_line>
+			本当にヒドイことを<end_line>
+			やってたんだね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Anise and her goons<end_line>
+    are really terrible<end_line>
+    aren't they<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1784,22 +1972,27 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 			今はとにかく遺跡の奥の<end_line>
 			魔晶柱を調べに行こう<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Right<three_dots><end_line>
+    For now we still need to find<end_line>
+    the Crystal Pillar in the ruins.<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<three_dots><end_line>
 			今はとにかく遺跡の奥の<end_line>
 			魔晶柱を調べに行こう<three_dots><end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
     For now we still need to find<end_line>
     the Crystal Pillar in the ruins.<end_line>
-  </ascii> 
+  </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 07/24528348_17645dc.xml
+++ b/Translation/JE Scripts/Day 07/24528348_17645dc.xml
@@ -161,21 +161,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスを連れてくるように<end_line>
 			牢屋の番人に伝えなきゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスを連れてくるように<end_line>
-			牢屋の番人さんに伝えなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I need to convince the<end_line>
     jailer to let Anise out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスを連れてくるように<end_line>
+			牢屋の番人さんに伝えなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    I need to convince the<end_line>
+    jailer to let Anise out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -213,18 +217,21 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			やるしかないんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やるしかないでしょ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We have to try!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やるしかないでしょ！<end_line>
+		</sjis>
+    <ascii>
+    We have to try!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -232,21 +239,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスを連れてくるように<end_line>
 			牢屋の番人に伝えなきゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスを連れてくるように<end_line>
-			牢屋の番人さんに伝えなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I need to convince the<end_line>
     jailer to let Anise out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスを連れてくるように<end_line>
+			牢屋の番人さんに伝えなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    I need to convince the<end_line>
+    jailer to let Anise out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -284,18 +295,21 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			やるしかないんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やるしかないでしょ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We have to try!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やるしかないでしょ！<end_line>
+		</sjis>
+    <ascii>
+    We have to try!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -303,21 +317,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスを連れてくるように<end_line>
 			牢屋の番人に伝えなきゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスを連れてくるように<end_line>
-			牢屋の番人さんに伝えなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I need to convince the<end_line>
     jailer to let Anise out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスを連れてくるように<end_line>
+			牢屋の番人さんに伝えなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    I need to convince the<end_line>
+    jailer to let Anise out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -355,39 +373,46 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			やるしかないんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やるしかないでしょ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We have to try!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やるしかないでしょ！<end_line>
+		</sjis>
+    <ascii>
+    We have to try!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			アニスを連れてくるように<end_line>
 			牢屋の番人に伝えなきゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスを連れてくるように<end_line>
-			牢屋の番人さんに伝えなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I need to convince the<end_line>
     jailer to let Anise out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスを連れてくるように<end_line>
+			牢屋の番人さんに伝えなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    I need to convince the<end_line>
+    jailer to let Anise out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -422,18 +447,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			やるしかないんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やるしかないでしょ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     We have to try!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やるしかないでしょ！<end_line>
+		</sjis>
+    <ascii>
+    We have to try!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -628,21 +656,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			トラムたちが村の出口で待ってる<end_line>
 			とりあえず、帰ろう<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			トラムたちが村の出口で待ってるよ<end_line>
-			とりあえず、帰ろう<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Tram and the others are waiting<end_line>
     for us at the gate<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			トラムたちが村の出口で待ってるよ<end_line>
+			とりあえず、帰ろう<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Tram and the others are waiting<end_line>
+    for us at the gate<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -686,7 +718,7 @@
   <ascii>
     Finally.<end_line>
     I'm sick of this place.<end_line>
-  </ascii> 
+  </ascii>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -709,18 +741,21 @@
 	<portrait_l entry="player" eye="sad" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスも逃がしちゃったしな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスも逃がしちゃったしね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise ran away<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスも逃がしちゃったしね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Anise ran away<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -755,24 +790,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			親方に怒られるのはイヤだけど<end_line>
 			とにかくプロスバンの町に戻るしか<end_line>
 			ないみたいだ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			親方に怒られるのはイヤだけど<end_line>
-			とにかくプロスバンの町に戻るしか<end_line>
-			ないみたい<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I don't really want to have<end_line>
     Master scold me, but we have to<end_line>
     go back to Prosban eventually<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			親方に怒られるのはイヤだけど<end_line>
+			とにかくプロスバンの町に戻るしか<end_line>
+			ないみたい<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I don't really want to have<end_line>
+    Master scold me, but we have to<end_line>
+    go back to Prosban eventually<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -865,21 +905,25 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			誰かがオレをさがしてるみたいだ<end_line>
 			誰だろう<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			誰かがわたしをさがしてるみたい<end_line>
-			誰だろう<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I heard someone looking for me.<end_line>
     I wonder who it is<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			誰かがわたしをさがしてるみたい<end_line>
+			誰だろう<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I heard someone looking for me.<end_line>
+    I wonder who it is<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">

--- a/Translation/JE Scripts/Day 07/25410412_183bb6c.xml
+++ b/Translation/JE Scripts/Day 07/25410412_183bb6c.xml
@@ -92,7 +92,7 @@
 	<portrait_l entry="player" eye="surprised_blush" mouth="tense">
 	<portrait_r entry="tier" eye="happy_blush" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			うわ<three_dots>！？<end_line>
 			ちょっと、なんだよ！？<end_line>
 		</sjis>
@@ -100,9 +100,9 @@
       Woah<three_dots>!?<end_line>
       Hey, what's wrong!?<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			きゃ<three_dots>！？<end_line>
 			ちょっと、なによ！？<end_line>
 		</sjis>
@@ -110,7 +110,7 @@
       Kya<three_dots>!?<end_line>
       Hey, what's wrong!?<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -198,21 +198,25 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="tier" eye="surprised" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			ホント<three_dots><end_line>
 			カンベンしてくれよ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ホントにもう<three_dots><end_line>
-			カンベンしてよね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hah<three_dots><end_line>
     Gimme a break<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ホントにもう<three_dots><end_line>
+			カンベンしてよね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Hah<three_dots><end_line>
+    Gimme a break<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">

--- a/Translation/JE Scripts/Day 08/002_24563292_176ce5c.xml
+++ b/Translation/JE Scripts/Day 08/002_24563292_176ce5c.xml
@@ -10,15 +10,18 @@
     <sjis>
       がんばってね！　おにーちゃん<end_line>
     </sjis>
+    <ascii>
+    Good luck, <player_nickname>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       がんばってね！　おねーちゃん<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Good luck, <player_nickname>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Translation/JE Scripts/Day 08/003_25434172_184183c.xml
+++ b/Translation/JE Scripts/Day 08/003_25434172_184183c.xml
@@ -20,17 +20,21 @@
       うん<end_line>
       もう大丈夫だぜ！<end_line>
     </sjis>
+    <ascii>
+    Yeah.<end_line>
+    I'm alright now!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん<end_line>
       もう大丈夫だよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah.<end_line>
     I'm alright now!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Translation/JE Scripts/Day 08/004_24549180_176973c.xml
+++ b/Translation/JE Scripts/Day 08/004_24549180_176973c.xml
@@ -1,10 +1,10 @@
 <location>
-	<sjis>
+  <sjis>
 		プロスバンの町<end_line>
 	</sjis>
 </location>
 <location>
-	<sjis>
+  <sjis>
 		プロスバンの町　北門前工房通り<end_line>
 	</sjis>
 </location>
@@ -12,24 +12,29 @@
 	<info box="simple">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ねらわれてるミューノをつれて<end_line>
 			あまりウロウロしない方がいいな<three_dots><end_line>
 			とにかく工房に行こう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ねらわれてるミューノをつれて<end_line>
-			あまりウロウロしない方がいいよね<three_dots><end_line>
-			とにかく工房に行こう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I shouldn't wander around while<end_line>
     Murno is still in danger<three_dots><end_line>
     Let's head to the workshop.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ねらわれてるミューノをつれて<end_line>
+			あまりウロウロしない方がいいよね<three_dots><end_line>
+			とにかく工房に行こう<end_line>
+		</sjis>
+    <ascii>
+    I shouldn't wander around while<end_line>
+    Murno is still in danger<three_dots><end_line>
+    Let's head to the workshop.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">

--- a/Translation/JE Scripts/Day 08/005_25436204_184202c.xml
+++ b/Translation/JE Scripts/Day 08/005_25436204_184202c.xml
@@ -16,21 +16,21 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="vee" eye="serious" mouth="neutral">
 	<option>
-		<sjis>
+    <sjis>
 			もちろん準備できたよ<end_line>
 		</sjis>
     <ascii>
       I'm ready.<end_line>
     </ascii>
-	</option>
-	<option>
-		<sjis>
+  </option>
+  <option>
+    <sjis>
 			もうちょっと待ってよ<end_line>
 		</sjis>
     <ascii>
       Not yet.<end_line>
     </ascii>
-	</option>
+  </option>
 </choice>
 <dialogue>
 	<info box="right">
@@ -251,21 +251,21 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="vee" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			おう！<end_line>
 		</sjis>
     <ascii>
       Yeah!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			はい！<end_line>
 		</sjis>
     <ascii>
       Yes!<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -281,18 +281,21 @@
 	<info box="right">
 	<portrait_r entry="player" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、あれ<three_dots>？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、あれ<three_dots>？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What's with him<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、あれ<three_dots>？<end_line>
+		</sjis>
+    <ascii>
+    What's with him<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -312,21 +315,21 @@
 	<portrait_l entry="vee" eye="decided" mouth="tense">
 	<portrait_r entry="player" eye="surprised" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			あ、わかったよ<end_line>
 		</sjis>
     <ascii>
       Ah, right.<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			あ、はーい<end_line>
 		</sjis>
     <ascii>
       Ah, coming.<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">

--- a/Translation/JE Scripts/Day 08/008_24559260_176be9c.xml
+++ b/Translation/JE Scripts/Day 08/008_24559260_176be9c.xml
@@ -17,6 +17,11 @@
       あまりウロウロしない方がいいな<three_dots><end_line>
       とにかく工房に行こう<end_line>
     </sjis>
+    <ascii>
+    I shouldn't wander around while<end_line>
+    Murno is still in danger<three_dots><end_line>
+    Let's head to the workshop.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -24,12 +29,12 @@
       あまりウロウロしない方がいいよね<three_dots><end_line>
       とにかく工房に行こう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I shouldn't wander around while<end_line>
     Murno is still in danger<three_dots><end_line>
     Let's head to the workshop.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Translation/JE Scripts/Day 08/009_25441660_184357c.xml
+++ b/Translation/JE Scripts/Day 08/009_25441660_184357c.xml
@@ -239,17 +239,21 @@
       スゲェ！　だからアカバネか<three_dots><end_line>
       なんかカッコイイ<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Amazing! So that's why its "Red"<three_dots><end_line>
+    That's kinda cool<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       スゴイ！　だからアカバネか<three_dots><end_line>
       なんかカッコイイ<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Amazing! So that's why its "Red"<three_dots><end_line>
     That's kinda cool<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -525,17 +529,21 @@
       な！<end_line>
       オレだって！<end_line>
     </sjis>
+    <ascii>
+    Wha!<end_line>
+    Even I!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な！<end_line>
       わたしだって！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wha!<end_line>
     Even I!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -555,15 +563,18 @@
     <sjis>
       なんだよ、もう<three_dots><end_line>
     </sjis>
+    <ascii>
+    What the hell<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、もう<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What the hell<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Translation/JE Scripts/Day 08/012_24557836_176b90c.xml
+++ b/Translation/JE Scripts/Day 08/012_24557836_176b90c.xml
@@ -17,6 +17,11 @@
       あまりウロウロしない方がいいな<three_dots><end_line>
       とにかく工房に行こう<end_line>
     </sjis>
+    <ascii>
+    I shouldn't wander around while<end_line>
+    Murno is still in danger<three_dots><end_line>
+    Let's head to the workshop.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -24,12 +29,12 @@
       あまりウロウロしない方がいいよね<three_dots><end_line>
       とにかく工房に行こう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I shouldn't wander around while<end_line>
     Murno is still in danger<three_dots><end_line>
     Let's head to the workshop.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Translation/JE Scripts/Day 08/017_24554524_176ac1c.xml
+++ b/Translation/JE Scripts/Day 08/017_24554524_176ac1c.xml
@@ -17,6 +17,11 @@
       あまりウロウロしない方がいいな<three_dots><end_line>
       とにかく工房に行こう<end_line>
     </sjis>
+    <ascii>
+    I shouldn't wander around while<end_line>
+    Murno is still in danger<three_dots><end_line>
+    Let's head to the workshop.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -24,12 +29,12 @@
       あまりウロウロしない方がいいよね<three_dots><end_line>
       とにかく工房に行こう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I shouldn't wander around while<end_line>
     Murno is still in danger<three_dots><end_line>
     Let's head to the workshop.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Translation/JE Scripts/Day 08/025_25444332_1843fec.xml
+++ b/Translation/JE Scripts/Day 08/025_25444332_1843fec.xml
@@ -29,6 +29,10 @@
       ちょっと出かけてくるんで<end_line>
       ミューノのことたのみます！<end_line>
     </sjis>
+    <ascii>
+    We'll be going out for a bit.<end_line>
+    Please take care of Murno!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -36,11 +40,11 @@
       ちょっと出かけてくるんで<end_line>
       ミューノのことたのみます！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We'll be going out for a bit.<end_line>
     Please take care of Murno!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -107,17 +111,21 @@
       <three_dots>なんか、通じ合ってるみたいだ<end_line>
       少しくやしい<three_dots><end_line>
     </sjis>
+    <ascii>
+    <three_dots>They get along well.<end_line>
+    It's a bit frustrating<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>なんか、通じ合ってるみたい<end_line>
       少しくやしい<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots>They get along well.<end_line>
     It's a bit frustrating<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -176,17 +184,21 @@
       <three_dots><end_line>
       ダメだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    <three_dots><end_line>
+    I can't do it<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots><end_line>
       ダメかぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots><end_line>
     I can't do it<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -249,15 +261,18 @@
     <sjis>
       ダメか<three_dots><end_line>
     </sjis>
+    <ascii>
+    No good<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ダメかぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No good<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -320,15 +335,18 @@
     <sjis>
       ダメか<three_dots><end_line>
     </sjis>
+    <ascii>
+    No good<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ダメかぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No good<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -391,15 +409,18 @@
     <sjis>
       ダメか<three_dots><end_line>
     </sjis>
+    <ascii>
+    No good<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ダメかぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No good<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -448,6 +469,10 @@
       アニスたちのかくれ場所を<end_line>
       さがしに行くぞ！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Time to look for Anise!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -455,9 +480,9 @@
       アニスたちのかくれ場所を<end_line>
       さがしに行こう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Time to look for Anise!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 08/026_25445996_184466c.xml
+++ b/Translation/JE Scripts/Day 08/026_25445996_184466c.xml
@@ -118,6 +118,10 @@
       情報通って？<end_line>
       はじめて聞いたぞ<end_line>
     </sjis>
+    <ascii>
+    You're an informant?<end_line>
+    Haven't heard that before.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -125,11 +129,11 @@
       情報通って？<end_line>
       はじめて聞いたよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're an informant?<end_line>
     Haven't heard that before.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -261,6 +265,11 @@
       他に手がかりもないしな～<three_dots><end_line>
       とりあえず行ってみるか<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Hmm, is that so<three_dots><end_line>
+    Well, we've got no other leads<three_dots><end_line>
+    Shall we take a look<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -268,12 +277,12 @@
       他に手がかりもないしな～<three_dots><end_line>
       とりあえず行ってみようか<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hmm, is that so<three_dots><end_line>
     Well, we've got no other leads<three_dots><end_line>
     Shall we take a look<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -465,15 +474,18 @@
     <sjis>
       気をつけてな<end_line>
     </sjis>
+    <ascii>
+    Take care.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       気をつけてね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Take care.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Translation/JE Scripts/Day 08/047_25448444_1844ffc.xml
+++ b/Translation/JE Scripts/Day 08/047_25448444_1844ffc.xml
@@ -7,6 +7,11 @@
       レミィ<end_line>
       何してんだよ？<end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    Lemmy?<end_line>
+    What are you doing here?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -14,12 +19,12 @@
       レミィ<end_line>
       何してるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     Lemmy?<end_line>
     What are you doing here?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -42,6 +47,11 @@
       ここにはアカバネって<end_line>
       コワイはぐれがすんでるって話だぜ<end_line>
     </sjis>
+    <ascii>
+    You didn't know?<end_line>
+    They say a scary Stray named<end_line>
+    Red Wing lives here.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -49,12 +59,12 @@
       ここにはアカバネって<end_line>
       コワイはぐれがすんでるって話だよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You didn't know?<end_line>
     They say a scary Stray named<end_line>
     Red Wing lives here.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -183,6 +193,11 @@
       わざわざアブナイとこで<end_line>
       鍛えてたのか<end_line>
     </sjis>
+    <ascii>
+    Oh! That's great!<end_line>
+    Deliberately training in<end_line>
+    such a dangerous place.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -190,12 +205,12 @@
       わざわざアブナイとこで<end_line>
       鍛えてたんだ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh! That's great!<end_line>
     Deliberately training in<end_line>
     such a dangerous place.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -218,6 +233,11 @@
       ずっと怒ってるのかよ<three_dots><end_line>
       ホント感じ悪いなぁ<end_line>
     </sjis>
+    <ascii>
+    What's wrong with him?<end_line>
+    Is he always that angry?<end_line>
+    He gives me a bad feeling.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -225,12 +245,12 @@
       ずっと怒ってるの？<end_line>
       ホント感じ悪いなぁ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's wrong with him?<end_line>
     Is he always that angry?<end_line>
     He gives me a bad feeling.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Day 08/050_25450092_184566c.xml
+++ b/Translation/JE Scripts/Day 08/050_25450092_184566c.xml
@@ -163,17 +163,21 @@
       やっぱ<end_line>
       たおすしかないか<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    All we can do<end_line>
+    is take them out<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       やっぱ<end_line>
       たおすしかないの<three_dots>！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     All we can do<end_line>
     is take them out<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -184,17 +188,21 @@
       なんだ？<end_line>
       見張る気ないのか？<end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    Why's it leaving?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに？<end_line>
       見張る気ないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     Why's it leaving?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Day 08/051_25457420_184730c.xml
+++ b/Translation/JE Scripts/Day 08/051_25457420_184730c.xml
@@ -20,17 +20,21 @@
       どうしたんだ、<partner>？<end_line>
       なんかあったのか？<end_line>
     </sjis>
+    <ascii>
+    What is it, <partner>?<end_line>
+    Is something there?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしたの、<partner>？<end_line>
       なんかあったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is it, <partner>?<end_line>
     Is something there?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -91,17 +95,21 @@
       どうしたんだ、<partner>？<end_line>
       なんかあったのか？<end_line>
     </sjis>
+    <ascii>
+    What is it, <partner>?<end_line>
+    Is something there?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしたの、<partner>？<end_line>
       なんかあったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is it, <partner>?<end_line>
     Is something there?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -129,17 +137,21 @@
       誰もいないぞ<end_line>
       気のせいじゃないか？<end_line>
     </sjis>
+    <ascii>
+    There's no one there.<end_line>
+    Isn't it just your imagination?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       誰もいないよ<end_line>
       気のせいじゃない？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There's no one there.<end_line>
     Isn't it just your imagination?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -177,17 +189,21 @@
       どうしたんだ、<partner>？<end_line>
       なんかあったのか？<end_line>
     </sjis>
+    <ascii>
+    What is it, <partner>?<end_line>
+    Is something there?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしたの、<partner>？<end_line>
       なんかあったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is it, <partner>?<end_line>
     Is something there?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -213,17 +229,21 @@
       誰もいないぞ<end_line>
       気のせいじゃないか？<end_line>
     </sjis>
+    <ascii>
+    There's no one there.<end_line>
+    Isn't it just your imagination?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       誰もいないよ<end_line>
       気のせいじゃない？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There's no one there.<end_line>
     Isn't it just your imagination?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -263,17 +283,21 @@
       どうしたんだ、<partner>？<end_line>
       なんかあったのか？<end_line>
     </sjis>
+    <ascii>
+    What is it, <partner>?<end_line>
+    Is something there?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしたの、<partner>？<end_line>
       なんかあったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is it, <partner>?<end_line>
     Is something there?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -300,17 +324,21 @@
       誰もいないぞ<end_line>
       気のせいじゃないか？<end_line>
     </sjis>
+    <ascii>
+    There's no one there.<end_line>
+    Isn't it just your imagination?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       誰もいないよ<end_line>
       気のせいじゃない？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There's no one there.<end_line>
     Isn't it just your imagination?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Translation/JE Scripts/Day 08/052_25458748_184783c.xml
+++ b/Translation/JE Scripts/Day 08/052_25458748_184783c.xml
@@ -18,17 +18,21 @@
       くっ<three_dots><end_line>
       キ<three_dots>キサマら<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Ugh<three_dots><end_line>
+    Y<three_dots>You guys<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       う<three_dots><end_line>
       あ<three_dots>あんたたち<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ugh<three_dots><end_line>
     Y<three_dots>You guys<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -267,13 +271,16 @@
     <sjis>
       くそっ！<end_line>
     </sjis>
+    <ascii>
+    Crap!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       このっ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Crap!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 08/053_25460412_1847ebc.xml
+++ b/Translation/JE Scripts/Day 08/053_25460412_1847ebc.xml
@@ -67,6 +67,11 @@
       はなせ！<end_line>
       はなせって！！<end_line>
     </sjis>
+    <ascii>
+    What are you doing!?<end_line>
+    Let go!<end_line>
+    Let me go!!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -74,12 +79,12 @@
       はなして！<end_line>
       はなしてよ！！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What are you doing!?<end_line>
     Let go!<end_line>
     Let me go!!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -151,7 +156,7 @@
       You, Summon Beast, quiet down.<end_line>
       If you don't,<end_line>
       the girl's neck will<three_dots><end_line>
-    </ascii> 
+    </ascii>
   </female>
 </dialogue>
 <dialogue>
@@ -201,6 +206,11 @@
       はなせ！<end_line>
       気色悪い！<end_line>
     </sjis>
+    <ascii>
+    Why you! Stop!<end_line>
+    Let me go!<end_line>
+    You're disgusting!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -208,12 +218,12 @@
       はなして！<end_line>
       気色悪い！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Why you! Stop!<end_line>
     Let me go!<end_line>
     You're disgusting!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -235,17 +245,21 @@
       い、いて<three_dots><end_line>
       いてててて！<end_line>
     </sjis>
+    <ascii>
+    O, ow<three_dots><end_line>
+    Owowowow!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       い、いた<three_dots><end_line>
       いたたたた！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     O, ow<three_dots><end_line>
     Owowowow!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -267,15 +281,18 @@
     <sjis>
       いぃってぇえ！<end_line>
     </sjis>
+    <ascii>
+    Owww!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       いぃったぁい！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Owww!<end_line>
   </ascii>
+  </female>
 </bigtext>
 <dialogue>
   <info box="right">
@@ -328,17 +345,21 @@
       な、なんだと！<end_line>
       ダレがお前なんかに<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Wh, what!?<end_line>
+    Like I'd let you<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な、なによ！<end_line>
       ダレがあんたなんかに<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wh, what!?<end_line>
     Like I'd let you<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 08/054_25846812_18a641c.xml
+++ b/Translation/JE Scripts/Day 08/054_25846812_18a641c.xml
@@ -25,15 +25,18 @@
     <sjis>
       レミィを助けに行くぞ！<end_line>
     </sjis>
+    <ascii>
+    Let's go save Lemmy!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       レミィを助けに行くよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Let's go save Lemmy!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Translation/JE Scripts/Day 08/055_25463036_18488fc.xml
+++ b/Translation/JE Scripts/Day 08/055_25463036_18488fc.xml
@@ -14,7 +14,7 @@
 	<info box="right">
 	<portrait_r entry="guilan" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			お目覚めかしら<end_line>
 			ボウヤ<three_dots>？<end_line>
 		</sjis>
@@ -22,9 +22,9 @@
       Are you awake,<end_line>
       boy<three_dots>?<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			お目覚めかしら<end_line>
 			おじょうちゃん<three_dots>？<end_line>
 		</sjis>
@@ -32,7 +32,7 @@
       Are you awake,<end_line>
       little lady<three_dots>?<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -49,48 +49,58 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			どこだ<three_dots>、ここ<three_dots><end_line>
 			いたっ<three_dots><end_line>
 			なんだ<three_dots>これ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			どこ<three_dots>、ここ<three_dots><end_line>
-			いたっ<three_dots><end_line>
-			なに<three_dots>これ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Where<three_dots>, am<three_dots><end_line>
     Ow<three_dots><end_line>
     What's<three_dots>this?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			どこ<three_dots>、ここ<three_dots><end_line>
+			いたっ<three_dots><end_line>
+			なに<three_dots>これ？<end_line>
+		</sjis>
+    <ascii>
+    Where<three_dots>, am<three_dots><end_line>
+    Ow<three_dots><end_line>
+    What's<three_dots>this?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="guilan" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			う<three_dots><end_line>
 			<partner>は<three_dots>？<end_line>
 			キサマら<partner>をドコに！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			う<three_dots><end_line>
-			<partner>は<three_dots>？<end_line>
-			あんたたち<partner>をドコに！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ugh<three_dots><end_line>
     <partner><three_dots>?<end_line>
     Where's <partner>!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			う<three_dots><end_line>
+			<partner>は<three_dots>？<end_line>
+			あんたたち<partner>をドコに！？<end_line>
+		</sjis>
+    <ascii>
+    Ugh<three_dots><end_line>
+    <partner><three_dots>?<end_line>
+    Where's <partner>!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -190,7 +200,7 @@
 	<portrait_l entry="player" eye="surprised" mouth="serious">
 	<portrait_r entry="guilan" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			あら？<end_line>
 			ボウヤ、コワイの？<end_line>
 			カワイイわね<end_line>
@@ -200,9 +210,9 @@
       Is the little boy scared?<end_line>
       How cute.<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			あら？<end_line>
 			おじょうちゃん、コワイの？<end_line>
 			カワイイわね<end_line>
@@ -212,28 +222,32 @@
       Is the little lady scared?<end_line>
       How cute.<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="guilan" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだと<three_dots><end_line>
 			ダレがコワイかよ<three_dots>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なんですって<three_dots><end_line>
-			ダレがコワイもんか<three_dots>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Shut up<three_dots><end_line>
     Of course I'm not<three_dots>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なんですって<three_dots><end_line>
+			ダレがコワイもんか<three_dots>！<end_line>
+		</sjis>
+    <ascii>
+    Shut up<three_dots><end_line>
+    Of course I'm not<three_dots>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -290,24 +304,29 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots><end_line>
 			<partner>は<three_dots><end_line>
 			ドコだ<three_dots>？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots><end_line>
-			<partner>は<three_dots><end_line>
-			ドコ<three_dots>？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots><end_line>
     <partner><three_dots><end_line>
     Where<three_dots>？<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots><end_line>
+			<partner>は<three_dots><end_line>
+			ドコ<three_dots>？<end_line>
+		</sjis>
+    <ascii>
+    <three_dots><end_line>
+    <partner><three_dots><end_line>
+    Where<three_dots>？<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -353,21 +372,25 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="guilan" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			く<three_dots>そ<three_dots><end_line>
 			ゆるさねえ、ぞ<three_dots>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そん<three_dots>な<three_dots><end_line>
-			ゆるさない、わよ<three_dots>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Damn<three_dots>you<three_dots><end_line>
     Unforgivable<three_dots>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そん<three_dots>な<three_dots><end_line>
+			ゆるさない、わよ<three_dots>！<end_line>
+		</sjis>
+    <ascii>
+    Damn<three_dots>you<three_dots><end_line>
+    Unforgivable<three_dots>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -722,24 +745,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="anise" eye="special" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			目的<three_dots>？<end_line>
 			お前、ゴヴァンの魔石を手に入れて<end_line>
 			一体なにをするつもりなんだ<three_dots>？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			目的<three_dots>？<end_line>
-			あんた、ゴヴァンの魔石を手に入れて<end_line>
-			一体なにをするつもりなの<three_dots>？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Voijin<three_dots>?<end_line>
     Once you have the Demon Stone,<end_line>
     just what are you planning to<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			目的<three_dots>？<end_line>
+			あんた、ゴヴァンの魔石を手に入れて<end_line>
+			一体なにをするつもりなの<three_dots>？<end_line>
+		</sjis>
+    <ascii>
+    Voijin<three_dots>?<end_line>
+    Once you have the Demon Stone,<end_line>
+    just what are you planning to<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -776,21 +804,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="anise" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			召喚獣から解放<three_dots>？<end_line>
 			なんだよ、それ<three_dots>？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			召喚獣から解放<three_dots>？<end_line>
-			なによ、それ<three_dots>？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Free us from Summon Beasts<three_dots>?<end_line>
     What do you mean<three_dots>?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			召喚獣から解放<three_dots>？<end_line>
+			なによ、それ<three_dots>？<end_line>
+		</sjis>
+    <ascii>
+    Free us from Summon Beasts<three_dots>?<end_line>
+    What do you mean<three_dots>?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -860,18 +892,21 @@
 	<info box="left">
 	<portrait_l entry="player" eye="surprised" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			な<three_dots>、なんだ！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			な<three_dots>、なによ！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Wha<three_dots>, what the!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			な<three_dots>、なによ！？<end_line>
+		</sjis>
+    <ascii>
+    Wha<three_dots>, what the!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">

--- a/Translation/JE Scripts/Day 08/056_25467372_18499ec.xml
+++ b/Translation/JE Scripts/Day 08/056_25467372_18499ec.xml
@@ -101,17 +101,21 @@
       お前<three_dots>？<end_line>
       どうして<three_dots><end_line>
     </sjis>
+    <ascii>
+    You<three_dots>?<end_line>
+    Why<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんた<three_dots>？<end_line>
       どうして<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You<three_dots>?<end_line>
     Why<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -241,6 +245,11 @@
       でも、オレ、ハンマーを<three_dots><end_line>
       あそこに<three_dots>、オレの武器も<three_dots><end_line>
     </sjis>
+    <ascii>
+    Thanks, but my hammer<three_dots><end_line>
+    And my weapons<three_dots><end_line>
+    I can't leave them behind.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -248,12 +257,12 @@
       でも、わたし、ハンマーを<three_dots><end_line>
       あそこに<three_dots>、わたしの武器も<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Thanks, but my hammer<three_dots><end_line>
     And my weapons<three_dots><end_line>
     I can't leave them behind.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -308,17 +317,21 @@
       ダメだ<three_dots>！<end_line>
       <partner>が<three_dots><end_line>
     </sjis>
+    <ascii>
+    No<three_dots>!<end_line>
+    <partner> is<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ダメ<three_dots>！<end_line>
       <partner>が<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No<three_dots>!<end_line>
     <partner> is<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -344,16 +357,19 @@
       <partner>をおいて<end_line>
       逃げるなんてできるもんか！<end_line>
     </sjis>
+    <ascii>
+    I can't leave <partner> behind!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner>をおいて<end_line>
       逃げるなんてできないよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I can't leave <partner> behind!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -379,17 +395,21 @@
       なっ！？<end_line>
       お前<three_dots><end_line>
     </sjis>
+    <ascii>
+    Wha!?<end_line>
+    You<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なっ！？<end_line>
       あんた<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wha!?<end_line>
     You<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Translation/JE Scripts/Day 08/057_25470140_184a4bc.xml
+++ b/Translation/JE Scripts/Day 08/057_25470140_184a4bc.xml
@@ -7,17 +7,21 @@
       <partner><end_line>
       大丈夫か！？<end_line>
     </sjis>
+    <ascii>
+    <partner>!<end_line>
+    Are you okay!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner><end_line>
       大丈夫！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner>!<end_line>
     Are you okay!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -92,17 +96,21 @@
       ヒデェことしやがる<three_dots>！<end_line>
       待ってろ！　すぐ外してやるから！<end_line>
     </sjis>
+    <ascii>
+    How could they<three_dots>!<end_line>
+    Just wait! I'll get it off!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なんてヒドイことを<three_dots>！<end_line>
       待ってて！　すぐ外してあげるから！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How could they<three_dots>!<end_line>
     Just wait! I'll get it off!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -179,6 +187,11 @@
       アイツ、ひとりでアカバネと<three_dots>！<end_line>
       とにかく出るぞ！<end_line>
     </sjis>
+    <ascii>
+    Lemmy came to save us.<end_line>
+    He's facing Red Wing alone<three_dots>!<end_line>
+    We have to leave!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -186,10 +199,10 @@
       あいつ、ひとりでアカバネと<three_dots>！<end_line>
       とにかく出るよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Lemmy came to save us.<end_line>
     He's facing Red Wing alone<three_dots>!<end_line>
     We have to leave!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 08/058_25471724_184aaec.xml
+++ b/Translation/JE Scripts/Day 08/058_25471724_184aaec.xml
@@ -16,17 +16,21 @@
       なんだ<three_dots>？<end_line>
       レミィ<three_dots><end_line>
     </sjis>
+    <ascii>
+    What was that<three_dots>?<end_line>
+    Lemmy<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに<three_dots>？<end_line>
       レミィ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that<three_dots>?<end_line>
     Lemmy<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -306,6 +310,11 @@
       今逃げるなんて<three_dots><end_line>
       そんなカッコ悪いことできるか<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    I can't do it<three_dots><end_line>
+    Running at a time like this<three_dots><end_line>
+    Like I could be so pathetic<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -313,12 +322,12 @@
       今逃げるなんて<three_dots><end_line>
       そんなカッコ悪いことしちゃ<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I can't do it<three_dots><end_line>
     Running at a time like this<three_dots><end_line>
     Like I could be so pathetic<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -388,15 +397,18 @@
     <sjis>
       決まってるだろ？<end_line>
     </sjis>
+    <ascii>
+    Isn't it obvious?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       決まってるでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Isn't it obvious?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">
@@ -405,16 +417,19 @@
       レミィをひとりにしておくワケには<end_line>
       いかないぜ！<end_line>
     </sjis>
+    <ascii>
+    I won't abandon Lemmy!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       レミィをひとりにしておくワケには<end_line>
       いかないよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I won't abandon Lemmy!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Day 08/060_25474060_184b40c.xml
+++ b/Translation/JE Scripts/Day 08/060_25474060_184b40c.xml
@@ -52,17 +52,21 @@
       すげぇ！<end_line>
       ひとりでか！？<end_line>
     </sjis>
+    <ascii>
+    Amazing!<end_line>
+    By yourself!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       すごい！<end_line>
       ひとりで！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Amazing!<end_line>
     By yourself!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -140,17 +144,21 @@
       お前<three_dots>！<end_line>
       大丈夫か！？<end_line>
     </sjis>
+    <ascii>
+    Lemmy<three_dots>!<end_line>
+    Are you okay!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちょっと<three_dots>！<end_line>
       大丈夫！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Lemmy<three_dots>!<end_line>
     Are you okay!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="simple" effect="big">

--- a/Translation/JE Scripts/Day 08/061_25475484_184b99c.xml
+++ b/Translation/JE Scripts/Day 08/061_25475484_184b99c.xml
@@ -77,6 +77,11 @@
       お前が先に戦ってくれたおかげて<end_line>
       たおせたみたいなもんだからな<end_line>
     </sjis>
+    <ascii>
+    Don't worry about that.<end_line>
+    We only won because you<end_line>
+    weakened it for us.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -84,12 +89,12 @@
       あなたが先に戦ってくれたおかげで<end_line>
       たおせたみたいなもんだからさ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't worry about that.<end_line>
     We only won because you<end_line>
     weakened it for us.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -174,6 +179,11 @@
       オレと、<partner>と<end_line>
       お前の<three_dots><end_line>
     </sjis>
+    <ascii>
+    So let's say we all helped<end_line>
+    defeat Red Wing.<end_line>
+    Me, <partner>, and you, together<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -181,12 +191,12 @@
       わたしと、<partner>と<end_line>
       あなたの<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So let's say we all helped<end_line>
     defeat Red Wing.<end_line>
     Me, <partner>, and you, together<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -221,17 +231,21 @@
       おーい！<end_line>
       こっちだー！<end_line>
     </sjis>
+    <ascii>
+    Heeey!<end_line>
+    Over here!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       おーい！<end_line>
       こっちだよー！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Heeey!<end_line>
     Over here!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="simple" effect="big">
@@ -713,17 +727,21 @@
       ち、ちょっと待て！<end_line>
       は、母って<three_dots>！？<end_line>
     </sjis>
+    <ascii>
+    Hey, wait!<end_line>
+    M-mother<three_dots>!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ち、ちょっと待って！<end_line>
       は、母って<three_dots>！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, wait!<end_line>
     M-mother<three_dots>!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 08/063_25480908_184cecc.xml
+++ b/Translation/JE Scripts/Day 08/063_25480908_184cecc.xml
@@ -16,17 +16,21 @@
       そんなわけ、あるもんか<three_dots><end_line>
       絶対に<three_dots><end_line>
     </sjis>
+    <ascii>
+    That's impossible<three_dots><end_line>
+    I'm sure<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなこと、あるわけないよ<three_dots><end_line>
       絶対に<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's impossible<three_dots><end_line>
     I'm sure<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Translation/JE Scripts/Day 08/064_25481708_184d1ec.xml
+++ b/Translation/JE Scripts/Day 08/064_25481708_184d1ec.xml
@@ -43,6 +43,11 @@
       ボスタフさんもアニスたちを捕まえるの<end_line>
       手伝ってくれるみたいだし<end_line>
     </sjis>
+    <ascii>
+    That's good to hear.<end_line>
+    It seems Bostaph is going to<end_line>
+    help capture Anise as well.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -50,12 +55,12 @@
       ボスタフさんもアニスたちを捕まえるの<end_line>
       手伝ってくれるみたいだし<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's good to hear.<end_line>
     It seems Bostaph is going to<end_line>
     help capture Anise as well.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -81,6 +86,11 @@
       結構ヒドイ目にあわされてるんだ<end_line>
       もうひとごとじゃないよ<end_line>
     </sjis>
+    <ascii>
+    It's fine! Those guys have<end_line>
+    been a pain for all of us.<end_line>
+    It's our problem too.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -88,12 +98,12 @@
       結構ヒドイ目にあわされてるんだから<end_line>
       もうひとごとじゃないよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's fine! Those guys have<end_line>
     been a pain for all of us.<end_line>
     It's our problem too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 08/065_25483164_184d79c.xml
+++ b/Translation/JE Scripts/Day 08/065_25483164_184d79c.xml
@@ -66,6 +66,11 @@
       ヒドイ目にあったもんなぁ<three_dots><end_line>
       <partner>も大丈夫か？<end_line>
     </sjis>
+    <ascii>
+    True, lots of things<end_line>
+    happened today<three_dots><end_line>
+    How are you feeling, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -73,12 +78,12 @@
       ヒドイ目にあったもんね<three_dots><end_line>
       <partner>も大丈夫？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     True, lots of things<end_line>
     happened today<three_dots><end_line>
     How are you feeling, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -203,15 +208,18 @@
     <sjis>
       アニスのヤツが言ったことも<three_dots><end_line>
     </sjis>
+    <ascii>
+    What Anise said<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       アニスが言ったことも<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What Anise said<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -235,17 +243,21 @@
       あ、いや<three_dots><end_line>
       別にいいんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah, no<three_dots><end_line>
+    It's nothing<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、ううん<three_dots><end_line>
       別にいいよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, no<three_dots><end_line>
     It's nothing<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -345,6 +357,11 @@
       ヒドイ目にあったもんなぁ<three_dots><end_line>
       <partner>も大丈夫か？<end_line>
     </sjis>
+    <ascii>
+    True, lots of things<end_line>
+    happened today<three_dots><end_line>
+    How are you feeling, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -352,12 +369,12 @@
       ヒドイ目にあったもんね<three_dots><end_line>
       <partner>も大丈夫？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     True, lots of things<end_line>
     happened today<three_dots><end_line>
     How are you feeling, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -500,15 +517,18 @@
     <sjis>
       アニスのヤツが言ったことも<three_dots><end_line>
     </sjis>
+    <ascii>
+    What Anise said<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       アニスが言ったことも<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What Anise said<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -532,17 +552,21 @@
       あ、いや<three_dots><end_line>
       別にいいんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah, no<three_dots><end_line>
+    It's nothing<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、ううん<three_dots><end_line>
       別にいいの<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, no<three_dots><end_line>
     It's nothing<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -641,6 +665,11 @@
       大丈夫なのかよ<end_line>
       結構ヒドイ目にあったんだろ？<end_line>
     </sjis>
+    <ascii>
+    Right back at you, <partner>.<end_line>
+    How are you feeling?<end_line>
+    Today's been pretty rough, right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -648,12 +677,12 @@
       大丈夫なの？<end_line>
       結構ヒドイ目にあったんでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Right back at you, <partner>.<end_line>
     How are you feeling?<end_line>
     Today's been pretty rough, right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -849,17 +878,21 @@
       あ、いや<three_dots><end_line>
       別にいいんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah, no<three_dots><end_line>
+    It's nothing<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、ううん<three_dots><end_line>
       別にいいの<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, no<three_dots><end_line>
     It's nothing<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -956,6 +989,11 @@
       ヒドイ目にあったもんなぁ<three_dots><end_line>
       <partner>も大丈夫か？<end_line>
     </sjis>
+    <ascii>
+    True, lots of things<end_line>
+    happened today<three_dots><end_line>
+    Are you okay, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -963,12 +1001,12 @@
       ヒドイ目にあったもんね<three_dots><end_line>
       <partner>も大丈夫？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     True, lots of things<end_line>
     happened today<three_dots><end_line>
     Are you okay, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1168,17 +1206,21 @@
       あ、いや<three_dots><end_line>
       別にいいんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah, no<three_dots><end_line>
+    It's nothing<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、ううん<three_dots><end_line>
       別にいいんだよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, no<three_dots><end_line>
     It's nothing<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Translation/JE Scripts/Day 08/066_25486556_184e4dc.xml
+++ b/Translation/JE Scripts/Day 08/066_25486556_184e4dc.xml
@@ -238,17 +238,21 @@
       そっか<three_dots>、そうだよね<three_dots><end_line>
       ならいいんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I see<three_dots>, of course<three_dots><end_line>
+    That's fine then<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっか<three_dots>、そうだよね<three_dots><end_line>
       ならいいの<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots>, of course<three_dots><end_line>
     That's fine then<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 08/067_25488300_184ebac.xml
+++ b/Translation/JE Scripts/Day 08/067_25488300_184ebac.xml
@@ -70,17 +70,21 @@
       今日はありがとな<end_line>
       お前のおかげで助かったぜ<end_line>
     </sjis>
+    <ascii>
+    Thanks for today.<end_line>
+    You were a big help.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今日はありがとね<end_line>
       おかげで助かったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Thanks for today.<end_line>
     You were a big help.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -103,6 +107,10 @@
       あの時、アニスたちに<end_line>
       やられてたかもしれなかったんだぜ<end_line>
     </sjis>
+    <ascii>
+    Really, if you hadn't shown up,<end_line>
+    it might have been over for me<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -110,11 +118,11 @@
       あの時、アニスたちに<end_line>
       やられてたかもしれなかったんだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Really, if you hadn't shown up,<end_line>
     it might have been over for me<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -140,6 +148,10 @@
       アカバネだってオレたちだけだったら<end_line>
       勝てたかどうか、わかんないし<end_line>
     </sjis>
+    <ascii>
+    And with Red Wing. I don't know if<end_line>
+    we could have won without you.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -147,11 +159,11 @@
       わたしたちだけだったら<end_line>
       勝てたかどうか、わからないし<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And with Red Wing. I don't know if<end_line>
     we could have won without you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -173,17 +185,21 @@
       それにボスタフさんだって<end_line>
       お前がいたから<three_dots><end_line>
     </sjis>
+    <ascii>
+    And with Bostaph.<end_line>
+    Since you were there<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       それにボスタフさんを<end_line>
       説得できたのだって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And with Bostaph.<end_line>
     Since you were there<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -205,17 +221,21 @@
       は<three_dots>？<end_line>
       どうぞ<end_line>
     </sjis>
+    <ascii>
+    Eh<three_dots>?<end_line>
+    Go ahead.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え<three_dots>？<end_line>
       どうぞ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh<three_dots>?<end_line>
     Go ahead.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -240,6 +260,11 @@
       助けられたのはオレたちの方だろ？<end_line>
       オレの話、聞いてたのか？<end_line>
     </sjis>
+    <ascii>
+    About what?<end_line>
+    You were the one who saved us.<end_line>
+    Were you listening?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -247,12 +272,12 @@
       わたしたちの方でしょ？<end_line>
       わたしの話、聞いてた？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     About what?<end_line>
     You were the one who saved us.<end_line>
     Were you listening?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -279,6 +304,11 @@
       お前にもわかってもらえて<end_line>
       ホント良かったよ！<end_line>
     </sjis>
+    <ascii>
+    Ah, right!<end_line>
+    I'm really happy<end_line>
+    that you understand now!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -286,12 +316,12 @@
       わかってもらえて<end_line>
       ホント良かったよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, right!<end_line>
     I'm really happy<end_line>
     that you understand now!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -316,6 +346,11 @@
       これからはもう少し<end_line>
       オレの言うことを信じるんだな<end_line>
     </sjis>
+    <ascii>
+    I see.<end_line>
+    I hope you'll be able to<end_line>
+    trust me a bit more after this.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -323,12 +358,12 @@
       これからはもう少し<end_line>
       わたしの言うことを信じるのね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see.<end_line>
     I hope you'll be able to<end_line>
     trust me a bit more after this.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -353,6 +388,11 @@
       素直じゃないなぁ<end_line>
       お前はいつもそんなんだから<three_dots><end_line>
     </sjis>
+    <ascii>
+    Consider it!?<end_line>
+    You aren't honest at all, huh.<end_line>
+    Because you're always like that<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -360,12 +400,12 @@
       素直じゃないなぁ<end_line>
       あんたはいつもそんなんだから<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Consider it!?<end_line>
     You aren't honest at all, huh.<end_line>
     Because you're always like that<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 08/068_25490060_184f28c.xml
+++ b/Translation/JE Scripts/Day 08/068_25490060_184f28c.xml
@@ -160,6 +160,11 @@
       弱らせてくれたから勝てたんだよ<end_line>
       くやしいけど、あいつはスゴイよ<end_line>
     </sjis>
+    <ascii>
+    Even that's because Lemmy<end_line>
+    was able to weaken it.<end_line>
+    I hate to admit it, but he's great.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -167,12 +172,12 @@
       弱らせてくれたから勝てたんだ<three_dots><end_line>
       くやしいけど、あいつはスゴイよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Even that's because Lemmy<end_line>
     was able to weaken it.<end_line>
     I hate to admit it, but he's great.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 08/069_25491564_184f86c.xml
+++ b/Translation/JE Scripts/Day 08/069_25491564_184f86c.xml
@@ -125,15 +125,18 @@
     <sjis>
       その言い方はやめろ！<end_line>
     </sjis>
+    <ascii>
+    Stop talking like that!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       その言い方はやめて！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Stop talking like that!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 08/24587596_1772d4c.xml
+++ b/Translation/JE Scripts/Day 08/24587596_1772d4c.xml
@@ -4,24 +4,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			今日は話し合いだ<end_line>
 			金の派閥に行かなきゃ<end_line>
 			がんばるぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今日は話し合いだよ<end_line>
-			金の派閥に行かなきゃ<end_line>
-			がんばるぞ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Today's the day for our<end_line>
     meeting at the Gold Council.<end_line>
     I'll do my best!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今日は話し合いだよ<end_line>
+			金の派閥に行かなきゃ<end_line>
+			がんばるぞ！<end_line>
+		</sjis>
+    <ascii>
+    Today's the day for our<end_line>
+    meeting at the Gold Council.<end_line>
+    I'll do my best!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -41,21 +46,25 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			<partner>はたよりに<end_line>
 			ならないみたいだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<partner>はたよりに<end_line>
-			ならないみたい<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Looks like I can't<end_line>
     rely on <partner> this time.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<partner>はたよりに<end_line>
+			ならないみたい<end_line>
+		</sjis>
+    <ascii>
+    Looks like I can't<end_line>
+    rely on <partner> this time.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -63,24 +72,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			今日は話し合いだ<end_line>
 			金の派閥に行かなきゃ<end_line>
 			がんばるぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今日は話し合いだよ<end_line>
-			金の派閥に行かなきゃ<end_line>
-			がんばるぞ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Today's the day for our<end_line>
     meeting at the Gold Council.<end_line>
     I'll do my best!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今日は話し合いだよ<end_line>
+			金の派閥に行かなきゃ<end_line>
+			がんばるぞ！<end_line>
+		</sjis>
+    <ascii>
+    Today's the day for our<end_line>
+    meeting at the Gold Council.<end_line>
+    I'll do my best!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -134,24 +148,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			今日は話し合いだ<end_line>
 			金の派閥に行かなきゃ<end_line>
 			がんばるぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今日は話し合いだよ<end_line>
-			金の派閥に行かなきゃ<end_line>
-			がんばるぞ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Today's the day for our<end_line>
     meeting at the Gold Council.<end_line>
     I'll do my best!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今日は話し合いだよ<end_line>
+			金の派閥に行かなきゃ<end_line>
+			がんばるぞ！<end_line>
+		</sjis>
+    <ascii>
+    Today's the day for our<end_line>
+    meeting at the Gold Council.<end_line>
+    I'll do my best!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -173,42 +192,50 @@
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、それ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ！<end_line>
+		</sjis>
+    <ascii>
+    Hey!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			今日は話し合いだ<end_line>
 			金の派閥に行かなきゃ<end_line>
 			がんばるぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今日は話し合いだよ<end_line>
-			金の派閥に行かなきゃ<end_line>
-			がんばるぞ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Today's the day for our<end_line>
     meeting at the Gold Council.<end_line>
     I'll do my best!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今日は話し合いだよ<end_line>
+			金の派閥に行かなきゃ<end_line>
+			がんばるぞ！<end_line>
+		</sjis>
+    <ascii>
+    Today's the day for our<end_line>
+    meeting at the Gold Council.<end_line>
+    I'll do my best!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -230,18 +257,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			なんかズレてないか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なんかズレてない？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Isn't that beside the point?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なんかズレてない？<end_line>
+		</sjis>
+    <ascii>
+    Isn't that beside the point?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -249,24 +279,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			今日は話し合いだ<end_line>
 			金の派閥に行かなきゃ<end_line>
 			がんばるぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今日は話し合いだよ<end_line>
-			金の派閥に行かなきゃ<end_line>
-			がんばるぞ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Today's the day for our<end_line>
     meeting at the Gold Council.<end_line>
     I'll do my best!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今日は話し合いだよ<end_line>
+			金の派閥に行かなきゃ<end_line>
+			がんばるぞ！<end_line>
+		</sjis>
+    <ascii>
+    Today's the day for our<end_line>
+    meeting at the Gold Council.<end_line>
+    I'll do my best!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -286,21 +321,25 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			<partner>はたよりに<end_line>
 			ならないみたいだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<partner>はたよりに<end_line>
-			ならないみたい<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Looks like I can't<end_line>
     rely on <partner> this time.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<partner>はたよりに<end_line>
+			ならないみたい<end_line>
+		</sjis>
+    <ascii>
+    Looks like I can't<end_line>
+    rely on <partner> this time.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -308,24 +347,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			今日は話し合いだ<end_line>
 			金の派閥に行かなきゃ<end_line>
 			がんばるぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今日は話し合いだよ<end_line>
-			金の派閥に行かなきゃ<end_line>
-			がんばるぞ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Today's the day for our<end_line>
     meeting at the Gold Council.<end_line>
     I'll do my best!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今日は話し合いだよ<end_line>
+			金の派閥に行かなきゃ<end_line>
+			がんばるぞ！<end_line>
+		</sjis>
+    <ascii>
+    Today's the day for our<end_line>
+    meeting at the Gold Council.<end_line>
+    I'll do my best!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -379,24 +423,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			今日は話し合いだ<end_line>
 			金の派閥に行かなきゃ<end_line>
 			がんばるぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今日は話し合いだよ<end_line>
-			金の派閥に行かなきゃ<end_line>
-			がんばるぞ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Today's the day for our<end_line>
     meeting at the Gold Council.<end_line>
     I'll do my best!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今日は話し合いだよ<end_line>
+			金の派閥に行かなきゃ<end_line>
+			がんばるぞ！<end_line>
+		</sjis>
+    <ascii>
+    Today's the day for our<end_line>
+    meeting at the Gold Council.<end_line>
+    I'll do my best!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -418,42 +467,50 @@
 	<portrait_l entry="player" eye="happy" mouth="stressed">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、それ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ！<end_line>
+		</sjis>
+    <ascii>
+    Hey!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			今日は話し合いだ<end_line>
 			金の派閥に行かなきゃ<end_line>
 			がんばるぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			今日は話し合いだよ<end_line>
-			金の派閥に行かなきゃ<end_line>
-			がんばるぞ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Today's the day for our<end_line>
     meeting at the Gold Council.<end_line>
     I'll do my best!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			今日は話し合いだよ<end_line>
+			金の派閥に行かなきゃ<end_line>
+			がんばるぞ！<end_line>
+		</sjis>
+    <ascii>
+    Today's the day for our<end_line>
+    meeting at the Gold Council.<end_line>
+    I'll do my best!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -475,18 +532,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			なんかズレてないか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なんかズレてない？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Isn't that beside the point?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なんかズレてない？<end_line>
+		</sjis>
+    <ascii>
+    Isn't that beside the point?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -520,24 +580,29 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="murno" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なに言ってるんだ<end_line>
 			ミューノは魔石を守るんだろ？<end_line>
 			立派に役に立ってるよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なに言ってるの<end_line>
-			ミューノは魔石を守ってるし<end_line>
-			立派に役に立ってるって！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You're not! You're protecting<end_line>
     the Demon Stone, right?<end_line>
     That's really important!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なに言ってるの<end_line>
+			ミューノは魔石を守ってるし<end_line>
+			立派に役に立ってるって！<end_line>
+		</sjis>
+    <ascii>
+    You're not! You're protecting<end_line>
+    the Demon Stone, right?<end_line>
+    That's really important!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">

--- a/Translation/JE Scripts/Day 08/24589212_177339c.xml
+++ b/Translation/JE Scripts/Day 08/24589212_177339c.xml
@@ -36,24 +36,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			うん！<end_line>
 			どんな手がかりも<end_line>
 			見落とさないぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん！<end_line>
-			どんな手がかりも<end_line>
-			見落とさないんだから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
     Keep your eyes peeled!<end_line>
     We can't miss a thing!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん！<end_line>
+			どんな手がかりも<end_line>
+			見落とさないんだから！<end_line>
+		</sjis>
+    <ascii>
+    Right!<end_line>
+    Keep your eyes peeled!<end_line>
+    We can't miss a thing!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -93,24 +98,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			うん！<end_line>
 			どんな手がかりも<end_line>
 			見落とさないぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん！<end_line>
-			どんな手がかりも<end_line>
-			見落とさないんだから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
     Keep your eyes peeled!<end_line>
     We can't miss a thing!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん！<end_line>
+			どんな手がかりも<end_line>
+			見落とさないんだから！<end_line>
+		</sjis>
+    <ascii>
+    Right!<end_line>
+    Keep your eyes peeled!<end_line>
+    We can't miss a thing!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -150,24 +160,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			うん！<end_line>
 			どんな手がかりも<end_line>
 			見落とさないぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん！<end_line>
-			どんな手がかりも<end_line>
-			見落とさないんだから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
     Keep your eyes peeled!<end_line>
     We can't miss a thing!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん！<end_line>
+			どんな手がかりも<end_line>
+			見落とさないんだから！<end_line>
+		</sjis>
+    <ascii>
+    Right!<end_line>
+    Keep your eyes peeled!<end_line>
+    We can't miss a thing!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -204,24 +219,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			うん！<end_line>
 			どんな手がかりも<end_line>
 			見落とさないぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん！<end_line>
-			どんな手がかりも<end_line>
-			見落とさないんだから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
     Keep your eyes peeled!<end_line>
     We can't miss a thing!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん！<end_line>
+			どんな手がかりも<end_line>
+			見落とさないんだから！<end_line>
+		</sjis>
+    <ascii>
+    Right!<end_line>
+    Keep your eyes peeled!<end_line>
+    We can't miss a thing!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -229,24 +249,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスたちはスレンジ採掘場の<end_line>
 			どこかにいるみたいだ<end_line>
 			さがしに行こう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスたちはスレンジ採掘場の<end_line>
-			どこかにいるみたいだよ<end_line>
-			さがしに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise seems to be hiding<end_line>
     somewhere in Slenj Mine.<end_line>
     Let's check it out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスたちはスレンジ採掘場の<end_line>
+			どこかにいるみたいだよ<end_line>
+			さがしに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Anise seems to be hiding<end_line>
+    somewhere in Slenj Mine.<end_line>
+    Let's check it out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -282,24 +307,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスたちはスレンジ採掘場の<end_line>
 			どこかにいるみたいだ<end_line>
 			さがしに行こう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスたちはスレンジ採掘場の<end_line>
-			どこかにいるみたいだよ<end_line>
-			さがしに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise seems to be hiding<end_line>
     somewhere in Slenj Mine.<end_line>
     Let's check it out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスたちはスレンジ採掘場の<end_line>
+			どこかにいるみたいだよ<end_line>
+			さがしに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Anise seems to be hiding<end_line>
+    somewhere in Slenj Mine.<end_line>
+    Let's check it out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -363,24 +393,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスたちはスレンジ採掘場の<end_line>
 			どこかにいるみたいだ<end_line>
 			さがしに行こう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスたちはスレンジ採掘場の<end_line>
-			どこかにいるみたいだよ<end_line>
-			さがしに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise seems to be hiding<end_line>
     somewhere in Slenj Mine.<end_line>
     Let's check it out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスたちはスレンジ採掘場の<end_line>
+			どこかにいるみたいだよ<end_line>
+			さがしに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Anise seems to be hiding<end_line>
+    somewhere in Slenj Mine.<end_line>
+    Let's check it out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -415,24 +450,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			アニスたちはスレンジ採掘場の<end_line>
 			どこかにいるみたいだ<end_line>
 			さがしに行こう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスたちはスレンジ採掘場の<end_line>
-			どこかにいるみたいだよ<end_line>
-			さがしに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise seems to be hiding<end_line>
     somewhere in Slenj Mine.<end_line>
     Let's check it out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスたちはスレンジ採掘場の<end_line>
+			どこかにいるみたいだよ<end_line>
+			さがしに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Anise seems to be hiding<end_line>
+    somewhere in Slenj Mine.<end_line>
+    Let's check it out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -466,24 +506,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスたちはスレンジ採掘場の<end_line>
 			どこかにいるみたいだ<end_line>
 			さがしに行こう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスたちはスレンジ採掘場の<end_line>
-			どこかにいるみたいだよ<end_line>
-			さがしに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise seems to be hiding<end_line>
     somewhere in Slenj Mine.<end_line>
     Let's check it out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスたちはスレンジ採掘場の<end_line>
+			どこかにいるみたいだよ<end_line>
+			さがしに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Anise seems to be hiding<end_line>
+    somewhere in Slenj Mine.<end_line>
+    Let's check it out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -519,24 +564,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスたちはスレンジ採掘場の<end_line>
 			どこかにいるみたいだ<end_line>
 			さがしに行こう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスたちはスレンジ採掘場の<end_line>
-			どこかにいるみたいだよ<end_line>
-			さがしに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise seems to be hiding<end_line>
     somewhere in Slenj Mine.<end_line>
     Let's check it out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスたちはスレンジ採掘場の<end_line>
+			どこかにいるみたいだよ<end_line>
+			さがしに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Anise seems to be hiding<end_line>
+    somewhere in Slenj Mine.<end_line>
+    Let's check it out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -600,24 +650,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスたちはスレンジ採掘場の<end_line>
 			どこかにいるみたいだ<end_line>
 			さがしに行こう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスたちはスレンジ採掘場の<end_line>
-			どこかにいるみたいだよ<end_line>
-			さがしに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise seems to be hiding<end_line>
     somewhere in Slenj Mine.<end_line>
     Let's check it out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスたちはスレンジ採掘場の<end_line>
+			どこかにいるみたいだよ<end_line>
+			さがしに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Anise seems to be hiding<end_line>
+    somewhere in Slenj Mine.<end_line>
+    Let's check it out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -652,24 +707,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			アニスたちはスレンジ採掘場の<end_line>
 			どこかにいるみたいだ<end_line>
 			さがしに行こう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスたちはスレンジ採掘場の<end_line>
-			どこかにいるみたいだよ<end_line>
-			さがしに行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise seems to be hiding<end_line>
     somewhere in Slenj Mine.<end_line>
     Let's check it out!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスたちはスレンジ採掘場の<end_line>
+			どこかにいるみたいだよ<end_line>
+			さがしに行こう！<end_line>
+		</sjis>
+    <ascii>
+    Anise seems to be hiding<end_line>
+    somewhere in Slenj Mine.<end_line>
+    Let's check it out!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -703,24 +763,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -742,21 +807,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			気をつけないと<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-			気をつけないと<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right.<end_line>
     I'll have to watch out<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+			気をつけないと<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Right.<end_line>
+    I'll have to watch out<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -764,24 +833,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -805,21 +879,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			シンチョウに行こう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-			シンチョウに行こう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right.<end_line>
     I'll be careful.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+			シンチョウに行こう<end_line>
+		</sjis>
+    <ascii>
+    Right.<end_line>
+    I'll be careful.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -827,24 +905,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -881,24 +964,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -920,21 +1008,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			シンチョウに行こう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-			シンチョウに行こう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right.<end_line>
     I'll be careful.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+			シンチョウに行こう<end_line>
+		</sjis>
+    <ascii>
+    Right.<end_line>
+    I'll be careful.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -942,24 +1034,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -997,24 +1094,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1038,24 +1140,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 			とにかくもう少し<end_line>
 			行ってみよう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<three_dots><end_line>
-			とにかくもう少し<end_line>
-			行ってみよう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
     Nothing we can do now.<end_line>
     Moving on<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<three_dots><end_line>
+			とにかくもう少し<end_line>
+			行ってみよう<end_line>
+		</sjis>
+    <ascii>
+    Right<three_dots><end_line>
+    Nothing we can do now.<end_line>
+    Moving on<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1063,24 +1170,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1129,24 +1241,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1168,24 +1285,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			がんばれ、<partner><end_line>
 			とにかくもう少し<end_line>
 			行ってみよう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			がんばって、<partner><end_line>
-			とにかくもう少し<end_line>
-			行ってみよう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     It'll be fine, <partner>!<end_line>
     Anyways, let's keep<end_line>
     going further in.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			がんばって、<partner><end_line>
+			とにかくもう少し<end_line>
+			行ってみよう<end_line>
+		</sjis>
+    <ascii>
+    It'll be fine, <partner>!<end_line>
+    Anyways, let's keep<end_line>
+    going further in.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1193,24 +1315,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1248,24 +1375,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1287,21 +1419,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			念には念を、だろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだな<end_line>
-			念には念を、でしょ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right.<end_line>
     Safety first, right?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだな<end_line>
+			念には念を、でしょ？<end_line>
+		</sjis>
+    <ascii>
+    Right.<end_line>
+    Safety first, right?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1323,24 +1459,29 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1362,21 +1503,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			ちょ<three_dots>っ！<end_line>
 			おどかすなよな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ちょっと<three_dots>！<end_line>
-			おどかさないでよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey<three_dots>!<end_line>
     Don't scare me like that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ちょっと<three_dots>！<end_line>
+			おどかさないでよ！<end_line>
+		</sjis>
+    <ascii>
+    Hey<three_dots>!<end_line>
+    Don't scare me like that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1392,24 +1537,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			やっぱりアニスたちは<end_line>
 			スレンジ採掘場にいるみたいだ<end_line>
 			奥に行ってみよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			やっぱりアニスたちは<end_line>
-			スレンジ採掘場にいるみたい<end_line>
-			奥に行ってみよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So Anise was hiding in<end_line>
     Slenj Mine after all.<end_line>
     Let's check inside!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			やっぱりアニスたちは<end_line>
+			スレンジ採掘場にいるみたい<end_line>
+			奥に行ってみよう！<end_line>
+		</sjis>
+    <ascii>
+    So Anise was hiding in<end_line>
+    Slenj Mine after all.<end_line>
+    Let's check inside!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1454,45 +1604,54 @@
 	<info box="left">
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>っ！<end_line>
 			まずは<partner>を<end_line>
 			助けにいかなきゃ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots>もうっ！<end_line>
-			まずは<partner>を<end_line>
-			助けにいかなきゃ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots>Ugh!<end_line>
     I have to save<end_line>
     <partner> first!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots>もうっ！<end_line>
+			まずは<partner>を<end_line>
+			助けにいかなきゃ<end_line>
+		</sjis>
+    <ascii>
+    <three_dots>Ugh!<end_line>
+    I have to save<end_line>
+    <partner> first!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			大丈夫か、<partner>？<end_line>
 			とにかくここから出よう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			大丈夫、<partner>？<end_line>
-			とにかくここから出よう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Are you okay, <partner>?<end_line>
     Let's get out of here!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			大丈夫、<partner>？<end_line>
+			とにかくここから出よう！<end_line>
+		</sjis>
+    <ascii>
+    Are you okay, <partner>?<end_line>
+    Let's get out of here!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1548,21 +1707,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			待ってろレミィ<end_line>
 			今行くからな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			待っててレミィ<end_line>
-			今行くから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hold on, Lemmy!<end_line>
     We'll be there soon!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			待っててレミィ<end_line>
+			今行くから！<end_line>
+		</sjis>
+    <ascii>
+    Hold on, Lemmy!<end_line>
+    We'll be there soon!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1584,21 +1747,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			待ってろレミィ<end_line>
 			今行くからな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			待っててレミィ<end_line>
-			今行くから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hold on, Lemmy!<end_line>
     We'll be there soon!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			待っててレミィ<end_line>
+			今行くから！<end_line>
+		</sjis>
+    <ascii>
+    Hold on, Lemmy!<end_line>
+    We'll be there soon!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1620,21 +1787,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			待ってろレミィ<end_line>
 			今行くからな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			待っててレミィ<end_line>
-			今行くから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hold on, Lemmy!<end_line>
     We'll be there soon!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			待っててレミィ<end_line>
+			今行くから！<end_line>
+		</sjis>
+    <ascii>
+    Hold on, Lemmy!<end_line>
+    We'll be there soon!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1655,21 +1826,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			待ってろレミィ<end_line>
 			今行くからな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			待っててレミィ<end_line>
-			今行くから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hold on, Lemmy!<end_line>
     We'll be there soon!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			待っててレミィ<end_line>
+			今行くから！<end_line>
+		</sjis>
+    <ascii>
+    Hold on, Lemmy!<end_line>
+    We'll be there soon!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">

--- a/Translation/JE Scripts/Day 09/001_25493836_185014c.xml
+++ b/Translation/JE Scripts/Day 09/001_25493836_185014c.xml
@@ -1,4 +1,3 @@
-#line 90
 <dialogue>
   <info box="left">
   <portrait_l entry="player" eye="decided" mouth="neutral">
@@ -9,6 +8,11 @@
       今日こそアニスたちを<end_line>
       とっつかまえてやるぜ！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Today is the day<end_line>
+    we catch Anise!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -16,12 +20,12 @@
       今日こそアニスたちを<end_line>
       捕まえてやるんだから！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Today is the day<end_line>
     we catch Anise!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -80,6 +84,11 @@
       アニスたちに捕まったときのこと<end_line>
       怒ってるのか？<end_line>
     </sjis>
+    <ascii>
+    What?<end_line>
+    Are you still angry about<end_line>
+    the time we were captured?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -87,12 +96,12 @@
       アニスたちに捕まったときのこと<end_line>
       怒ってるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What?<end_line>
     Are you still angry about<end_line>
     the time we were captured?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -120,6 +129,11 @@
       ま、とにかく落ちついて<end_line>
       行こうぜ<end_line>
     </sjis>
+    <ascii>
+    Really?<end_line>
+    Well, either way, calm down.<end_line>
+    Let's go.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -127,12 +141,12 @@
       ま、とにかく落ちついて<end_line>
       行こう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Really?<end_line>
     Well, either way, calm down.<end_line>
     Let's go.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -160,17 +174,21 @@
       ハラが立つのはわかるけどさ<end_line>
       あんまりムチャなことするなよ<end_line>
     </sjis>
+    <ascii>
+    I know you're angry,<end_line>
+    but don't go too crazy.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ハラが立つのはわかるけどさ<end_line>
       あんまりムチャなことしないでよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know you're angry,<end_line>
     but don't go too crazy.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -230,6 +248,11 @@
       ムチャはするなよな<end_line>
       落ちついて行こうぜ<end_line>
     </sjis>
+    <ascii>
+    Please, I'm begging you.<end_line>
+    Don't take this too far.<end_line>
+    Let's all calm down.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -237,12 +260,12 @@
       ムチャはしないでよ<end_line>
       落ちついて行こう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Please, I'm begging you.<end_line>
     Don't take this too far.<end_line>
     Let's all calm down.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -270,17 +293,21 @@
       ハラが立つのはわかるけどさ<end_line>
       あんまりムチャなことするなよ<end_line>
     </sjis>
+    <ascii>
+    I know you're angry,<end_line>
+    but don't go too crazy.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ハラが立つのはわかるけどさ<end_line>
       あんまりムチャなことしないでよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know you're angry,<end_line>
     but don't go too crazy.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -308,17 +335,21 @@
       だからムチャすんなって！<end_line>
       自警団の人もいるんだからさ<end_line>
     </sjis>
+    <ascii>
+    That's why I'm telling you!<end_line>
+    The Vigilante Corps will be there.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       だからムチャしないでって！<end_line>
       自警団の人もいるんだからさ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's why I'm telling you!<end_line>
     The Vigilante Corps will be there.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -344,6 +375,11 @@
       人手が多い方がいいんだから<end_line>
       ガマンしろよ<end_line>
     </sjis>
+    <ascii>
+    What, you don't want to?<end_line>
+    The more people helping, the better.<end_line>
+    Deal with it.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -351,12 +387,12 @@
       人手が多い方がいいんだから<end_line>
       ガマンしてよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What, you don't want to?<end_line>
     The more people helping, the better.<end_line>
     Deal with it.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -383,6 +419,11 @@
       ムチャはするなよな<end_line>
       落ちついて行こうぜ<end_line>
     </sjis>
+    <ascii>
+    Please, I'm begging you.<end_line>
+    Don't take this too far.<end_line>
+    Let's all calm down.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -390,12 +431,12 @@
       ムチャはしないでよ<end_line>
       落ちついて行こう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Please, I'm begging you.<end_line>
     Don't take this too far.<end_line>
     Let's all calm down.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -423,17 +464,21 @@
       ハラが立つのはわかるけどさ<end_line>
       あんまりムチャなことするなよ<end_line>
     </sjis>
+    <ascii>
+    I know you're angry,<end_line>
+    but don't go too crazy.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ハラが立つのはわかるけどさ<end_line>
       あんまりムチャなことしないでよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know you're angry,<end_line>
     but don't go too crazy.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -463,7 +508,7 @@
     Of course not!<end_line>
     We have to be able to hand them<end_line>
     over to the Vigilante Corps.<end_line>
-  </ascii> 
+  </ascii>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -490,6 +535,11 @@
       ムチャはするなよな<end_line>
       落ちついて行こうぜ<end_line>
     </sjis>
+    <ascii>
+    Please, I'm begging you.<end_line>
+    Don't take this too far.<end_line>
+    Let's all calm down.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -497,10 +547,10 @@
       ムチャはしないでよ<end_line>
       落ちついて行こう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Please, I'm begging you.<end_line>
     Don't take this too far.<end_line>
     Let's all calm down.<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 09/002_25495772_18508dc.xml
+++ b/Translation/JE Scripts/Day 09/002_25495772_18508dc.xml
@@ -80,15 +80,19 @@
       まったく！<end_line>
       こんな時に！<end_line>
     </sjis>
+    <ascii>
+    Oh, come on!<end_line>
+    What terrible timing!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       もう！<end_line>
       こんな時に！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, come on!<end_line>
     What terrible timing!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 09/004_25496796_1850cdc.xml
+++ b/Translation/JE Scripts/Day 09/004_25496796_1850cdc.xml
@@ -125,17 +125,21 @@
       ならないわね<three_dots>って<end_line>
       お前も来るつもりなのか？<end_line>
     </sjis>
+    <ascii>
+    Right<three_dots> wait,<end_line>
+    you're helping too?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ならないわね<three_dots>って<end_line>
       あなたも来るつもりなの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Right<three_dots> wait,<end_line>
     you're helping too?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 09/041_25502780_185243c.xml
+++ b/Translation/JE Scripts/Day 09/041_25502780_185243c.xml
@@ -65,17 +65,21 @@
       オ、オレ！？<end_line>
       オレ何もしてないぞ！<end_line>
     </sjis>
+    <ascii>
+    M-me!?<end_line>
+    I didn't do anything!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わ、わたし！？<end_line>
       わたし何もしてないよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     M-me!?<end_line>
     I didn't do anything!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 09/042_25503788_185282c.xml
+++ b/Translation/JE Scripts/Day 09/042_25503788_185282c.xml
@@ -75,13 +75,16 @@
     <sjis>
       行くぞ！<end_line>
     </sjis>
+    <ascii>
+    Here we go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       行くよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Here we go!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 09/043_25504748_1852bec.xml
+++ b/Translation/JE Scripts/Day 09/043_25504748_1852bec.xml
@@ -20,17 +20,21 @@
       平気平気<end_line>
       楽勝だぜ！<end_line>
     </sjis>
+    <ascii>
+    No worries.<end_line>
+    That was almost too easy!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       平気平気<end_line>
       楽勝だよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No worries.<end_line>
     That was almost too easy!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -54,16 +58,19 @@
       で、さっきのアニスの仲間<end_line>
       どこ行ったんだ？<end_line>
     </sjis>
+    <ascii>
+    So, where did Anise's buddies go?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       で、さっきのアニスの仲間<end_line>
       どこ行ったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     So, where did Anise's buddies go?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -100,17 +107,21 @@
       エリエまで<end_line>
       どうしたんだ！？<end_line>
     </sjis>
+    <ascii>
+    Elieze!?<end_line>
+    What's going on!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       エリエまで<end_line>
       どうしたの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Elieze!?<end_line>
     What's going on!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -376,16 +387,19 @@
       ミューノの方はオレたちに<end_line>
       まかせてくれ！<end_line>
     </sjis>
+    <ascii>
+    Leave Murno to us!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ミューノの方はわたしたちに<end_line>
       まかせて！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Leave Murno to us!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -521,17 +535,21 @@
       あ、そうか<end_line>
       それがいいよ！<end_line>
     </sjis>
+    <ascii>
+    Ah, right,<end_line>
+    that sounds good!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、そっか<end_line>
       それがいいよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, right,<end_line>
     that sounds good!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -584,17 +602,21 @@
       よっし！<end_line>
       オレたちも行こう！<end_line>
     </sjis>
+    <ascii>
+    Okay!<end_line>
+    Let's get moving!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       わたしたちも行こう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay!<end_line>
     Let's get moving!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 09/044_25508284_18539bc.xml
+++ b/Translation/JE Scripts/Day 09/044_25508284_18539bc.xml
@@ -18,16 +18,19 @@
       アイツらの手がかりが<end_line>
       見つかったのか？<end_line>
     </sjis>
+    <ascii>
+    Find any clues?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       アイツらの手がかりが<end_line>
       見つかったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Find any clues?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -51,17 +54,21 @@
       なんだって<three_dots><end_line>
       まさか、あいつひとりで？<end_line>
     </sjis>
+    <ascii>
+    Zakk<three_dots><end_line>
+    You mean, alone?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんな<three_dots><end_line>
       まさか、ザックひとりで？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Zakk<three_dots><end_line>
     You mean, alone?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -141,15 +148,19 @@
       わかった！<end_line>
       急ごう！<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+    Let's hurry!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん！<end_line>
       急ごう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
     Let's hurry!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 09/045_25509484_1853e6c.xml
+++ b/Translation/JE Scripts/Day 09/045_25509484_1853e6c.xml
@@ -7,17 +7,21 @@
       ザック！？<end_line>
       お前、どうしたんだ！？<end_line>
     </sjis>
+    <ascii>
+    Zakk!?<end_line>
+    Hey, what happened!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ザック！？<end_line>
       あなた、どうしたの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Zakk!?<end_line>
     Hey, what happened!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -192,6 +196,11 @@
       じゃあティエはザックをつれて<end_line>
       町にかえれ<end_line>
     </sjis>
+    <ascii>
+    Got it<three_dots><end_line>
+    Okay Tier, take Zakk<end_line>
+    and return to town.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -199,12 +208,12 @@
       じゃあティエはザックをつれて<end_line>
       町に戻ってて<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Got it<three_dots><end_line>
     Okay Tier, take Zakk<end_line>
     and return to town.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -227,6 +236,10 @@
       だからティエ、お前は<end_line>
       ザックをたのむ、な<end_line>
     </sjis>
+    <ascii>
+    We'll take care of the rest!<end_line>
+    So Tier, you watch over Zakk, okay?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -234,11 +247,11 @@
       だからティエ、あなたは<end_line>
       ザックをおねがい、ね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We'll take care of the rest!<end_line>
     So Tier, you watch over Zakk, okay?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -263,13 +276,16 @@
     <sjis>
       おう！<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 09/046_25511132_18544dc.xml
+++ b/Translation/JE Scripts/Day 09/046_25511132_18544dc.xml
@@ -19,17 +19,21 @@
       待っていたのか？<end_line>
       オレたちを<three_dots><end_line>
     </sjis>
+    <ascii>
+    Waiting?<end_line>
+    For us<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       待っていたの？<end_line>
       わたしたちを<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Waiting?<end_line>
     For us<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -149,6 +153,11 @@
       ミューノを助ける方が大事なんだ<end_line>
       あんたには付き合ってられないよ<end_line>
     </sjis>
+    <ascii>
+    Sorry, but right now, saving Murno<end_line>
+    is more important. We don't have<end_line>
+    time to play with you.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -156,12 +165,12 @@
       ミューノを助ける方が大事なの<end_line>
       あんたに付き合ってるヒマはないよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sorry, but right now, saving Murno<end_line>
     is more important. We don't have<end_line>
     time to play with you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -172,17 +181,21 @@
       なんだと、こぞう<three_dots><end_line>
       なめるなよ！<end_line>
     </sjis>
+    <ascii>
+    The fuck, you brat<three_dots><end_line>
+    Don't underestimate me!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なんだと、きさま<three_dots><end_line>
       なめるなよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The fuck, you brat<three_dots><end_line>
     Don't underestimate me!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -209,6 +222,11 @@
       じゃあ、お前をぶったおして<end_line>
       ミューノのとこまで案内してもらうぜ<end_line>
     </sjis>
+    <ascii>
+    Alright, fine!<end_line>
+    You'll tell us where she is,<end_line>
+    after I beat the crap out of you.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -216,12 +234,12 @@
       それじゃあ、あんたをたおして<end_line>
       ミューノのとこまで案内してもらうわ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright, fine!<end_line>
     You'll tell us where she is,<end_line>
     after I beat the crap out of you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -248,6 +266,11 @@
       お前にはまだ聞きたいことが<end_line>
       あるんだ！<end_line>
     </sjis>
+    <ascii>
+    Oh, shut up!<end_line>
+    I still have things<end_line>
+    I want to ask you!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -255,12 +278,12 @@
       あんたにはまだ聞きたいことが<end_line>
       あるのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, shut up!<end_line>
     I still have things<end_line>
     I want to ask you!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -284,16 +307,19 @@
       ザックにケガさせたのは<end_line>
       お前か？<end_line>
     </sjis>
+    <ascii>
+    Are you the one who hurt Zakk?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ザックにケガさせたのって<end_line>
       あんた？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Are you the one who hurt Zakk?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -316,13 +342,16 @@
     <sjis>
       手加減しねぇってことだ！<end_line>
     </sjis>
+    <ascii>
+    Then I won't hold back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       手加減しないってことよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Then I won't hold back!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 09/047_25512972_1854c0c.xml
+++ b/Translation/JE Scripts/Day 09/047_25512972_1854c0c.xml
@@ -8,6 +8,10 @@
       ミューノのところに<end_line>
       案内してもらうぞ！<end_line>
     </sjis>
+    <ascii>
+    Now,<end_line>
+    take me to where Murno is!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -15,11 +19,11 @@
       ミューノのところに<end_line>
       案内してもらうわよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Now,<end_line>
     take me to where Murno is!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -83,17 +87,21 @@
       ちょっと<three_dots><end_line>
       なんなんだよ、コイツ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Woah<three_dots><end_line>
+    What's up with him<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちょっと<three_dots><end_line>
       なんなのよ、コイツ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Woah<three_dots><end_line>
     What's up with him<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -169,17 +177,21 @@
       ちょ、ちょっと<three_dots>！<end_line>
       オレ<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    W-wait<three_dots>!<end_line>
+    I<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちょ、ちょっと<three_dots>！<end_line>
       わたし<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     W-wait<three_dots>!<end_line>
     I<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -438,15 +450,18 @@
     <sjis>
       オ、オレたちも行こう！<end_line>
     </sjis>
+    <ascii>
+    L-let's go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わ、わたしたちも行こう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     L-let's go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Day 09/049_25516108_185584c.xml
+++ b/Translation/JE Scripts/Day 09/049_25516108_185584c.xml
@@ -139,15 +139,18 @@
     <sjis>
       なんだと！<end_line>
     </sjis>
+    <ascii>
+    What was that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -383,6 +386,11 @@
       でも、あのギランってヤツは<end_line>
       オレにまかせて欲しいんだ<end_line>
     </sjis>
+    <ascii>
+    Sorry, Brother<three_dots><end_line>
+    But, I want you to leave<end_line>
+    that Gillan guy to me.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -390,12 +398,12 @@
       でも、あのギランって人は<end_line>
       わたしにまかせて欲しいんだ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sorry, Brother<three_dots><end_line>
     But, I want you to leave<end_line>
     that Gillan guy to me.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -446,6 +454,11 @@
       教わってないと思うんだ<end_line>
       それをアイツに証明したくて<three_dots><end_line>
     </sjis>
+    <ascii>
+    I want to prove it to them<three_dots><end_line>
+    That Master has never taught<end_line>
+    me anything wrong.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -453,12 +466,12 @@
       教わってないと思うんだ<end_line>
       それをアイツに証明したくて<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I want to prove it to them<three_dots><end_line>
     That Master has never taught<end_line>
     me anything wrong.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 09/050_25518780_18562bc.xml
+++ b/Translation/JE Scripts/Day 09/050_25518780_18562bc.xml
@@ -77,17 +77,21 @@
       さあ<end_line>
       親方にあやまれよ！<end_line>
     </sjis>
+    <ascii>
+    Go on,<end_line>
+    apologize to Master!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       さあ<end_line>
       親方にあやまってよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Go on,<end_line>
     apologize to Master!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -420,15 +424,18 @@
     <sjis>
       お、オレたちも急ごう<end_line>
     </sjis>
+    <ascii>
+    We should get going too.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしたちも急ごう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We should get going too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Day 09/051_25521372_1856cdc.xml
+++ b/Translation/JE Scripts/Day 09/051_25521372_1856cdc.xml
@@ -6,17 +6,21 @@
       見つけたぞ、アニス！<end_line>
       ミューノを返せ！<end_line>
     </sjis>
+    <ascii>
+    Found you, Anise!<end_line>
+    Let Murno go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       見つけたわよ、アニス！<end_line>
       ミューノを返して！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Found you, Anise!<end_line>
     Let Murno go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -168,6 +172,11 @@
       ミューノを返せって<end_line>
       言ってンだろ！？<end_line>
     </sjis>
+    <ascii>
+    Wait!<end_line>
+    I told you to return Murno,<end_line>
+    didn't I!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -175,12 +184,12 @@
       ミューノを返してって<end_line>
       言ってるでしょ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wait!<end_line>
     I told you to return Murno,<end_line>
     didn't I!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -340,17 +349,21 @@
       待て<three_dots><end_line>
       ミューノを返せ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Wait<three_dots><end_line>
+    Let Murno go<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       待って<three_dots><end_line>
       ミューノを返して<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wait<three_dots><end_line>
     Let Murno go<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -477,15 +490,18 @@
     <sjis>
       き<three_dots>、きっさま<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Y<three_dots> You<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ<three_dots>、あんたっ<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Y<three_dots> You<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 09/052_25524476_18578fc.xml
+++ b/Translation/JE Scripts/Day 09/052_25524476_18578fc.xml
@@ -76,17 +76,21 @@
       お前<three_dots><end_line>
       今、なにをした！？<end_line>
     </sjis>
+    <ascii>
+    Why you<three_dots><end_line>
+    What did you do!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんた<three_dots><end_line>
       今、なにをしたの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Why you<three_dots><end_line>
     What did you do!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -206,17 +210,21 @@
       アニスはオレが捕まえるから<end_line>
       親方たちは逃げたヤツらを！<end_line>
     </sjis>
+    <ascii>
+    I'll catch Anise,<end_line>
+    Master, go after the runners!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       アニスはわたしが捕まえるから<end_line>
       親方たちは逃げたふたりを！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'll catch Anise,<end_line>
     Master, go after the runners!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -506,17 +514,21 @@
       <partner><three_dots><end_line>
       いけるな？<end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots><end_line>
+    Can you do it?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <partner><three_dots><end_line>
       いけるね？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots><end_line>
     Can you do it?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -576,6 +588,10 @@
       お前はオレたちが<end_line>
       ぶっとばす！！！！！<end_line>
     </sjis>
+    <ascii>
+    Alright, prepare yourself!<end_line>
+    We're gonna destroy you!!!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -583,11 +599,11 @@
       あんたはわたしたちが<end_line>
       ぶっとばす！！！！！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright, prepare yourself!<end_line>
     We're gonna destroy you!!!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="right" effect="big">

--- a/Translation/JE Scripts/Day 09/053_25528492_18588ac.xml
+++ b/Translation/JE Scripts/Day 09/053_25528492_18588ac.xml
@@ -7,17 +7,21 @@
       さあ<end_line>
       おとなしくしろ！<end_line>
     </sjis>
+    <ascii>
+    Now,<end_line>
+    still still!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       さあ<end_line>
       おとなしくするのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Now,<end_line>
     still still!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -115,6 +119,11 @@
       これで終わりだな<end_line>
       さあ、お前も<three_dots><end_line>
     </sjis>
+    <ascii>
+    This is the end<end_line>
+    of your schemes.<end_line>
+    Come, you too<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -122,12 +131,12 @@
       これで終わりね<end_line>
       さあ、あんたも<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This is the end<end_line>
     of your schemes.<end_line>
     Come, you too<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -307,17 +316,21 @@
       てめぇ！<end_line>
       何してんだ！<end_line>
     </sjis>
+    <ascii>
+    You!<end_line>
+    What are you doing!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんたっ！<end_line>
       何するのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You!<end_line>
     What are you doing!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">

--- a/Translation/JE Scripts/Day 09/054_25531292_185939c.xml
+++ b/Translation/JE Scripts/Day 09/054_25531292_185939c.xml
@@ -57,6 +57,11 @@
       これ以上やる気なら<end_line>
       オレは、こいつを<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    The match is already over.<end_line>
+    If you still want to fight,<end_line>
+    I'll be the one<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -64,12 +69,12 @@
       これ以上やる気なら<end_line>
       わたしは、こいつを<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The match is already over.<end_line>
     If you still want to fight,<end_line>
     I'll be the one<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -211,17 +216,21 @@
       ふう<end_line>
       やったな、<partner><end_line>
     </sjis>
+    <ascii>
+    Phew.<end_line>
+    We did it, <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ふう<end_line>
       やったね、<partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Phew.<end_line>
     We did it, <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -497,6 +506,11 @@
       みんながいてくれたおかげだよ<end_line>
       レミィもありがとな<end_line>
     </sjis>
+    <ascii>
+    It's thanks to everyone that<end_line>
+    we've been able to come this far.<end_line>
+    Thank you too, Lemmy.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -504,12 +518,12 @@
       みんながいてくれたおかげだよ<end_line>
       レミィもありがとね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's thanks to everyone that<end_line>
     we've been able to come this far.<end_line>
     Thank you too, Lemmy.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -664,6 +678,11 @@
       じゃ、あとひとふんばり<end_line>
       がんばろうぜ！<end_line>
     </sjis>
+    <ascii>
+    Ah, right.<end_line>
+    Then, for this last part,<end_line>
+    let's do our best!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -671,12 +690,12 @@
       じゃ、あとひとふんばり<end_line>
       がんばろう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, right.<end_line>
     Then, for this last part,<end_line>
     let's do our best!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -686,15 +705,18 @@
     <sjis>
       な、ミューノ！<end_line>
     </sjis>
+    <ascii>
+    Right, Murno?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ね、ミューノ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Right, Murno?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -728,6 +750,11 @@
       ど、どうして<three_dots>！？<end_line>
       オレ、なんか悪いこと言った！？<end_line>
     </sjis>
+    <ascii>
+    Eh!?<end_line>
+    Wh-why<three_dots>!?<end_line>
+    Did I say something wrong!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -735,12 +762,12 @@
       ど、どうして<three_dots>！？<end_line>
       わたし、なんか悪いこと言った！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh!?<end_line>
     Wh-why<three_dots>!?<end_line>
     Did I say something wrong!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Translation/JE Scripts/Day 09/057_25536988_185a9dc.xml
+++ b/Translation/JE Scripts/Day 09/057_25536988_185a9dc.xml
@@ -57,6 +57,11 @@
       じゃあ、お父さんが元気になって<end_line>
       村に戻れるのも、もうすぐだ<end_line>
     </sjis>
+    <ascii>
+    I see, that's great.<end_line>
+    So it won't be long until<end_line>
+    you can go back to your village.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -64,12 +69,12 @@
       じゃあ、お父さんが元気になって<end_line>
       村に戻れるのも、もうすぐだね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see, that's great.<end_line>
     So it won't be long until<end_line>
     you can go back to your village.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -96,6 +101,11 @@
       魔石を戻すまでは<end_line>
       終わっていないんだぜ<end_line>
     </sjis>
+    <ascii>
+    It's not over yet.<end_line>
+    Until we return the Demon Stone,<end_line>
+    this isn't over.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -103,12 +113,12 @@
       魔石を戻すまでは<end_line>
       終わっていないんだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's not over yet.<end_line>
     Until we return the Demon Stone,<end_line>
     this isn't over.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -159,6 +169,11 @@
       オレが行きたいんだ<end_line>
       ダメだって言われてもついていくぞ<end_line>
     </sjis>
+    <ascii>
+    Sorry, Murno.<end_line>
+    I'm going with you.<end_line>
+    Even if you tell me not to.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -166,12 +181,12 @@
       わたしが行きたいんだ<end_line>
       ダメだって言われてもついていくから<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Sorry, Murno.<end_line>
     I'm going with you.<end_line>
     Even if you tell me not to.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -198,6 +213,11 @@
       ミューノと出会って色々あったなぁ<end_line>
       これまであっという間だったよ<end_line>
     </sjis>
+    <ascii>
+    Still<three_dots> Ever since we met,<end_line>
+    It's been quite a ride.<end_line>
+    Everything went by so fast.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -205,12 +225,12 @@
       ミューノと出会って色々あったね<end_line>
       これまであっという間だったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Still<three_dots> Ever since we met,<end_line>
     It's been quite a ride.<end_line>
     Everything went by so fast.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -353,6 +373,11 @@
       そんなのお安いご用さ<three_dots><end_line>
       <three_dots>って待てよ<end_line>
     </sjis>
+    <ascii>
+    Eh! Is that it?<end_line>
+    That's an easy reque<three_dots><end_line>
+    <three_dots>Hey, wait.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -360,12 +385,12 @@
       そんなのお安いご用よ<three_dots><end_line>
       <three_dots>ってちょっと待って<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh! Is that it?<end_line>
     That's an easy reque<three_dots><end_line>
     <three_dots>Hey, wait.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -446,6 +471,11 @@
       いいに決まってるじゃないか！<end_line>
       じゃ、明日いっしょに作ろう！<end_line>
     </sjis>
+    <ascii>
+    Okay okay, I was joking!<end_line>
+    Of course it's okay!<end_line>
+    Let's do it tomorrow!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -453,12 +483,12 @@
       いいに決まってるじゃないの！<end_line>
       じゃ、明日いっしょに作ろうね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Okay okay, I was joking!<end_line>
     Of course it's okay!<end_line>
     Let's do it tomorrow!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 09/058_25539052_185b1ec.xml
+++ b/Translation/JE Scripts/Day 09/058_25539052_185b1ec.xml
@@ -1,4 +1,3 @@
-#400
 <dialogue>
   <partner name="run-dor">
   <info box="nobox">
@@ -65,6 +64,11 @@
       あとはゴヴァンの魔石を戻せば<end_line>
       おしまいだな<three_dots><end_line>
     </sjis>
+    <ascii>
+    We've captured Anise,<end_line>
+    so once we return the Demon Stone,<end_line>
+    it'll be over<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -72,12 +76,12 @@
       あとはゴヴァンの魔石を戻せば<end_line>
       おしまいだね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We've captured Anise,<end_line>
     so once we return the Demon Stone,<end_line>
     it'll be over<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -103,17 +107,21 @@
       そっか<three_dots><end_line>
       よかったな、ミューノ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    Murno must be happy<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっか<three_dots><end_line>
       よかったね、ミューノ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     Murno must be happy<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -135,6 +143,11 @@
       お前と会ってから<end_line>
       いろんなことがあったな<three_dots><end_line>
     </sjis>
+    <ascii>
+    You know<three_dots><end_line>
+    Since I met you,<end_line>
+    all sorts of things have happened<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -142,12 +155,12 @@
       あなたと会ってから<end_line>
       いろんなことがあったね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You know<three_dots><end_line>
     Since I met you,<end_line>
     all sorts of things have happened<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -176,6 +189,10 @@
       鍛冶師のパートナーは<end_line>
       面白かったか？<end_line>
     </sjis>
+    <ascii>
+    How was it?<end_line>
+    Did you find it interesting?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -183,11 +200,11 @@
       鍛冶師のパートナーは<end_line>
       面白かった？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How was it?<end_line>
     Did you find it interesting?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -247,6 +264,11 @@
       <partner>の仕事はすごく正確だし<end_line>
       良い職人になれると思うけどな<end_line>
     </sjis>
+    <ascii>
+    Hmm<three_dots><end_line>
+    Your work is always so precise.<end_line>
+    I think you'd make a great smith.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -254,12 +276,12 @@
       <partner>の仕事はすごく正確だし<end_line>
       良い職人になれると思うけど<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hmm<three_dots><end_line>
     Your work is always so precise.<end_line>
     I think you'd make a great smith.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -318,6 +340,11 @@
       自分ではよくわからないんだけど<end_line>
       そうなのかな？<end_line>
     </sjis>
+    <ascii>
+    Hmm<three_dots><end_line>
+    I don't really get it myself,<end_line>
+    is that how it is?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -325,12 +352,12 @@
       自分ではよくわからないんだけど<end_line>
       そうなのかな？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hmm<three_dots><end_line>
     I don't really get it myself,<end_line>
     is that how it is?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -359,6 +386,10 @@
       <partner>にだって<end_line>
       魂はあるさ！<end_line>
     </sjis>
+    <ascii>
+    That's not true!<end_line>
+    You have a soul too, <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -366,11 +397,11 @@
       <partner>にだって<end_line>
       魂はあるよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's not true!<end_line>
     You have a soul too, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -395,6 +426,11 @@
       たまに<partner>だって怒ったり<end_line>
       するときがあるじゃないか！<end_line>
     </sjis>
+    <ascii>
+    Well<three_dots> I don't know, but<end_line>
+    sometimes, even you get angry<end_line>
+    about things, <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -402,12 +438,12 @@
       たまに<partner>だって怒ったり<end_line>
       するときがあるじゃない！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well<three_dots> I don't know, but<end_line>
     sometimes, even you get angry<end_line>
     about things, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -434,6 +470,11 @@
       そういう<partner>だから<end_line>
       オレたちは今までパートナーとして<end_line>
     </sjis>
+    <ascii>
+    I don't think that's true.<end_line>
+    It's because you do have emotions,<end_line>
+    that we've been able to get here,<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -441,12 +482,12 @@
       そういう<partner>だから<end_line>
       わたしたちは今までパートナーとして<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I don't think that's true.<end_line>
     It's because you do have emotions,<end_line>
     that we've been able to get here,<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -511,6 +552,11 @@
       あとはゴヴァンの魔石を戻せば<end_line>
       おしまいだな<three_dots><end_line>
     </sjis>
+    <ascii>
+    We've captured Anise,<end_line>
+    so once we return the Demon Stone,<end_line>
+    it'll be over<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -518,12 +564,12 @@
       あとはゴヴァンの魔石を戻せば<end_line>
       おしまいだね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We've captured Anise,<end_line>
     so once we return the Demon Stone,<end_line>
     it'll be over<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 #6
 <dialogue>
@@ -552,17 +598,21 @@
       そっか<three_dots><end_line>
       よかったな、ミューノ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    Murno must be happy<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっか<three_dots><end_line>
       よかったね、ミューノ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     Murno must be happy<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -591,6 +641,11 @@
       それにしても、お前と会ってから<end_line>
       いろんなことがあったな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Thanks, <partner><three_dots><end_line>
+    You know, since I met you,<end_line>
+    all sorts of things have happened<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -598,12 +653,12 @@
       それにしても、あなたと会ってから<end_line>
       いろんなことがあったね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Thanks, <partner><three_dots><end_line>
     You know, since I met you,<end_line>
     all sorts of things have happened<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -632,6 +687,10 @@
       鍛冶師のパートナーは<end_line>
       面白かったか？<end_line>
     </sjis>
+    <ascii>
+    How was it?<end_line>
+    Did you find it interesting?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -639,11 +698,11 @@
       鍛冶師のパートナーは<end_line>
       面白かった？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How was it?<end_line>
     Did you find it interesting?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -687,6 +746,11 @@
       オレだってお前と会ってから<end_line>
       毎日ドキドキすることばっかだったぜ<end_line>
     </sjis>
+    <ascii>
+    I feel the same way.<end_line>
+    Ever since we met, every day<end_line>
+    has been full of excitement.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -694,12 +758,12 @@
       わたしだってあなたと会ってから<end_line>
       毎日ドキドキすることばっかだったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I feel the same way.<end_line>
     Ever since we met, every day<end_line>
     has been full of excitement.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -743,6 +807,11 @@
       いつか<partner>用の武器も<end_line>
       作ってやるからな<end_line>
     </sjis>
+    <ascii>
+    Yeah, I will!<end_line>
+    One day, I'll make a weapon<end_line>
+    for you to use.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -750,12 +819,12 @@
       いつか<partner>用の武器も<end_line>
       作ってあげるからね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, I will!<end_line>
     One day, I'll make a weapon<end_line>
     for you to use.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -784,6 +853,11 @@
       魔石を戻しに行く前に<end_line>
       なんかやり残したこととかないのか？<end_line>
     </sjis>
+    <ascii>
+    That reminds me, <partner>.<end_line>
+    Before we return the Demon Stone,<end_line>
+    is there anything you'd like to do?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -791,12 +865,12 @@
       魔石を戻しに行く前に<end_line>
       なんかやり残したこととかないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That reminds me, <partner>.<end_line>
     Before we return the Demon Stone,<end_line>
     is there anything you'd like to do?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -832,17 +906,21 @@
       そ、そうなのか<three_dots><end_line>
       なんかさびしいなぁ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I-is that so<three_dots><end_line>
+    That makes me feel kinda lonely<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そ、そうなんだ<three_dots><end_line>
       なんかさびしいなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I-is that so<three_dots><end_line>
     That makes me feel kinda lonely<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -883,6 +961,11 @@
       あとはゴヴァンの魔石を戻せば<end_line>
       おしまいだな<three_dots><end_line>
     </sjis>
+    <ascii>
+    We've captured Anise,<end_line>
+    so once we return the Demon Stone,<end_line>
+    it'll be over<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -890,12 +973,12 @@
       あとはゴヴァンの魔石を戻せば<end_line>
       おしまいだね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We've captured Anise,<end_line>
     so once we return the Demon Stone,<end_line>
     it'll be over<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -923,17 +1006,21 @@
       そっか<three_dots><end_line>
       よかったな、ミューノ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    Murno must be happy<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっか<three_dots><end_line>
       よかったね、ミューノ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     Murno must be happy<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -958,6 +1045,11 @@
       お前と会ってから<end_line>
       いろんなことがあったな<three_dots><end_line>
     </sjis>
+    <ascii>
+    You know<three_dots><end_line>
+    Since I met you,<end_line>
+    all sorts of things have happened<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -965,12 +1057,12 @@
       あなたと会ってから<end_line>
       いろんなことがあったね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You know<three_dots><end_line>
     Since I met you,<end_line>
     all sorts of things have happened<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -999,6 +1091,10 @@
       鍛冶師のパートナーは<three_dots><end_line>
       やっぱイヤだったか？<end_line>
     </sjis>
+    <ascii>
+    How was it?<end_line>
+    Did you hate it after all?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1006,11 +1102,11 @@
       鍛冶師のパートナーって<three_dots><end_line>
       やっぱイヤだった？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How was it?<end_line>
     Did you hate it after all?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1039,6 +1135,11 @@
       そんなにつらかったのか<end_line>
       悪かったな<three_dots><end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    It must have been tough.<end_line>
+    Sorry<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1046,12 +1147,12 @@
       そんなにつらかったんだ<end_line>
       悪かったね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     It must have been tough.<end_line>
     Sorry<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1079,17 +1180,21 @@
       もう<three_dots><end_line>
       なんなんだよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Geez<three_dots><end_line>
+    What's with you<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       もう<three_dots><end_line>
       なんなのよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Geez<three_dots><end_line>
     What's with you<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1129,17 +1234,21 @@
       たしかにお前といると<end_line>
       問題ばっか起きたからな<end_line>
     </sjis>
+    <ascii>
+    It's true, problems seem to<end_line>
+    come up when I'm with you.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       たしかにあなたといると<end_line>
       問題ばっか起きたからね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's true, problems seem to<end_line>
     come up when I'm with you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1246,6 +1355,11 @@
       魔石を戻しに行く前に<end_line>
       なんかやり残したこととかないのか？<end_line>
     </sjis>
+    <ascii>
+    That reminds me, <partner>.<end_line>
+    Before we return the Demon Stone,<end_line>
+    is there anything you'd like to do?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1253,12 +1367,12 @@
       魔石を戻しに行く前に<end_line>
       なんかやり残したこととかないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That reminds me, <partner>.<end_line>
     Before we return the Demon Stone,<end_line>
     is there anything you'd like to do?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1294,17 +1408,21 @@
       そ、そうなのか<three_dots><end_line>
       なんかさびしいなぁ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I-is that so<three_dots><end_line>
+    That makes me feel kinda lonely<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そ、そうなんだ<three_dots><end_line>
       なんかさびしいなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I-is that so<three_dots><end_line>
     That makes me feel kinda lonely<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1341,6 +1459,11 @@
       あとはゴヴァンの魔石を戻せば<end_line>
       おしまいだな<three_dots><end_line>
     </sjis>
+    <ascii>
+    We've captured Anise,<end_line>
+    so once we return the Demon Stone,<end_line>
+    it'll be over<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1348,12 +1471,12 @@
       あとはゴヴァンの魔石を戻せば<end_line>
       おしまいだね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We've captured Anise,<end_line>
     so once we return the Demon Stone,<end_line>
     it'll be over<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1379,17 +1502,21 @@
       そっか<three_dots><end_line>
       よかったな、ミューノ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    Murno must be happy<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっか<three_dots><end_line>
       よかったね、ミューノ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     Murno must be happy<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1416,6 +1543,11 @@
       それにしても、お前と会ってから<end_line>
       いろんなことがあったな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Yeah<three_dots><end_line>
+    You know, since I met you,<end_line>
+    all sorts of things have happened<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1423,12 +1555,12 @@
       それにしても、あなたと会ってから<end_line>
       いろんなことがあったね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah<three_dots><end_line>
     You know, since I met you,<end_line>
     all sorts of things have happened<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1481,17 +1613,21 @@
       あはは<three_dots><end_line>
       そっか<three_dots>、ごめんな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ahaha<three_dots><end_line>
+    I see<three_dots> Sorry<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あはは<three_dots><end_line>
       そっか<three_dots>、ごめんね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ahaha<three_dots><end_line>
     I see<three_dots> Sorry<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1583,6 +1719,11 @@
       いつか<partner>用の武器も<end_line>
       作ってやるからな<end_line>
     </sjis>
+    <ascii>
+    Yeah, leave it to me!<end_line>
+    One day, I'll make a weapon<end_line>
+    for you to use, <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1590,12 +1731,12 @@
       いつか<partner>用の武器も<end_line>
       作ってあげるからね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, leave it to me!<end_line>
     One day, I'll make a weapon<end_line>
     for you to use, <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1620,6 +1761,11 @@
       魔石を戻しに行く前に<end_line>
       なんかやり残したこととかないのか？<end_line>
     </sjis>
+    <ascii>
+    That reminds me, <partner>.<end_line>
+    Before we return the Demon Stone,<end_line>
+    is there anything you'd like to do?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1627,12 +1773,12 @@
       魔石を戻しに行く前に<end_line>
       なんかやり残したこととかないの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That reminds me, <partner>.<end_line>
     Before we return the Demon Stone,<end_line>
     is there anything you'd like to do?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1667,17 +1813,21 @@
       そ、そうなのか<three_dots><end_line>
       なんかさびしいなぁ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I-is that so<three_dots><end_line>
+    That makes me feel kinda lonely<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そ、そうなんだ<three_dots><end_line>
       なんかさびしいなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I-is that so<three_dots><end_line>
     That makes me feel kinda lonely<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Translation/JE Scripts/Day 09/059_25543452_185c31c.xml
+++ b/Translation/JE Scripts/Day 09/059_25543452_185c31c.xml
@@ -5,15 +5,18 @@
     <sjis>
       お、ヒーロー発見！<end_line>
     </sjis>
+    <ascii>
+    Oh, there's our hero!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       お、ヒロイン発見！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, there's our hero!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -60,6 +63,11 @@
       そんなにオレのこと、ほめるなんて<end_line>
       なんだか気持ち悪いよ<end_line>
     </sjis>
+    <ascii>
+    Wait<three_dots> What's wrong, Master?<end_line>
+    It's kind of creepy for you to<end_line>
+    praise me so much.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -67,12 +75,12 @@
       そんなにわたしのこと、ほめるなんて<end_line>
       なんだか気持ち悪いよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wait<three_dots> What's wrong, Master?<end_line>
     It's kind of creepy for you to<end_line>
     praise me so much.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -127,6 +135,11 @@
       悪い男になったんだい<end_line>
       <player_nickname><three_dots><end_line>
     </sjis>
+    <ascii>
+    Since when have you been<end_line>
+    such a horrible person?<end_line>
+    <player_nickname><three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -134,12 +147,12 @@
       ヒドイ女になったんだい<end_line>
       <player_nickname><three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Since when have you been<end_line>
     such a horrible person?<end_line>
     <player_nickname><three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -149,15 +162,18 @@
     <sjis>
       なんだよ、それ<three_dots><end_line>
     </sjis>
+    <ascii>
+    What the<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What the<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 09/060_25545292_185ca4c.xml
+++ b/Translation/JE Scripts/Day 09/060_25545292_185ca4c.xml
@@ -17,17 +17,21 @@
       ホントお前はいっつも<end_line>
       いいとこに現れるよな<end_line>
     </sjis>
+    <ascii>
+    Really, you always show up<end_line>
+    at the perfect time.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あなたってホントいつも<end_line>
       いいところに現れるよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Really, you always show up<end_line>
     at the perfect time.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -209,6 +213,11 @@
       ミューノの村へは行けそうに<end_line>
       ないよな<three_dots><end_line>
     </sjis>
+    <ascii>
+    But in your condition,<end_line>
+    I don't think you'll be able to<end_line>
+    go to Murno's village<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -216,12 +225,12 @@
       ミューノの村へは行けそうに<end_line>
       ないよね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     But in your condition,<end_line>
     I don't think you'll be able to<end_line>
     go to Murno's village<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -244,6 +253,11 @@
       すっごく反対されてたじゃないか<end_line>
       行っちゃダメだって<end_line>
     </sjis>
+    <ascii>
+    Well, your mother was really<end_line>
+    against it, saying<end_line>
+    you weren't allowed to go.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -251,12 +265,12 @@
       すっごく反対されてたじゃない<end_line>
       行っちゃダメだって<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, your mother was really<end_line>
     against it, saying<end_line>
     you weren't allowed to go.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -279,6 +293,11 @@
       お母さんだってお前のこと<end_line>
       心配してるんだしさ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Doesn't matter, you say<three_dots><end_line>
+    Your mother's worrying<end_line>
+    about you, you know<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -286,12 +305,12 @@
       お母さんだってあなたのこと<end_line>
       心配してるんだしさ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Doesn't matter, you say<three_dots><end_line>
     Your mother's worrying<end_line>
     about you, you know<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -331,6 +350,11 @@
       お前、どうしてそんなに<end_line>
       ボスタフさんにこだわるんだ？<end_line>
     </sjis>
+    <ascii>
+    Bostaph this, Bostaph that<three_dots><end_line>
+    Why are you so<end_line>
+    obsessed with him?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -338,12 +362,12 @@
       どうしてそんなにボスタフさんに<end_line>
       こだわるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Bostaph this, Bostaph that<three_dots><end_line>
     Why are you so<end_line>
     obsessed with him?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 09/061_25547068_185d13c.xml
+++ b/Translation/JE Scripts/Day 09/061_25547068_185d13c.xml
@@ -263,6 +263,11 @@
       もったいぶるなよ！<end_line>
       ケチ！<end_line>
     </sjis>
+    <ascii>
+    Hey, Bro!<end_line>
+    Don't go acting all high and mighty!<end_line>
+    Stingy!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -270,12 +275,12 @@
       もったいぶらないでよ！<end_line>
       ケチ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey, Bro!<end_line>
     Don't go acting all high and mighty!<end_line>
     Stingy!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 09/062_25548636_185d75c.xml
+++ b/Translation/JE Scripts/Day 09/062_25548636_185d75c.xml
@@ -73,17 +73,21 @@
       <three_dots>って、お前<end_line>
       ついてくるつもりなのか？<end_line>
     </sjis>
+    <ascii>
+    <three_dots>Wait, you're<end_line>
+    coming too?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>って、あなた<end_line>
       ついてくるつもりなの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots>Wait, you're<end_line>
     coming too?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -203,6 +207,11 @@
       止められてたんだぜ<end_line>
       ムリしないで家にいた方がいいって<end_line>
     </sjis>
+    <ascii>
+    Even that Lemmy was<end_line>
+    dissuaded by his mother.<end_line>
+    She told him not to push himself.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -210,12 +219,12 @@
       止められてたんだよ<end_line>
       ムリしないで家にいた方がいいって<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Even that Lemmy was<end_line>
     dissuaded by his mother.<end_line>
     She told him not to push himself.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -240,15 +249,18 @@
     <sjis>
       遊びじゃないんだ！<end_line>
     </sjis>
+    <ascii>
+    This isn't a game!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       遊びじゃないの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This isn't a game!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -271,6 +283,11 @@
       両親は心配してるんだろ？<end_line>
       それなのにまた勝手にそんな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Your parents have been worried<end_line>
+    about you the whole time, right?<end_line>
+    Yet you keep running off<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -278,12 +295,12 @@
       ご両親は心配してるんでしょ？<end_line>
       それなのにまた勝手にそんな<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Your parents have been worried<end_line>
     about you the whole time, right?<end_line>
     Yet you keep running off<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -348,17 +365,21 @@
       そっか<end_line>
       両親もよろこぶとおもうぜ<end_line>
     </sjis>
+    <ascii>
+    Good, I'm sure your parents<end_line>
+    will be happy to see you.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっか<end_line>
       ご両親もよろこぶとおもうよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Good, I'm sure your parents<end_line>
     will be happy to see you.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -383,17 +404,21 @@
       ん～<three_dots>？<end_line>
       なんだよ？<end_line>
     </sjis>
+    <ascii>
+    Hmm<three_dots>?<end_line>
+    What is it?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ん～<three_dots>？<end_line>
       なによ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hmm<three_dots>?<end_line>
     What is it?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -417,6 +442,11 @@
       オレひとりでいいのか？<end_line>
       みんなでアイサツに行った方が<three_dots><end_line>
     </sjis>
+    <ascii>
+    Eh<three_dots>?<end_line>
+    Just me?<end_line>
+    It'd be better if everyone<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -424,12 +454,12 @@
       わたしひとりでいいの？<end_line>
       みんなでアイサツに行った方が<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh<three_dots>?<end_line>
     Just me?<end_line>
     It'd be better if everyone<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 09/24646252_178126c.xml
+++ b/Translation/JE Scripts/Day 09/24646252_178126c.xml
@@ -32,24 +32,29 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			それは、そうだけど<three_dots><end_line>
 			あまりムチャなことは<end_line>
 			考えないようにな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			それは、そうだけど<three_dots><end_line>
-			あまりムチャなことは<end_line>
-			考えないようにね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, yeah<three_dots><end_line>
     Don't do anything<end_line>
     too reckless.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			それは、そうだけど<three_dots><end_line>
+			あまりムチャなことは<end_line>
+			考えないようにね<end_line>
+		</sjis>
+    <ascii>
+    Well, yeah<three_dots><end_line>
+    Don't do anything<end_line>
+    too reckless.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -85,21 +90,25 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			あまりムチャなことは<end_line>
 			考えないようにな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あまりムチャなことは<end_line>
-			考えないようにね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Don't do anything<end_line>
     too crazy.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あまりムチャなことは<end_line>
+			考えないようにね<end_line>
+		</sjis>
+    <ascii>
+    Don't do anything<end_line>
+    too crazy.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -135,21 +144,25 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			あまりムチャなことは<end_line>
 			考えないようにな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あまりムチャなことは<end_line>
-			考えないようにね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Don't do anything<end_line>
     too crazy.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あまりムチャなことは<end_line>
+			考えないようにね<end_line>
+		</sjis>
+    <ascii>
+    Don't do anything<end_line>
+    too crazy.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -182,21 +195,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			あまりムチャなことは<end_line>
 			考えないようにな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あまりムチャなことは<end_line>
-			考えないようにね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Don't do anything<end_line>
     too reckless.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あまりムチャなことは<end_line>
+			考えないようにね<end_line>
+		</sjis>
+    <ascii>
+    Don't do anything<end_line>
+    too reckless.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -234,18 +251,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Right<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -295,18 +315,21 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Right<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -358,18 +381,21 @@
 	<portrait_l entry="player" eye="sad" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			わかったよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わかったわよ、もう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright, fine.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わかったわよ、もう<end_line>
+		</sjis>
+    <ascii>
+    Alright, fine.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -418,18 +444,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Right<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -478,24 +507,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノなら大丈夫だよ<end_line>
 			ベンソン親方もついてるしさ<end_line>
 			オレたちもできることをやらなきゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノなら大丈夫だよ<end_line>
-			ベンソン親方もついてるしさ<end_line>
-			わたしたちもできることをやらなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Murno will be fine.<end_line>
     Master Benson is with her.<end_line>
     We have to do what we can!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノなら大丈夫だよ<end_line>
+			ベンソン親方もついてるしさ<end_line>
+			わたしたちもできることをやらなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    Murno will be fine.<end_line>
+    Master Benson is with her.<end_line>
+    We have to do what we can!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -547,24 +581,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノなら大丈夫だよ<end_line>
 			ベンソン親方もついてるしさ<end_line>
 			オレたちもできることをやらなきゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノなら大丈夫だよ<end_line>
-			ベンソン親方もついてるしさ<end_line>
-			わたしたちもできることをやらなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Murno will be fine.<end_line>
     Master Benson is with her.<end_line>
     We have to do what we can!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノなら大丈夫だよ<end_line>
+			ベンソン親方もついてるしさ<end_line>
+			わたしたちもできることをやらなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    Murno will be fine.<end_line>
+    Master Benson is with her.<end_line>
+    We have to do what we can!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -616,24 +655,29 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノなら大丈夫だよ<end_line>
 			ベンソン親方もついてるしさ<end_line>
 			オレたちもできることをやらなきゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノなら大丈夫だよ<end_line>
-			ベンソン親方もついてるしさ<end_line>
-			わたしたちもできることをやらなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Murno will be fine.<end_line>
     Master Benson is with her.<end_line>
     We have to do what we can!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノなら大丈夫だよ<end_line>
+			ベンソン親方もついてるしさ<end_line>
+			わたしたちもできることをやらなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    Murno will be fine.<end_line>
+    Master Benson is with her.<end_line>
+    We have to do what we can!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -684,24 +728,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノなら大丈夫だよ<end_line>
 			ベンソン親方もついてるしさ<end_line>
 			オレたちもできることをやらなきゃ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノなら大丈夫だよ<end_line>
-			ベンソン親方もついてるしさ<end_line>
-			わたしたちもできることをやらなきゃ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Murno will be fine.<end_line>
     Master Benson is with her.<end_line>
     We have to do what we can!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノなら大丈夫だよ<end_line>
+			ベンソン親方もついてるしさ<end_line>
+			わたしたちもできることをやらなきゃ！<end_line>
+		</sjis>
+    <ascii>
+    Murno will be fine.<end_line>
+    Master Benson is with her.<end_line>
+    We have to do what we can!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -724,24 +773,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間がリュート岩窟に<end_line>
 			いたみたいだ！<end_line>
 			急ぐぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間がリュート岩窟に<end_line>
-			いたみたい！<end_line>
-			急ごう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise must be hiding<end_line>
     out in Lute Cave!<end_line>
     Let's go!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間がリュート岩窟に<end_line>
+			いたみたい！<end_line>
+			急ごう！<end_line>
+		</sjis>
+    <ascii>
+    Anise must be hiding<end_line>
+    out in Lute Cave!<end_line>
+    Let's go!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -763,21 +817,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よぉし！<end_line>
-			行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
     Come on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よぉし！<end_line>
+			行こう！<end_line>
+		</sjis>
+    <ascii>
+    Right!<end_line>
+    Come on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -785,24 +843,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間がリュート岩窟に<end_line>
 			いたみたいだ！<end_line>
 			急ぐぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間がリュート岩窟に<end_line>
-			いたみたい！<end_line>
-			急ごう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise must be hiding<end_line>
     out in Lute Cave!<end_line>
     Let's go!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間がリュート岩窟に<end_line>
+			いたみたい！<end_line>
+			急ごう！<end_line>
+		</sjis>
+    <ascii>
+    Anise must be hiding<end_line>
+    out in Lute Cave!<end_line>
+    Let's go!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -826,21 +889,25 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よぉし！<end_line>
-			行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
     Come on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よぉし！<end_line>
+			行こう！<end_line>
+		</sjis>
+    <ascii>
+    Right!<end_line>
+    Come on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -848,24 +915,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間がリュート岩窟に<end_line>
 			いたみたいだ！<end_line>
 			急ぐぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間がリュート岩窟に<end_line>
-			いたみたい！<end_line>
-			急ごう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise must be hiding<end_line>
     out in Lute Cave!<end_line>
     Let's go!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間がリュート岩窟に<end_line>
+			いたみたい！<end_line>
+			急ごう！<end_line>
+		</sjis>
+    <ascii>
+    Anise must be hiding<end_line>
+    out in Lute Cave!<end_line>
+    Let's go!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -887,45 +959,54 @@
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="partner" eye="special" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よぉし！<end_line>
-			行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
     Come on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よぉし！<end_line>
+			行こう！<end_line>
+		</sjis>
+    <ascii>
+    Right!<end_line>
+    Come on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間がリュート岩窟に<end_line>
 			いたみたいだ！<end_line>
 			急ぐぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間がリュート岩窟に<end_line>
-			いたみたい！<end_line>
-			急ごう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise must be hiding<end_line>
     out in Lute Cave!<end_line>
     Let's go!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間がリュート岩窟に<end_line>
+			いたみたい！<end_line>
+			急ごう！<end_line>
+		</sjis>
+    <ascii>
+    Anise must be hiding<end_line>
+    out in Lute Cave!<end_line>
+    Let's go!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -945,21 +1026,25 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			よっし！<end_line>
 			行くぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			よぉし！<end_line>
-			行こう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right!<end_line>
     Come on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			よぉし！<end_line>
+			行こう！<end_line>
+		</sjis>
+    <ascii>
+    Right!<end_line>
+    Come on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -967,24 +1052,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			スポート洞窟に入っていった<end_line>
 			アニスの仲間を追いかけよう<end_line>
 			きっとヤツらのアジトがあるはずだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			スポート洞窟に入っていった<end_line>
-			アニスの仲間を追いかけよう<end_line>
-			きっとアジトが見つかるハズよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's follow Anise's<end_line>
     comrades to Spoat Grotto.<end_line>
     Their hideout must be there.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			スポート洞窟に入っていった<end_line>
+			アニスの仲間を追いかけよう<end_line>
+			きっとアジトが見つかるハズよ<end_line>
+		</sjis>
+    <ascii>
+    Let's follow Anise's<end_line>
+    comrades to Spoat Grotto.<end_line>
+    Their hideout must be there.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1008,21 +1098,25 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			う<three_dots><end_line>
 			イタイとこ突くなぁ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			う<three_dots><end_line>
-			イタイとこ突くわね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ugh<three_dots><end_line>
     You hit where it hurts<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			う<three_dots><end_line>
+			イタイとこ突くわね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Ugh<three_dots><end_line>
+    You hit where it hurts<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1030,24 +1124,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			スポート洞窟に入っていった<end_line>
 			アニスの仲間を追いかけよう<end_line>
 			きっとヤツらのアジトがあるはずだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			スポート洞窟に入っていった<end_line>
-			アニスの仲間を追いかけよう<end_line>
-			きっとアジトが見つかるハズよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's follow Anise's<end_line>
     comrades to Spoat Grotto.<end_line>
     Their hideout must be there.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			スポート洞窟に入っていった<end_line>
+			アニスの仲間を追いかけよう<end_line>
+			きっとアジトが見つかるハズよ<end_line>
+		</sjis>
+    <ascii>
+    Let's follow Anise's<end_line>
+    comrades to Spoat Grotto.<end_line>
+    Their hideout must be there.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1071,21 +1170,25 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			また何かむずかしい言葉で<end_line>
 			責められてるぞ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			また何かむずかしい言葉で<end_line>
-			責められてる<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Again with the difficult<end_line>
     to understand phrases<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			また何かむずかしい言葉で<end_line>
+			責められてる<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Again with the difficult<end_line>
+    to understand phrases<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1093,24 +1196,29 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			スポート洞窟に入っていった<end_line>
 			アニスの仲間を追いかけよう<end_line>
 			きっとヤツらのアジトがあるはずだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			スポート洞窟に入っていった<end_line>
-			アニスの仲間を追いかけよう<end_line>
-			きっとアジトが見つかるハズよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's follow Anise's<end_line>
     comrades to Spoat Grotto.<end_line>
     Their hideout must be there.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			スポート洞窟に入っていった<end_line>
+			アニスの仲間を追いかけよう<end_line>
+			きっとアジトが見つかるハズよ<end_line>
+		</sjis>
+    <ascii>
+    Let's follow Anise's<end_line>
+    comrades to Spoat Grotto.<end_line>
+    Their hideout must be there.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1134,45 +1242,54 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			う<three_dots><end_line>
 			わかったよ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			う<three_dots><end_line>
-			わかったわよ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ugh<three_dots><end_line>
     Okay<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			う<three_dots><end_line>
+			わかったわよ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Ugh<three_dots><end_line>
+    Okay<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			スポート洞窟に入っていった<end_line>
 			アニスの仲間を追いかけよう<end_line>
 			きっとヤツらのアジトがあるはずだ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			スポート洞窟に入っていった<end_line>
-			アニスの仲間を追いかけよう<end_line>
-			きっとアジトが見つかるハズよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Let's follow Anise's<end_line>
     comrades to Spoat Grotto.<end_line>
     Their hideout must be there.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			スポート洞窟に入っていった<end_line>
+			アニスの仲間を追いかけよう<end_line>
+			きっとアジトが見つかるハズよ<end_line>
+		</sjis>
+    <ascii>
+    Let's follow Anise's<end_line>
+    comrades to Spoat Grotto.<end_line>
+    Their hideout must be there.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1194,18 +1311,21 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			まかせとけって！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			まかせといてよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Leave it to me!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			まかせといてよ！<end_line>
+		</sjis>
+    <ascii>
+    Leave it to me!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1213,24 +1333,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間がスポート洞窟の奥に<end_line>
 			逃げていったぞ！<end_line>
 			急いで追いかけよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間がスポート洞窟の奥に<end_line>
-			逃げていったよ！<end_line>
-			急いで追いかけよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise's comrades fled further<end_line>
     in to Spoat Grotto.<end_line>
     After them!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間がスポート洞窟の奥に<end_line>
+			逃げていったよ！<end_line>
+			急いで追いかけよう！<end_line>
+		</sjis>
+    <ascii>
+    Anise's comrades fled further<end_line>
+    in to Spoat Grotto.<end_line>
+    After them!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -1250,22 +1375,26 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			だ、だからオレは何もしてないって！<end_line>
 			見つかったのはオレのせいじゃない<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    H-hey, I didn't do anything!<end_line>
+    It's not my fault!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			だ、だからわたし、何もしてないよ！<end_line>
 			見つかったのはわたしのせいじゃ<end_line>
 			ないもん！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     H-hey, I didn't do anything!<end_line>
     It's not my fault!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1273,24 +1402,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間がスポート洞窟の奥に<end_line>
 			逃げていったぞ！<end_line>
 			急いで追いかけよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間がスポート洞窟の奥に<end_line>
-			逃げていったよ！<end_line>
-			急いで追いかけよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise's comrades fled further<end_line>
     in to Spoat Grotto.<end_line>
     After them!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間がスポート洞窟の奥に<end_line>
+			逃げていったよ！<end_line>
+			急いで追いかけよう！<end_line>
+		</sjis>
+    <ascii>
+    Anise's comrades fled further<end_line>
+    in to Spoat Grotto.<end_line>
+    After them!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -1312,22 +1446,26 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			だ、だからオレは何もしてないって！<end_line>
 			見つかったのはオレのせいじゃない<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    H-hey, I didn't do anything!<end_line>
+    It's not my fault!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			だ、だからわたし、何もしてないよ！<end_line>
 			見つかったのはわたしのせいじゃ<end_line>
 			ないもん！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     H-hey, I didn't do anything!<end_line>
     It's not my fault!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1335,24 +1473,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間がスポート洞窟の奥に<end_line>
 			逃げていったぞ！<end_line>
 			急いで追いかけよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間がスポート洞窟の奥に<end_line>
-			逃げていったよ！<end_line>
-			急いで追いかけよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise's comrades fled further<end_line>
     in to Spoat Grotto.<end_line>
     After them!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間がスポート洞窟の奥に<end_line>
+			逃げていったよ！<end_line>
+			急いで追いかけよう！<end_line>
+		</sjis>
+    <ascii>
+    Anise's comrades fled further<end_line>
+    in to Spoat Grotto.<end_line>
+    After them!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1374,46 +1517,55 @@
 	<portrait_l entry="player" eye="happy" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			だ、だからオレは何もしてないって！<end_line>
 			見つかったのはオレのせいじゃない<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    H-hey, I didn't do anything!<end_line>
+    It's not my fault!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			だ、だからわたし、何もしてないよ！<end_line>
 			見つかったのはわたしのせいじゃ<end_line>
 			ないもん！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     H-hey, I didn't do anything!<end_line>
     It's not my fault!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			アニスの仲間がスポート洞窟の奥に<end_line>
 			逃げていったぞ！<end_line>
 			急いで追いかけよう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			アニスの仲間がスポート洞窟の奥に<end_line>
-			逃げていったよ！<end_line>
-			急いで追いかけよう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Anise's comrades fled further<end_line>
     in to Spoat Grotto.<end_line>
     After them!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			アニスの仲間がスポート洞窟の奥に<end_line>
+			逃げていったよ！<end_line>
+			急いで追いかけよう！<end_line>
+		</sjis>
+    <ascii>
+    Anise's comrades fled further<end_line>
+    in to Spoat Grotto.<end_line>
+    After them!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1433,20 +1585,24 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			だ、だからオレは何もしてないって！<end_line>
 			見つかったのはオレのせいじゃない<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    H-hey, I didn't do anything!<end_line>
+    It's not my fault!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			だ、だからわたし、何もしてないよ！<end_line>
 			見つかったのはわたしのせいじゃ<end_line>
 			ないもん！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     H-hey, I didn't do anything!<end_line>
     It's not my fault!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 10/Jade/000_25584956_186653c.xml
+++ b/Translation/JE Scripts/Day 10/Jade/000_25584956_186653c.xml
@@ -6,17 +6,21 @@
       あれ？<end_line>
       <partner>、ドコ行くんだよ<end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    <partner>, where are you going?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あれ？<end_line>
       <partner>、ドコ行くの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     <partner>, where are you going?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -90,6 +94,11 @@
       そうだな<three_dots><end_line>
       わかったよ<end_line>
     </sjis>
+    <ascii>
+    Oh<three_dots><end_line>
+    Okay<three_dots><end_line>
+    Understood.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -97,12 +106,12 @@
       そうだね<three_dots><end_line>
       わかったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh<three_dots><end_line>
     Okay<three_dots><end_line>
     Understood.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -249,17 +258,21 @@
       オレ<three_dots><end_line>
       そのナックルと勝負したいんだ<end_line>
     </sjis>
+    <ascii>
+    I<three_dots> want to fight<end_line>
+    against those knuckles.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたし<three_dots><end_line>
       そのナックルと勝負したいの<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I<three_dots> want to fight<end_line>
     against those knuckles.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="right" effect="big">
@@ -282,6 +295,11 @@
       オレの武器がどこまで通用するか<end_line>
       知りたいんだ<end_line>
     </sjis>
+    <ascii>
+    I want to know how my<end_line>
+    weapons compare to one<end_line>
+    that Master Rob acknowledged.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -289,12 +307,12 @@
       わたしの武器がどこまで通用するか<end_line>
       知りたいの<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I want to know how my<end_line>
     weapons compare to one<end_line>
     that Master Rob acknowledged.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -374,15 +392,19 @@
       工房の前だね！<end_line>
       よっし！<end_line>
     </sjis>
+    <ascii>
+    Outside the workshop!<end_line>
+    Right!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       工房の前ね！<end_line>
       わかった！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Outside the workshop!<end_line>
     Right!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 10/Jade/002_25605740_186b66c.xml
+++ b/Translation/JE Scripts/Day 10/Jade/002_25605740_186b66c.xml
@@ -7,16 +7,19 @@
       この武器なら<end_line>
       アニキのナックルに<three_dots><end_line>
     </sjis>
+    <ascii>
+    This one should be able to do it<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       この武器なら<end_line>
       アニキのナックルに<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This one should be able to do it<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
   <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 10/Jade/003_25587836_186707c.xml
+++ b/Translation/JE Scripts/Day 10/Jade/003_25587836_186707c.xml
@@ -8,6 +8,11 @@
       大切な武器なのに<three_dots><end_line>
       ごめん<three_dots>、オレ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Br<three_dots> bro<three_dots>!<end_line>
+    Such a precious weapon, yet<three_dots><end_line>
+    Sorry<three_dots>, I<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -15,12 +20,12 @@
       大切な武器なのに<three_dots><end_line>
       ごめん<three_dots>、わたし<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Br<three_dots> bro<three_dots>!<end_line>
     Such a precious weapon, yet<three_dots><end_line>
     Sorry<three_dots>, I<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -31,17 +36,21 @@
       どうしたんだよ、アニキ<end_line>
       ちょっと動きがおかしかった<three_dots><end_line>
     </sjis>
+    <ascii>
+    What's wrong, Bro?<end_line>
+    You're acting strange<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしたの、アニキ<end_line>
       ちょっと動きがおかしかったよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's wrong, Bro?<end_line>
     You're acting strange<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -64,6 +73,11 @@
       そんな<three_dots>、オレ<three_dots><end_line>
       こわすつもりなんて<three_dots><end_line>
     </sjis>
+    <ascii>
+    Uwah!<end_line>
+    But<three_dots>, I<three_dots><end_line>
+    I didn't mean to break it<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -71,12 +85,12 @@
       そんな<three_dots>、わたし<three_dots><end_line>
       こわすつもりなんて<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uwah!<end_line>
     But<three_dots>, I<three_dots><end_line>
     I didn't mean to break it<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -131,6 +145,11 @@
       それって<three_dots><end_line>
       オレが<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah<three_dots>, Bro<three_dots><end_line>
+    You mean<three_dots><end_line>
+    That I<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -138,12 +157,12 @@
       それって<three_dots><end_line>
       わたし<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah<three_dots>, Bro<three_dots><end_line>
     You mean<three_dots><end_line>
     That I<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -249,15 +268,18 @@
     <sjis>
       へへ<end_line>
     </sjis>
+    <ascii>
+    Heheh.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       えへへ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Heheh.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="nobox">

--- a/Translation/JE Scripts/Day 10/Lemmy/000_25577756_186491c.xml
+++ b/Translation/JE Scripts/Day 10/Lemmy/000_25577756_186491c.xml
@@ -6,17 +6,21 @@
       あれ？<end_line>
       <partner>、ドコ行くんだよ<end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    <partner>, where are you going?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あれ？<end_line>
       <partner>、ドコ行くの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     <partner>, where are you going?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -90,6 +94,11 @@
       そうだな<three_dots><end_line>
       わかったよ<end_line>
     </sjis>
+    <ascii>
+    Oh<three_dots><end_line>
+    Okay<three_dots><end_line>
+    Understood.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -97,12 +106,12 @@
       そうだね<three_dots><end_line>
       わかったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh<three_dots><end_line>
     Okay<three_dots><end_line>
     Understood.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <player gender="male">
@@ -173,7 +182,7 @@
     わたしはわたしでミューノの村へ行く<end_line>
     準備をすすめておこう<end_line>
   </sjis>
-   <ascii>
+  <ascii>
     Oh well.<end_line>
     I need to get my own<end_line>
     things ready too.<end_line>

--- a/Translation/JE Scripts/Day 10/Lemmy/001_25579084_1864e4c.xml
+++ b/Translation/JE Scripts/Day 10/Lemmy/001_25579084_1864e4c.xml
@@ -6,17 +6,21 @@
       あれ<three_dots>？<end_line>
       何やってんだ？<end_line>
     </sjis>
+    <ascii>
+    Huh<three_dots>?<end_line>
+    What's going on?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あれ<three_dots>？<end_line>
       何やってんだろ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh<three_dots>?<end_line>
     What's going on?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -151,6 +155,11 @@
       普通、心配するだろ？<end_line>
       母親だぜ？<end_line>
     </sjis>
+    <ascii>
+    It's normal to worry when your<end_line>
+    child might be in danger, isn't it?<end_line>
+    That's what a mother does.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -158,12 +167,12 @@
       普通、心配するでしょ？<end_line>
       母親だよ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's normal to worry when your<end_line>
     child might be in danger, isn't it?<end_line>
     That's what a mother does.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -190,6 +199,11 @@
       <partner>がいなくたって<end_line>
       オレは<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    What's that!?<end_line>
+    Even without <partner>,<end_line>
+    I'm<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -197,12 +211,12 @@
       <partner>がいなくたって<end_line>
       わたしは<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's that!?<end_line>
     Even without <partner>,<end_line>
     I'm<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -242,6 +256,11 @@
       オレひとりだってお前くらい<end_line>
       たおせるさ！<end_line>
     </sjis>
+    <ascii>
+    Well, look who's talking!<end_line>
+    I could beat someone like<end_line>
+    you alone, easy!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -249,12 +268,12 @@
       わたしひとりだってあんたくらい<end_line>
       たおしてみせるわ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, look who's talking!<end_line>
     I could beat someone like<end_line>
     you alone, easy!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -281,6 +300,11 @@
       一度お前とは１対１で<end_line>
       勝負してみたかったんだ！<end_line>
     </sjis>
+    <ascii>
+    Shut up!<end_line>
+    I've always wanted to fight you,<end_line>
+    one on one!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -288,12 +312,12 @@
       一度あんたとは１対１で<end_line>
       勝負してみたかったのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Shut up!<end_line>
     I've always wanted to fight you,<end_line>
     one on one!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -371,6 +395,11 @@
       わかった<end_line>
       待ってろよ！<end_line>
     </sjis>
+    <ascii>
+    The North Gate.<end_line>
+    Okay!<end_line>
+    I'll be there!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -378,10 +407,10 @@
       わかったわ<end_line>
       待ってなさいよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The North Gate.<end_line>
     Okay!<end_line>
     I'll be there!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 10/Lemmy/003_25606508_186b96c.xml
+++ b/Translation/JE Scripts/Day 10/Lemmy/003_25606508_186b96c.xml
@@ -3,18 +3,21 @@
 	<portrait_l entry="player" eye="serious" mouth="tense">
 	<portrait_r entry="zakk" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			お前、ケガは大丈夫なのか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あなた、ケガは大丈夫なの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey, how are your wounds?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あなた、ケガは大丈夫なの？<end_line>
+		</sjis>
+    <ascii>
+    Hey, how are your wounds?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -34,21 +37,25 @@
 	<portrait_l entry="player" eye="serious" mouth="talk">
 	<portrait_r entry="zakk" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			良かった<three_dots><end_line>
 			みんな心配してたぞ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			良かった<three_dots><end_line>
-			みんな心配してたよ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Thank goodness<three_dots><end_line>
     Everyone was worried.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			良かった<three_dots><end_line>
+			みんな心配してたよ<end_line>
+		</sjis>
+    <ascii>
+    Thank goodness<three_dots><end_line>
+    Everyone was worried.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -68,24 +75,29 @@
 	<portrait_l entry="player" eye="serious" mouth="neutral">
 	<portrait_r entry="zakk" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			お前があやまることないよ<end_line>
 			でも、今度からはあんまり<end_line>
 			ムチャなことすんなよな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あなたがあやまることないよ<end_line>
-			でも、今度からはあんまり<end_line>
-			ムチャなことしないでね！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You don't need to apologize.<end_line>
     But make sure not to do<end_line>
     anything too reckless from now on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あなたがあやまることないよ<end_line>
+			でも、今度からはあんまり<end_line>
+			ムチャなことしないでね！<end_line>
+		</sjis>
+    <ascii>
+    You don't need to apologize.<end_line>
+    But make sure not to do<end_line>
+    anything too reckless from now on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">

--- a/Translation/JE Scripts/Day 10/Lemmy/005_25604908_186b32c.xml
+++ b/Translation/JE Scripts/Day 10/Lemmy/005_25604908_186b32c.xml
@@ -58,15 +58,19 @@
       なんだと<three_dots><end_line>
       行くぞ！<end_line>
     </sjis>
+    <ascii>
+    Oh, shut up<three_dots><end_line>
+    Here I come!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なんですって<three_dots><end_line>
       行っくぞー！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, shut up<three_dots><end_line>
     Here I come!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 10/Lemmy/006_25581884_186593c.xml
+++ b/Translation/JE Scripts/Day 10/Lemmy/006_25581884_186593c.xml
@@ -23,6 +23,11 @@
       迷ってちゃ<end_line>
       いい勝負はできないぜ<end_line>
     </sjis>
+    <ascii>
+    You know<three_dots><end_line>
+    If you hesitate,<end_line>
+    we can't have a good fight.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -30,12 +35,12 @@
       そんな風に迷ってたら<end_line>
       いい勝負はできないよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You know<three_dots><end_line>
     If you hesitate,<end_line>
     we can't have a good fight.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -60,6 +65,11 @@
       勝負に集中してないっていうか<three_dots><end_line>
       アレだろ？　母親のことだろ？<end_line>
     </sjis>
+    <ascii>
+    How should I put this<three_dots><end_line>
+    It's like you can't focus<three_dots><end_line>
+    It's that, isn't it? Your mother?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -67,12 +77,12 @@
       勝負に集中してないっていうか<three_dots><end_line>
       アレでしょ？　お母さんのことでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How should I put this<three_dots><end_line>
     It's like you can't focus<three_dots><end_line>
     It's that, isn't it? Your mother?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -97,6 +107,11 @@
       悩みがあんなら話してみろよ<end_line>
       スッキリするかもしれないぜ？<end_line>
     </sjis>
+    <ascii>
+    Why dont you try talking<end_line>
+    about your troubles?<end_line>
+    It might make you feel better.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -104,12 +119,12 @@
       悩みがあるなら話してみない？<end_line>
       スッキリするかもしれないよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Why dont you try talking<end_line>
     about your troubles?<end_line>
     It might make you feel better.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -131,17 +146,21 @@
       んで、スッキリしたら<end_line>
       もう１回勝負だ！<end_line>
     </sjis>
+    <ascii>
+    And once you're feeling better,<end_line>
+    we'll have another match!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       それでスッキリしたら<end_line>
       もう１回勝負よ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And once you're feeling better,<end_line>
     we'll have another match!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -183,6 +202,11 @@
       お前は鍛冶職人の修行だろ？<end_line>
       どうしてだよ？<end_line>
     </sjis>
+    <ascii>
+    But look, your mother's a Summoner,<end_line>
+    and you're training as a smithy?<end_line>
+    Isn't that odd?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -190,12 +214,12 @@
       どうして鍛冶職人の修行してるの？<end_line>
       ヘンじゃない？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     But look, your mother's a Summoner,<end_line>
     and you're training as a smithy?<end_line>
     Isn't that odd?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -222,6 +246,10 @@
       だからお前も全部話しちまえば<end_line>
       いいんだよ<end_line>
     </sjis>
+    <ascii>
+    Is that so?<end_line>
+    See, it's okay to be open!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -229,11 +257,11 @@
       だからあなたも全部話しちゃえば<end_line>
       いいのよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Is that so?<end_line>
     See, it's okay to be open!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -591,6 +619,10 @@
       なんでそんな風に言えるんだよ？<end_line>
       お母さんからそう聞いたのか？<end_line>
     </sjis>
+    <ascii>
+    And how can you be so sure?<end_line>
+    You didn't ask her, did you?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -598,11 +630,11 @@
       お母さんからそう聞いたワケじゃ<end_line>
       ないんでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     And how can you be so sure?<end_line>
     You didn't ask her, did you?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -902,7 +934,7 @@
     I hate to admit it, but it's<end_line>
     as you said. I do feel better.<end_line>
     But the match will have to wait<three_dots><end_line>
-  </ascii>  
+  </ascii>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 10/Murno/000_25551612_185e2fc.xml
+++ b/Translation/JE Scripts/Day 10/Murno/000_25551612_185e2fc.xml
@@ -405,17 +405,21 @@
       どうしたんだよ、ミューノ<end_line>
       今日はなんかヘンだよ<end_line>
     </sjis>
+    <ascii>
+    What's wrong, Murno?<end_line>
+    You're acting strange.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どうしたのよ、ミューノ<end_line>
       今日はなんかヘンだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's wrong, Murno?<end_line>
     You're acting strange.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 10/Murno/001_25553356_185e9cc.xml
+++ b/Translation/JE Scripts/Day 10/Murno/001_25553356_185e9cc.xml
@@ -76,17 +76,21 @@
       ちょっと<three_dots>本当に<end_line>
       本気、なのか<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Murno<three_dots><end_line>
+    Are you sure<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちょっと<three_dots>本当に<end_line>
       本気、なの<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Murno<three_dots><end_line>
     Are you sure<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -141,6 +145,11 @@
       ミューノの武器はひとつだから<end_line>
       オレも武器をひとつ選ぶよ<end_line>
     </sjis>
+    <ascii>
+    I know, I know.<end_line>
+    You only have one weapon,<end_line>
+    so I'll only use one too.<end_line>
+ </ascii>
   </male>
   <female>
     <sjis>
@@ -148,12 +157,12 @@
       ミューノの武器はひとつだから<end_line>
       わたしも武器をひとつ選ぶよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I know, I know.<end_line>
     You only have one weapon,<end_line>
     so I'll only use one too.<end_line>
  </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 10/Murno/004_25555404_185f1cc.xml
+++ b/Translation/JE Scripts/Day 10/Murno/004_25555404_185f1cc.xml
@@ -8,6 +8,11 @@
       だからゴカイだって<end_line>
       言ってるだろ！？<end_line>
     </sjis>
+    <ascii>
+    Calm down!<end_line>
+    I told you,<end_line>
+    it's a misunderstanding!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -15,12 +20,12 @@
       だからゴカイだって<end_line>
       言ってるでしょ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Calm down!<end_line>
     I told you,<end_line>
     it's a misunderstanding!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -250,17 +255,21 @@
       もちろん！<end_line>
       みんなでやろうぜ！<end_line>
     </sjis>
+    <ascii>
+    Of course!<end_line>
+    Let's do it together!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       もちろん！<end_line>
       みんなでやろう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Of course!<end_line>
     Let's do it together!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 10/Partner/000_25556988_185f7fc.xml
+++ b/Translation/JE Scripts/Day 10/Partner/000_25556988_185f7fc.xml
@@ -9,6 +9,11 @@
       今までお前とは<end_line>
       たくさん武器を作ってきたよなぁ<end_line>
     </sjis>
+    <ascii>
+    Come to think of it, <partner>,<end_line>
+    we've crafted quite a few<end_line>
+    weapons so far.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -16,12 +21,12 @@
       今まであなたとは<end_line>
       たくさん武器を作ってきたよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Come to think of it, <partner>,<end_line>
     we've crafted quite a few<end_line>
     weapons so far.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -79,6 +84,11 @@
       何度も作ってきたんだから<end_line>
       あるだろ？　お気に入りとか<end_line>
     </sjis>
+    <ascii>
+    Not like that, the one you like.<end_line>
+    We've crafted so many, you have to<end_line>
+    have one, right? A favorite.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -86,12 +96,12 @@
       何度も作ってきたんだから<end_line>
       あるでしょ？　お気に入りとか<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Not like that, the one you like.<end_line>
     We've crafted so many, you have to<end_line>
     have one, right? A favorite.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -150,6 +160,11 @@
       ちょっと待てよ<three_dots><end_line>
       すぐには決められないな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Eh~!<end_line>
+    Hold on<three_dots><end_line>
+    I can't decide so quickly<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -157,12 +172,12 @@
       ちょっと待ってよ<three_dots><end_line>
       すぐには決められないなぁ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh~!<end_line>
     Hold on<three_dots><end_line>
     I can't decide so quickly<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -299,6 +314,11 @@
       そういえば、あの時お前は<end_line>
       本気が出せなかったんだよな<end_line>
     </sjis>
+    <ascii>
+    Well<three_dots><end_line>
+    That reminds me, you couldn't<end_line>
+    bring out your true strength.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -306,12 +326,12 @@
       そういえば、あの時あなたは<end_line>
       本気が出せなかったんだよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well<three_dots><end_line>
     That reminds me, you couldn't<end_line>
     bring out your true strength.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -355,17 +375,21 @@
       そうだな<three_dots><end_line>
       勝負するか！<end_line>
     </sjis>
+    <ascii>
+    You're right<three_dots><end_line>
+    Why don't we have a match?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そうだね<three_dots><end_line>
       勝負しよっか！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're right<three_dots><end_line>
     Why don't we have a match?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -392,6 +416,11 @@
       というか、お前に勝負を申し込んで<end_line>
       礼を言われるなんて、感動だよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Oh, it's nothing<three_dots><end_line>
+    Rather, I'm touched that you'd thank<end_line>
+    me for challenging you to a fight<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -399,12 +428,12 @@
       というか、あなたに勝負を申し込んで<end_line>
       お礼を言われるなんて、感動だよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, it's nothing<three_dots><end_line>
     Rather, I'm touched that you'd thank<end_line>
     me for challenging you to a fight<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -432,17 +461,21 @@
       なるほど<three_dots><end_line>
       たしかにそうかもな<end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    That might be true.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なるほど<three_dots><end_line>
       たしかに、それってあるかも<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     That might be true.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -469,6 +502,11 @@
       よっしゃ！<end_line>
       待ってろよ！<end_line>
     </sjis>
+    <ascii>
+    Front of the workshop.<end_line>
+    Alright!<end_line>
+    Just you wait!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -476,12 +514,12 @@
       よおっし！<end_line>
       待っててよね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Front of the workshop.<end_line>
     Alright!<end_line>
     Just you wait!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -494,6 +532,11 @@
       今までお前とは<end_line>
       たくさん武器を作ってきたよなぁ<end_line>
     </sjis>
+    <ascii>
+    Come to think of it, <partner>,<end_line>
+    we've crafted quite a few<end_line>
+    weapons so far.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -501,12 +544,12 @@
       今まであなたとは<end_line>
       たくさん武器を作ってきたよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Come to think of it, <partner>,<end_line>
     we've crafted quite a few<end_line>
     weapons so far.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -550,17 +593,21 @@
       ん？<end_line>
       どうしたんだ？<end_line>
     </sjis>
+    <ascii>
+    Hm?<end_line>
+    What's up?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ん？<end_line>
       どうしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hm?<end_line>
     What's up?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -587,15 +634,18 @@
     <sjis>
       なんだよ、突然<end_line>
     </sjis>
+    <ascii>
+    What's this all of a sudden?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、突然<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's this all of a sudden?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -624,6 +674,11 @@
       もういいじゃないか<end_line>
       今さら<three_dots><end_line>
     </sjis>
+    <ascii>
+    Aren't you a sore loser?<end_line>
+    Don't worry about it, that was<end_line>
+    already long ago<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -631,12 +686,12 @@
       もういいじゃない<end_line>
       今さら<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Aren't you a sore loser?<end_line>
     Don't worry about it, that was<end_line>
     already long ago<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -860,6 +915,11 @@
       今までお前とは<end_line>
       たくさん武器を作ってきたよなぁ<end_line>
     </sjis>
+    <ascii>
+    Come to think of it, <partner>,<end_line>
+    we've crafted quite a few<end_line>
+    weapons so far.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -867,12 +927,12 @@
       今まであなたとは<end_line>
       たくさん武器を作ってきたよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Come to think of it, <partner>,<end_line>
     we've crafted quite a few<end_line>
     weapons so far.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -900,17 +960,21 @@
       昨日もそんなこと言ってたよな<three_dots><end_line>
       意外とシツコイなぁ<end_line>
     </sjis>
+    <ascii>
+    You said the same thing yesterday<three_dots><end_line>
+    You're surprisingly stubborn<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       昨日もそんなこと言ってたよね<three_dots><end_line>
       意外とシツコイんだ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You said the same thing yesterday<three_dots><end_line>
     You're surprisingly stubborn<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -950,17 +1014,21 @@
       ん？<end_line>
       どうしたんだ？<end_line>
     </sjis>
+    <ascii>
+    Hm?<end_line>
+    What's wrong?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ん？<end_line>
       どうしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hm?<end_line>
     What's wrong?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -985,15 +1053,18 @@
     <sjis>
       なんだよ、突然<end_line>
     </sjis>
+    <ascii>
+    What's this all of a sudden?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、突然<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's this all of a sudden?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1038,6 +1109,11 @@
       もういいじゃないか<end_line>
       今さら<three_dots><end_line>
     </sjis>
+    <ascii>
+    Aren't you a sore loser?<end_line>
+    Don't worry about it, that was<end_line>
+    already long ago<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1045,12 +1121,12 @@
       もういいじゃない<end_line>
       今さら<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Aren't you a sore loser?<end_line>
     Don't worry about it, that was<end_line>
     already long ago<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1139,6 +1215,11 @@
       勝負するったら<end_line>
       勝負だ！<end_line>
     </sjis>
+    <ascii>
+    Shut up!<end_line>
+    I said I'll fight you,<end_line>
+    so let's go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1146,12 +1227,12 @@
       勝負するったら<end_line>
       勝負よ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Shut up!<end_line>
     I said I'll fight you,<end_line>
     so let's go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1313,6 +1394,11 @@
       今までお前とは<end_line>
       たくさん武器を作ってきたよなぁ<end_line>
     </sjis>
+    <ascii>
+    Come to think of it, <partner>,<end_line>
+    we've crafted quite a few<end_line>
+    weapons so far.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1320,12 +1406,12 @@
       今まであなたとは<end_line>
       たくさん武器を作ってきたよね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Come to think of it, <partner>,<end_line>
     we've crafted quite a few<end_line>
     weapons so far.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1392,6 +1478,11 @@
       そんなことないだろ？<end_line>
       なんならもう１回勝負するか？<end_line>
     </sjis>
+    <ascii>
+    Definitely? You can't be so sure,<end_line>
+    can you? Then how about we fight,<end_line>
+    one last time?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1399,12 +1490,12 @@
       そんなことないでしょ？<end_line>
       なんならもう１回勝負する？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Definitely? You can't be so sure,<end_line>
     can you? Then how about we fight,<end_line>
     one last time?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1429,6 +1520,11 @@
       あーもー勝負だ！<end_line>
       勝負しよう！<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+    Argh, alright, let's do this!<end_line>
+    Let's have a match!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1436,12 +1532,12 @@
       あーもー勝負よ！<end_line>
       勝負しよう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
     Argh, alright, let's do this!<end_line>
     Let's have a match!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1507,15 +1603,18 @@
     <sjis>
       なんだよ、それ<end_line>
     </sjis>
+    <ascii>
+    What's that supposed to mean?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's that supposed to mean?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1564,15 +1663,18 @@
     <sjis>
       ひとつだ！<end_line>
     </sjis>
+    <ascii>
+    One!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ひとつよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     One!<end_line>
   </ascii>
+  </female>
 </bigtext>
 <dialogue>
   <partner name="rufeel">
@@ -1597,6 +1699,12 @@
       ひとつで十分だって<end_line>
       言ってるんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I'm saying that using<end>
+    only one weapon will be<end_line>
+    enough to deal with you<three_dots><end_line>
+  </end>
+    </ascii>
   </male>
   <female>
     <sjis>
@@ -1604,12 +1712,13 @@
       ひとつで十分だって<end_line>
       言ってるんだよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm saying that using<end>
     only one weapon will be<end_line>
     enough to deal with you<three_dots><end_line>
-  </ascii>
+  </end>
+    </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1659,17 +1768,21 @@
       じゃあ、オレは武器を選ぶから<end_line>
       少し待ってろよ<end_line>
     </sjis>
+    <ascii>
+    Then I need to pick out a weapon,<end_line>
+    so wait a bit.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       じゃあ、わたしは武器を選ぶから<end_line>
       少し待っててよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Then I need to pick out a weapon,<end_line>
     so wait a bit.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Translation/JE Scripts/Day 10/Partner/001_25561340_18608fc.xml
+++ b/Translation/JE Scripts/Day 10/Partner/001_25561340_18608fc.xml
@@ -110,16 +110,19 @@
       まあ、一番好きだっていうんだから<end_line>
       一本だよなぁ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Well, you're right about that<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       まあ、一番好きだっていうんだから<end_line>
       一本だよね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, you're right about that<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Day 10/Partner/002_25602588_186aa1c.xml
+++ b/Translation/JE Scripts/Day 10/Partner/002_25602588_186aa1c.xml
@@ -9,6 +9,10 @@
       お前にオレの魂を<end_line>
       伝えてやるぜ！<end_line>
     </sjis>
+    <ascii>
+    With this weapon<three_dots><end_line>
+    I'll show you my determination!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -16,11 +20,11 @@
       あなたにわたしの魂を<end_line>
       伝えてあげる！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     With this weapon<three_dots><end_line>
     I'll show you my determination!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -44,17 +48,21 @@
       お前の本気、見せてもらうぜ<end_line>
       <partner><three_dots><end_line>
     </sjis>
+    <ascii>
+    Show me what you're made of,<end_line>
+    <partner><three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あなたの本気、見せてもらうわ<end_line>
       <partner><three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Show me what you're made of,<end_line>
     <partner><three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -80,17 +88,21 @@
       手加減はいらないぜ<end_line>
       <partner><three_dots><end_line>
     </sjis>
+    <ascii>
+    Don't hold back,<end_line>
+    <partner><three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       手加減はいらないわよ<end_line>
       <partner><three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't hold back,<end_line>
     <partner><three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -118,17 +130,21 @@
       この武器ならお前も<end_line>
       手加減してられないだろ？<end_line>
     </sjis>
+    <ascii>
+    With this weapon, you won't be<end_line>
+    able to hold back, right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       この武器ならあなたも<end_line>
       手加減してられないでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     With this weapon, you won't be<end_line>
     able to hold back, right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Translation/JE Scripts/Day 10/Partner/Enzi_25564572_186159c.xml
+++ b/Translation/JE Scripts/Day 10/Partner/Enzi_25564572_186159c.xml
@@ -22,6 +22,11 @@
       お前の戦い方を見ていれば<end_line>
       オレにケガさせないようにって<three_dots><end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots><three_dots><end_line>
+    The way you fought<three_dots><end_line>
+    You were obviously holding back.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -29,12 +34,12 @@
       あなたの戦い方を見ていれば<end_line>
       わたしにケガさせないようにって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots><three_dots><end_line>
     The way you fought<three_dots><end_line>
     You were obviously holding back.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -72,6 +77,11 @@
       オレが勝てたのはこの武器の<three_dots><end_line>
       お前との修行のおかげだよ！<end_line>
     </sjis>
+    <ascii>
+    Ahaha! You're right!<end_line>
+    I won thanks to this weapon<three_dots><end_line>
+    And you, too!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -79,12 +89,12 @@
       わたしが勝てたのはこの武器の<three_dots><end_line>
       あなたとの修行のおかげだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ahaha! You're right!<end_line>
     I won thanks to this weapon<three_dots><end_line>
     And you, too!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -119,17 +129,21 @@
       なんだよ、それ？<end_line>
       バカにしてんのか？<end_line>
     </sjis>
+    <ascii>
+    What's that supposed to mean?<end_line>
+    Are you making fun of me?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ？<end_line>
       バカにしてるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's that supposed to mean?<end_line>
     Are you making fun of me?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -186,6 +200,11 @@
       どうして？<end_line>
       何か悪いことでもしたのかよ？<end_line>
     </sjis>
+    <ascii>
+    They hated you<three_dots>?<end_line>
+    Why?<end_line>
+    Did you do something bad to them?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -193,12 +212,12 @@
       どうして？<end_line>
       何か悪いことでもしたの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     They hated you<three_dots>?<end_line>
     Why?<end_line>
     Did you do something bad to them?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -225,6 +244,10 @@
       ことじゃないか<end_line>
       何で憎まれなきゃなんないんだ？<end_line>
     </sjis>
+    <ascii>
+    Isn't that the right thing to do?<end_line>
+    Why would they hate you for it?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -232,11 +255,11 @@
       ことじゃないの<end_line>
       何で憎まれなきゃなんないのよ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Isn't that the right thing to do?<end_line>
     Why would they hate you for it?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -360,6 +383,11 @@
       オレだって<partner>に会えて<end_line>
       本当に良かったぜ！<end_line>
     </sjis>
+    <ascii>
+    Wha, um<three_dots><end_line>
+    I'm really happy I met<end_line>
+    you too, <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -367,12 +395,12 @@
       わたしだって<partner>に会えて<end_line>
       本当に良かったよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wha, um<three_dots><end_line>
     I'm really happy I met<end_line>
     you too, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 10/Partner/Killfith_25566700_1861dec.xml
+++ b/Translation/JE Scripts/Day 10/Partner/Killfith_25566700_1861dec.xml
@@ -19,15 +19,18 @@
     <sjis>
       ありがとな、<partner><end_line>
     </sjis>
+    <ascii>
+    Thanks, <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ありがとう、<partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Thanks, <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -52,6 +55,11 @@
       オレなんか一発で<end_line>
       吹き飛んでたはずだぜ<end_line>
     </sjis>
+    <ascii>
+    Well, if you used your magic,<end_line>
+    I would have been<end_line>
+    blown away in an instant.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -59,12 +67,12 @@
       わたしなんか一発で<end_line>
       吹き飛んでたはずだよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well, if you used your magic,<end_line>
     I would have been<end_line>
     blown away in an instant.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -168,6 +176,11 @@
       <partner>がミューノのこと<end_line>
       大事にしてるのは、わかったからさ<end_line>
     </sjis>
+    <ascii>
+    Oh, cut the act already<three_dots><end_line>
+    I know you really<end_line>
+    treasure her.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -175,12 +188,12 @@
       <partner>がミューノのこと<end_line>
       大事にしてるのは、わかったから<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, cut the act already<three_dots><end_line>
     I know you really<end_line>
     treasure her.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -203,6 +216,11 @@
       素直に言った方が<end_line>
       ミューノもよろこぶと思うぜ<end_line>
     </sjis>
+    <ascii>
+    If you would just come out and<end_line>
+    tell her your feelings, I'm sure<end_line>
+    Murno would be happy.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -210,12 +228,12 @@
       素直に言った方が<end_line>
       ミューノもよろこぶと思うよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     If you would just come out and<end_line>
     tell her your feelings, I'm sure<end_line>
     Murno would be happy.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -240,6 +258,11 @@
       じゃあお前にはミューノを守る気<end_line>
       ないのかよ<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    What now!?<end_line>
+    Then are you saying you don't<end_line>
+    want to protect her?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -247,12 +270,12 @@
       じゃああなたにはミューノを<end_line>
       守る気がないっていうの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What now!?<end_line>
     Then are you saying you don't<end_line>
     want to protect her?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -313,17 +336,21 @@
       ミューノが命がけでお前を<three_dots><end_line>
       一体なにがあったんだ？<end_line>
     </sjis>
+    <ascii>
+    Murno risked her life for you<three_dots><end_line>
+    What on earth happened?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ミューノが命がけであなたを<three_dots><end_line>
       一体なにがあったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Murno risked her life for you<three_dots><end_line>
     What on earth happened?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -409,6 +436,11 @@
       それ、どういうことだよ？<end_line>
       お前、犬が弱点なのか？<end_line>
     </sjis>
+    <ascii>
+    Woah, hold on!<end_line>
+    What do you mean?<end_line>
+    <partner>, are you scared of dogs?<end_line>
+   </ascii>
   </male>
   <female>
     <sjis>
@@ -416,12 +448,12 @@
       それ、どういうことなの？<end_line>
       <partner>、犬が弱点なの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Woah, hold on!<end_line>
     What do you mean?<end_line>
     <partner>, are you scared of dogs?<end_line>
    </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -529,15 +561,18 @@
     <sjis>
       お前ってヤツは<three_dots><end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       まったく、あんたは<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -669,17 +704,21 @@
       <three_dots>って、おい！？<end_line>
       どういうことだよ？<end_line>
     </sjis>
+    <ascii>
+    <three_dots>wait, what!?<end_line>
+    What do you mean?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots>って、ちょっと！？<end_line>
       それ、どういうこと？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots>wait, what!?<end_line>
     What do you mean?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -735,6 +774,11 @@
       お前<three_dots><end_line>
       本当にそれでいいのかよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots><end_line>
+    Is that<three_dots><end_line>
+    really okay with you<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -742,12 +786,12 @@
       あなた<three_dots><end_line>
       本当にそれでいいの<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots><end_line>
     Is that<three_dots><end_line>
     really okay with you<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 10/Partner/Rufeel_25569532_18628fc.xml
+++ b/Translation/JE Scripts/Day 10/Partner/Rufeel_25569532_18628fc.xml
@@ -59,18 +59,23 @@
       そんなに勝ちたちゃ<end_line>
       強い技を使えばよかったのに<end_line>
     </sjis>
+    <ascii>
+    If you wanted to win that badly,<end_line>
+    you should have used your<end_line>
+    strongest moves.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなに勝ちたいなら<end_line>
       強い技を使えばよかったのに<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     If you wanted to win that badly,<end_line>
     you should have used your<end_line>
     strongest moves.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -167,17 +172,21 @@
       だってけっこう<end_line>
       コワがってただろ？<end_line>
     </sjis>
+    <ascii>
+    You did look pretty<end_line>
+    scared, you know?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       だってけっこう<end_line>
       コワがってたでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You did look pretty<end_line>
     scared, you know?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -199,17 +208,21 @@
       どっちなんだよ<end_line>
       コワがりじゃなかったのか？<end_line>
     </sjis>
+    <ascii>
+    Which is it,<end_line>
+    are you a coward or not?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どっちなのよ<end_line>
       コワがりじゃなかったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Which is it,<end_line>
     are you a coward or not?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -247,15 +260,18 @@
     <sjis>
       そうだったのか<three_dots><end_line>
     </sjis>
+    <ascii>
+    Is that so<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そうだったんだ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Is that so<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 10/Partner/Run-Dor_25562556_1860dbc.xml
+++ b/Translation/JE Scripts/Day 10/Partner/Run-Dor_25562556_1860dbc.xml
@@ -6,17 +6,21 @@
       どうだ？<end_line>
       なんか伝わっただろ？<end_line>
     </sjis>
+    <ascii>
+    How was that?<end_line>
+    You felt it, didn't you?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       どう？<end_line>
       なんか伝わったでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     How was that?<end_line>
     You felt it, didn't you?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -241,6 +245,10 @@
       ガーンときただろ？<end_line>
       ガーンと<end_line>
     </sjis>
+    <ascii>
+    Like, when you got hit,<end_line>
+    didn't it feel like a shock?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -248,11 +256,11 @@
       ガーンときたでしょ？<end_line>
       ガーンと<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Like, when you got hit,<end_line>
     didn't it feel like a shock?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -291,17 +299,21 @@
       あとはお前が<end_line>
       それを感じるだけだ！<end_line>
     </sjis>
+    <ascii>
+    All that's left is for<end_line>
+    you to feel it!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あとはあなたが<end_line>
       それを感じるだけよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     All that's left is for<end_line>
     you to feel it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -324,6 +336,11 @@
       相手の動きとか表情をみていれば<end_line>
       何を考えているか大体わかるだろ<end_line>
     </sjis>
+    <ascii>
+    That's right. You know how you can<end_line>
+    figure out what your opponent is<end_line>
+    thinking from their body language?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -331,12 +348,12 @@
       相手の動きとか表情をみていれば<end_line>
       何を考えているか大体わかるでしょ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's right. You know how you can<end_line>
     figure out what your opponent is<end_line>
     thinking from their body language?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -449,6 +466,10 @@
       <partner>はやさしくて<end_line>
       いいやつだ<end_line>
     </sjis>
+    <ascii>
+    You are.<end_line>
+    <partner> is kind and gentle.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -456,11 +477,11 @@
       <partner>はやさしくて<end_line>
       いい子よ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You are.<end_line>
     <partner> is kind and gentle.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -495,17 +516,21 @@
       うわっ！　ちょっと！？<end_line>
       そんなに泣くなよ<end_line>
     </sjis>
+    <ascii>
+    Uwah! What!?<end_line>
+    Don't cry!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うわっ！　ちょっと！？<end_line>
       そんなに泣かないで<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uwah! What!?<end_line>
     Don't cry!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 10/Tier/000_25589724_18677dc.xml
+++ b/Translation/JE Scripts/Day 10/Tier/000_25589724_18677dc.xml
@@ -6,17 +6,21 @@
       あれ？<end_line>
       <partner>、ドコ行くんだよ<end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    <partner>, where are you going?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あれ？<end_line>
       <partner>、ドコ行くの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     <partner>, where are you going?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -90,6 +94,11 @@
       そうだな<three_dots><end_line>
       わかったよ<end_line>
     </sjis>
+    <ascii>
+    Oh<three_dots><end_line>
+    Okay<three_dots><end_line>
+    Understood.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -97,12 +106,12 @@
       そうだね<three_dots><end_line>
       わかったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh<three_dots><end_line>
     Okay<three_dots><end_line>
     Understood.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -136,16 +145,19 @@
       そっか<end_line>
       そうだったな<end_line>
     </sjis>
+    <ascii>
+    Oh, right.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっか<end_line>
       そうだったね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh, right.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <choice>
   <info box="left">
@@ -177,17 +189,21 @@
       準備するから<end_line>
       ちょっと待っててくれよ<end_line>
     </sjis>
+    <ascii>
+    I need to get ready,<end_line>
+    wait a moment.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       準備するから<end_line>
       ちょっと待ってて<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I need to get ready,<end_line>
     wait a moment.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 10/Tier/001_25592076_186810c.xml
+++ b/Translation/JE Scripts/Day 10/Tier/001_25592076_186810c.xml
@@ -7,17 +7,21 @@
       へー、そんなことが<three_dots><end_line>
       <player_nickname>くんも大変だねぇ<end_line>
     </sjis>
+    <ascii>
+    Huh, I see<three_dots><end_line>
+    You've got it hard too.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       へー、そんなことが<three_dots><end_line>
       <player_nickname>ちゃんも大変だねぇ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh, I see<three_dots><end_line>
     You've got it hard too.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -82,17 +86,21 @@
       ちょっと待てよ！<end_line>
       今回は留守番じゃなかったのか？<end_line>
     </sjis>
+    <ascii>
+    Wait a minute!<end_line>
+    Didn't you say you'd watch the inn?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちょっと待ってよ！<end_line>
       今回は留守番じゃなかったの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wait a minute!<end_line>
     Didn't you say you'd watch the inn?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -267,17 +275,21 @@
       よしなさい、ティエ<end_line>
       <player_nickname>くんも困ってるだろう<end_line>
     </sjis>
+    <ascii>
+    Cut it out, Tier.<end_line>
+    You're troubling <player_nickname>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よしなさい、ティエ<end_line>
       <player_nickname>ちゃんも困ってるだろう<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Cut it out, Tier.<end_line>
     You're troubling <player_nickname>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -311,15 +323,18 @@
     <sjis>
       <player_nickname>くん<three_dots><end_line>
     </sjis>
+    <ascii>
+    <player_nickname><three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <player_nickname>ちゃん<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <player_nickname><three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -344,6 +359,11 @@
       勝負してやるぜ<end_line>
       ティエ！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    Let's have a match,<end_line>
+    Tier!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -351,12 +371,12 @@
       勝負してあげるよ<end_line>
       ティエ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     Let's have a match,<end_line>
     Tier!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 10/Tier/002_25593868_186880c.xml
+++ b/Translation/JE Scripts/Day 10/Tier/002_25593868_186880c.xml
@@ -63,15 +63,18 @@
     <sjis>
       <player_nickname>くん<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    <player_nickname>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <player_nickname>ちゃん<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <player_nickname>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -83,6 +86,11 @@
       この勝負、ティエの両親のためにも<end_line>
       絶対に負けるわけにはいかない！<end_line>
     </sjis>
+    <ascii>
+    That's right<three_dots><end_line>
+    I have to win, not just for me,<end_line>
+    but for Tier's parents!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -90,10 +98,10 @@
       この勝負、ティエの両親のためにも<end_line>
       絶対に負けるわけにはいかない！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's right<three_dots><end_line>
     I have to win, not just for me,<end_line>
     but for Tier's parents!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 10/Tier/003_25594780_1868b9c.xml
+++ b/Translation/JE Scripts/Day 10/Tier/003_25594780_1868b9c.xml
@@ -8,6 +8,11 @@
       これで自分の力がわかっただろ？<end_line>
       やっぱ留守番してろよ<end_line>
     </sjis>
+    <ascii>
+    Now then<three_dots><end_line>
+    Do you understand?<end_line>
+    You really should stay home.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -15,12 +20,12 @@
       これで自分の力がわかったでしょ？<end_line>
       やっぱり留守番してなよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Now then<three_dots><end_line>
     Do you understand?<end_line>
     You really should stay home.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -56,17 +61,21 @@
       なんだと？<end_line>
       どうして<three_dots><end_line>
     </sjis>
+    <ascii>
+    What?<end_line>
+    Why<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ？<end_line>
       どうして<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What?<end_line>
     Why<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -158,6 +167,11 @@
       それほどまでに<end_line>
       <player_nickname>くんを<three_dots><end_line>
     </sjis>
+    <ascii>
+    Tier<three_dots><end_line>
+    You care for <player_nickname><end_line>
+    that much<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -165,12 +179,12 @@
       それほどまでに<end_line>
       <player_nickname>ちゃんを<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Tier<three_dots><end_line>
     You care for <player_nickname><end_line>
     that much<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -182,6 +196,11 @@
       悪いがティエをいっしょに<end_line>
       連れて行ってくれないか？<end_line>
     </sjis>
+    <ascii>
+    <player_nickname>,<end_line>
+    I'm sorry, but could you<end_line>
+    take her with you?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -189,12 +208,12 @@
       悪いがティエをいっしょに<end_line>
       連れて行ってくれないか？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <player_nickname>,<end_line>
     I'm sorry, but could you<end_line>
     take her with you?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -274,6 +293,11 @@
       そんな、あの<end_line>
       すみません、オレ、あの<end_line>
     </sjis>
+    <ascii>
+    Wha,<end_line>
+    well, um,<end_line>
+    sorry, I<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -281,12 +305,12 @@
       そんな、あの<end_line>
       すみません、わたし、あの<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wha,<end_line>
     well, um,<end_line>
     sorry, I<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -333,6 +357,11 @@
       良かったなティエ<end_line>
       さあ、元気だしなさい<end_line>
     </sjis>
+    <ascii>
+    Thank you, <player_nickname>.<end_line>
+    Isn't that great, Tier?<end_line>
+    Now, cheer up, alright?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -340,12 +369,12 @@
       良かったなティエ<end_line>
       さあ、元気だしなさい<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Thank you, <player_nickname>.<end_line>
     Isn't that great, Tier?<end_line>
     Now, cheer up, alright?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -356,17 +385,21 @@
       だから、ほら<end_line>
       もう泣くなよ<end_line>
     </sjis>
+    <ascii>
+    Yeah, come on,<end_line>
+    don't cry.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       だから、ほら<end_line>
       もう泣かないで<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah, come on,<end_line>
     don't cry.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -517,6 +550,10 @@
       なんとも<three_dots><end_line>
       すまない、<player_nickname>くん<three_dots><end_line>
     </sjis>
+    <ascii>
+    Our daughter is just so<three_dots><end_line>
+    I'm sorry, <player_nickname><three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -524,11 +561,11 @@
       なんとも<three_dots><end_line>
       すまない、<player_nickname>ちゃん<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Our daughter is just so<three_dots><end_line>
     I'm sorry, <player_nickname><three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 10/V.E/001_25572044_18632cc.xml
+++ b/Translation/JE Scripts/Day 10/V.E/001_25572044_18632cc.xml
@@ -6,17 +6,21 @@
       あれ？<end_line>
       <partner>、ドコ行くんだよ<end_line>
     </sjis>
+    <ascii>
+    Huh?<end_line>
+    <partner>, where are you going?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あれ？<end_line>
       <partner>、ドコ行くの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     <partner>, where are you going?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -90,6 +94,11 @@
       そうだな<three_dots><end_line>
       わかったよ<end_line>
     </sjis>
+    <ascii>
+    Oh<three_dots><end_line>
+    Okay<three_dots><end_line>
+    Understood.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -97,12 +106,12 @@
       そうだね<three_dots><end_line>
       わかったよ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Oh<three_dots><end_line>
     Okay<three_dots><end_line>
     Understood.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -142,6 +151,11 @@
       この武器、ロブ親方と作った<end_line>
       親方のお気に入りの斧じゃないか！<end_line>
     </sjis>
+    <ascii>
+    <three_dots>Wait, Master!<end_line>
+    Isn't this your favorite axe,<end_line>
+    one you crafted with Master Rob!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -149,12 +163,12 @@
       この武器、ロブ親方と作った<end_line>
       親方のお気に入りの斧じゃない！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots>Wait, Master!<end_line>
     Isn't this your favorite axe,<end_line>
     one you crafted with Master Rob!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -180,17 +194,21 @@
       でも、これ<three_dots><end_line>
       オレが直してもいいの<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    But this<three_dots><end_line>
+    Is it really okay for me to<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       でも、これ<three_dots><end_line>
       わたしが直してもいいの<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     But this<three_dots><end_line>
     Is it really okay for me to<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -217,6 +235,11 @@
       わかった<three_dots>！<end_line>
       まかせといてよ！<end_line>
     </sjis>
+    <ascii>
+    O-of course I can!<end_line>
+    Okay<three_dots>!<end_line>
+    Leave it to me!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -224,12 +247,12 @@
       わかった<three_dots>！<end_line>
       まかせといて！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     O-of course I can!<end_line>
     Okay<three_dots>!<end_line>
     Leave it to me!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 10/V.E/002_25573772_186398c.xml
+++ b/Translation/JE Scripts/Day 10/V.E/002_25573772_186398c.xml
@@ -103,17 +103,21 @@
       使ってみなくちゃわからない<end_line>
       <three_dots>ってことか<end_line>
     </sjis>
+    <ascii>
+    Until we test it.<end_line>
+    <three_dots>Right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       使ってみなくちゃわからない<end_line>
       <three_dots>だね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Until we test it.<end_line>
     <three_dots>Right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -253,15 +257,19 @@
       オレたちのすべてをかけた武器、か<three_dots><end_line>
       どれにしようかな<end_line>
     </sjis>
+    <ascii>
+    The best one I've got, huh<three_dots><end_line>
+    I wonder which one to choose.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしたちのすべてをかけた武器、ね<three_dots><end_line>
       どれにしようかな<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The best one I've got, huh<three_dots><end_line>
     I wonder which one to choose.<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Day 10/V.E/004_25604124_186b01c.xml
+++ b/Translation/JE Scripts/Day 10/V.E/004_25604124_186b01c.xml
@@ -7,16 +7,19 @@
       この武器に<end_line>
       オレと<partner>のすべてを<three_dots><end_line>
     </sjis>
+    <ascii>
+    With this weapon, I'm sure<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       この武器に<end_line>
       わたしと<partner>のすべてを<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     With this weapon, I'm sure<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Day 10/V.E/005_25576012_186424c.xml
+++ b/Translation/JE Scripts/Day 10/V.E/005_25576012_186424c.xml
@@ -19,6 +19,11 @@
       ごめん、親方<three_dots><end_line>
       オレ、またこわしちゃって<three_dots><end_line>
     </sjis>
+    <ascii>
+    Uwah<three_dots><end_line>
+    Sorry, Master<three_dots><end_line>
+    I broke it again<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -26,12 +31,12 @@
       ごめん、親方<three_dots><end_line>
       わたし、またこわしちゃって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Uwah<three_dots><end_line>
     Sorry, Master<three_dots><end_line>
     I broke it again<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -97,6 +102,11 @@
       オレ<three_dots><end_line>
       勝ったんだ<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    I<three_dots><end_line>
+    I won<three_dots><end_line>
+    I really won<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -104,12 +114,12 @@
       わたし<three_dots><end_line>
       勝ったんだ<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I<three_dots><end_line>
     I won<three_dots><end_line>
     I really won<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Final Day/003_25607980_186bf2c.xml
+++ b/Translation/JE Scripts/Final Day/003_25607980_186bf2c.xml
@@ -7,17 +7,21 @@
       よっし！<end_line>
       じゃあ今日は<three_dots><end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    So today I'll<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よーし！<end_line>
       じゃあ今日は<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     So today I'll<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Translation/JE Scripts/Final Day/005_25609372_186c49c.xml
+++ b/Translation/JE Scripts/Final Day/005_25609372_186c49c.xml
@@ -29,24 +29,29 @@
 	<info box="right">
 	<portrait_r entry="player" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			<three_dots>ってことは<end_line>
 			ふたりで出かけたってことか？<end_line>
 			ドコへ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<three_dots>ってことは<end_line>
-			ふたりで出かけたってこと？<end_line>
-			ドコへ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <three_dots>Which means,<end_line>
     they left together?<end_line>
     Where to?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<three_dots>ってことは<end_line>
+			ふたりで出かけたってこと？<end_line>
+			ドコへ？<end_line>
+		</sjis>
+    <ascii>
+    <three_dots>Which means,<end_line>
+    they left together?<end_line>
+    Where to?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -132,21 +137,25 @@
 	<portrait_l entry="player" eye="decided" mouth="serious">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			もう少しこの辺りもさがしてみよう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-			もう少しこの辺りもさがしてみよう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You're right.<end_line>
     Let's look around for a bit longer.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+			もう少しこの辺りもさがしてみよう<end_line>
+		</sjis>
+    <ascii>
+    You're right.<end_line>
+    Let's look around for a bit longer.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">

--- a/Translation/JE Scripts/Final Day/007_25610764_186ca0c.xml
+++ b/Translation/JE Scripts/Final Day/007_25610764_186ca0c.xml
@@ -791,13 +791,16 @@
     <sjis>
       おう！<end_line>
     </sjis>
+    <ascii>
+    Yeah!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       うん！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yeah!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Final Day/040_25614476_186d88c.xml
+++ b/Translation/JE Scripts/Final Day/040_25614476_186d88c.xml
@@ -42,15 +42,18 @@
     <sjis>
       ミューノを返せ！<end_line>
     </sjis>
+    <ascii>
+    Let her go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ミューノを返して！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Let her go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -62,6 +65,11 @@
       返すも何も、あいつの父親が<end_line>
       私たちを連れ出したんだ<end_line>
     </sjis>
+    <ascii>
+    Let her go? Ha!<end_line>
+    Why should I? Her father's the<end_line>
+    one who led us here.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -69,12 +77,12 @@
       返すも何も、あいつの父親が<end_line>
       私たちを連れ出したんだ<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Let her go? Ha!<end_line>
     Why should I? Her father's the<end_line>
     one who led us here.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -211,6 +219,11 @@
       村に帰るなら、なんであいつらと<end_line>
       いっしょなんだ！？<end_line>
     </sjis>
+    <ascii>
+    Wait, he did?<end_line>
+    But then why are<end_line>
+    you with Anise!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -218,12 +231,12 @@
       村に帰るなら、なんであいつらと<end_line>
       いっしょなのよ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wait, he did?<end_line>
     But then why are<end_line>
     you with Anise!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -355,17 +368,21 @@
       ちょっと待てよ！<end_line>
       ちゃんとワケを<three_dots><end_line>
     </sjis>
+    <ascii>
+    Wait!<end_line>
+    Hear me out<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ちょっと待ってよ！<end_line>
       ちゃんとワケを<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wait!<end_line>
     Hear me out<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -482,17 +499,21 @@
       ミューノ<three_dots><end_line>
       オレ<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Murno<three_dots><end_line>
+    I<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ミューノ<three_dots><end_line>
       わたし<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Murno<three_dots><end_line>
     I<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -517,15 +538,18 @@
     <sjis>
       そんな！　ウソだろ！？<end_line>
     </sjis>
+    <ascii>
+    Murno! Why!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんな！　ウソでしょ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Murno! Why!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -586,17 +610,21 @@
       <three_dots><end_line>
       なん、だよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    <three_dots><end_line>
+    What<three_dots>was that<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       <three_dots><end_line>
       なんなの<three_dots>よ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <three_dots><end_line>
     What<three_dots>was that<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -630,7 +658,7 @@
   <sjis>
     <player_nickname>！<end_line>
   </sjis>
-   <ascii>
+  <ascii>
     <player_nickname>!<end_line>
   </ascii>
 </dialogue>
@@ -642,7 +670,7 @@
   <sjis>
     <player_nickname>さん！<end_line>
   </sjis>
-   <ascii>
+  <ascii>
     <player_nickname>!<end_line>
   </ascii>
 </dialogue>
@@ -777,6 +805,11 @@
       村に帰るから、ついてくるなって<end_line>
       ミューノが<three_dots><end_line>
     </sjis>
+    <ascii>
+    Well<three_dots><end_line>
+    Murno said she's heading home,<end_line>
+    and not to follow her<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -784,12 +817,12 @@
       村に帰るから、ついてこないでって<end_line>
       ミューノが<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well<three_dots><end_line>
     Murno said she's heading home,<end_line>
     and not to follow her<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -814,15 +847,18 @@
     <sjis>
       そんなこと、オレが知るかよ！<end_line>
     </sjis>
+    <ascii>
+    That's what I want to know!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなのわかんないよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's what I want to know!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -859,6 +895,11 @@
       納得なんてできるわけないだろ<three_dots><end_line>
       でも、ミューノが<three_dots><end_line>
     </sjis>
+    <ascii>
+    With Anise there<three_dots><end_line>
+    Of course not<three_dots><end_line>
+    But Murno<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -866,12 +907,12 @@
       納得なんてできるわけないよ<three_dots><end_line>
       でも、ミューノが<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     With Anise there<three_dots><end_line>
     Of course not<three_dots><end_line>
     But Murno<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -881,17 +922,21 @@
       いってー！<end_line>
       なにすんだよ！<end_line>
     </sjis>
+    <ascii>
+    Owww!<end_line>
+    What was that for!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       いったーい！<end_line>
       なにするのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Owww!<end_line>
     What was that for!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -1072,15 +1117,18 @@
     <sjis>
       オレの答え<three_dots><end_line>
     </sjis>
+    <ascii>
+    My answer<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしの答え<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     My answer<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -1145,15 +1193,19 @@
       そんなこと<three_dots><end_line>
       決まってるだろ！<end_line>
     </sjis>
+    <ascii>
+    Isn't it obvious?<end_line>
+    Let's go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんなこと<three_dots><end_line>
       決まってるでしょ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Isn't it obvious?<end_line>
     Let's go!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Final Day/042_25619308_186eb6c.xml
+++ b/Translation/JE Scripts/Final Day/042_25619308_186eb6c.xml
@@ -183,24 +183,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="murno" eye="sad" mouth="stressed">
 	<male>
-		<sjis>
+    <sjis>
 			行っちゃダメだ！<end_line>
 			本当はミューノだって<end_line>
 			そう思ってるんだろ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			行っちゃダメだよ！<end_line>
-			本当はミューノだって<end_line>
-			そう思ってるんでしょ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Don't go!<end_line>
     I'm sure that deep down,<end_line>
     this isn't what you want!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			行っちゃダメだよ！<end_line>
+			本当はミューノだって<end_line>
+			そう思ってるんでしょ！<end_line>
+		</sjis>
+    <ascii>
+    Don't go!<end_line>
+    I'm sure that deep down,<end_line>
+    this isn't what you want!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -426,19 +431,19 @@
 	<info box="right">
 	<portrait_r entry="jade" eye="special" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			オレが見込んだ男だからだ！<end_line>
 		</sjis>
     <ascii>
       a man I can respect!<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			オレが見込んだ女だからだ！<end_line>
 		</sjis>
     <ascii>
       a woman I can respect!<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Final Day/043_25647404_187592c.xml
+++ b/Translation/JE Scripts/Final Day/043_25647404_187592c.xml
@@ -102,6 +102,11 @@
       この廃墟の奥に、ミューノが<three_dots><end_line>
       今ならまだ追いつけるはずだ！<end_line>
     </sjis>
+    <ascii>
+    You're right<three_dots>!<end_line>
+    Murno is futher inside<three_dots><end_line>
+    We should still be able to catch up!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -109,10 +114,10 @@
       この廃墟の奥に、ミューノが<three_dots><end_line>
       今ならまだ追いつけるはずだよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're right<three_dots>!<end_line>
     Murno is futher inside<three_dots><end_line>
     We should still be able to catch up!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Final Day/045_25622540_186f80c.xml
+++ b/Translation/JE Scripts/Final Day/045_25622540_186f80c.xml
@@ -88,6 +88,11 @@
       ミューノを放せ！<end_line>
       話はそれからだ！！！<end_line>
     </sjis>
+    <ascii>
+    Enough already,<end_line>
+    just let Murno go!<end_line>
+    We can talk after that!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -95,12 +100,12 @@
       ミューノを放して<end_line>
       話はそれからだよ！！！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Enough already,<end_line>
     just let Murno go!<end_line>
     We can talk after that!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Final Day/051_25624812_18700ec.xml
+++ b/Translation/JE Scripts/Final Day/051_25624812_18700ec.xml
@@ -7,6 +7,11 @@
       こわれた家が多いな<three_dots><end_line>
       何があったんだろ<three_dots><end_line>
     </sjis>
+    <ascii>
+    There's quite a lot of<end_line>
+    wrecked homes here<three_dots><end_line>
+    I wonder what happened<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -14,12 +19,12 @@
       こわれた家が多いね<three_dots><end_line>
       何があったんだろ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     There's quite a lot of<end_line>
     wrecked homes here<three_dots><end_line>
     I wonder what happened<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -105,17 +110,21 @@
       ゴヴァンの遺跡だな<three_dots>！<end_line>
       急ぐぞ！<end_line>
     </sjis>
+    <ascii>
+    The Govan Ruins<three_dots>!<end_line>
+    Let's hurry!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ゴヴァンの遺跡だね<three_dots>！<end_line>
       急ごう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The Govan Ruins<three_dots>!<end_line>
     Let's hurry!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -201,17 +210,21 @@
       ゴヴァンの遺跡だな<three_dots>！<end_line>
       急ぐぞ！<end_line>
     </sjis>
+    <ascii>
+    The Govan Ruins<three_dots>!<end_line>
+    Let's hurry!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ゴヴァンの遺跡だね<three_dots>！<end_line>
       急ごう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The Govan Ruins<three_dots>!<end_line>
     Let's hurry!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -296,17 +309,21 @@
       ゴヴァンの遺跡だな<three_dots>！<end_line>
       急ぐぞ！<end_line>
     </sjis>
+    <ascii>
+    The Govan Ruins<three_dots>!<end_line>
+    Let's hurry!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ゴヴァンの遺跡だね<three_dots>！<end_line>
       急ごう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The Govan Ruins<three_dots>!<end_line>
     Let's hurry!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -392,15 +409,19 @@
       ゴヴァンの遺跡だな<three_dots>！<end_line>
       急ぐぞ！<end_line>
     </sjis>
+    <ascii>
+    The Govan Ruins<three_dots>!<end_line>
+    Let's hurry!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ゴヴァンの遺跡だね<three_dots>！<end_line>
       急ごう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The Govan Ruins<three_dots>!<end_line>
     Let's hurry!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Final Day/053_25626348_18706ec.xml
+++ b/Translation/JE Scripts/Final Day/053_25626348_18706ec.xml
@@ -115,38 +115,45 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			大丈夫か？　<partner><three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			大丈夫？　<partner><three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <partner>, are you okay?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			大丈夫？　<partner><three_dots><end_line>
+		</sjis>
+    <ascii>
+    <partner>, are you okay?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そこの家で<end_line>
 			少し休んでいくか？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そこの家で<end_line>
-			少し休もうか？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Want to rest<end_line>
     over there?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そこの家で<end_line>
+			少し休もうか？<end_line>
+		</sjis>
+    <ascii>
+    Want to rest<end_line>
+    over there?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">

--- a/Translation/JE Scripts/Final Day/055_25627660_1870c0c.xml
+++ b/Translation/JE Scripts/Final Day/055_25627660_1870c0c.xml
@@ -5,15 +5,18 @@
     <sjis>
       お、お前たち<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Y-you two<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、あんたたち<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Y-you two<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -67,6 +70,11 @@
       親方は<three_dots><end_line>
       アニキはどうした！？<end_line>
     </sjis>
+    <ascii>
+    Why are you here<three_dots>?<end_line>
+    What about Master<three_dots><end_line>
+    Where are Master and Jade!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -74,12 +82,12 @@
       親方は<three_dots><end_line>
       アニキはどうしたの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Why are you here<three_dots>?<end_line>
     What about Master<three_dots><end_line>
     Where are Master and Jade!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -104,15 +112,18 @@
     <sjis>
       なんだと<three_dots>っ！？<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
   </ascii>
+  </female>
 </bigtext>
 <dialogue>
   <info box="right">
@@ -137,15 +148,18 @@
     <sjis>
       キサマら<three_dots>、なんてこと<three_dots><end_line>
     </sjis>
+    <ascii>
+    You<three_dots> How could you<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんたたち<three_dots>、なんてこと<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You<three_dots> How could you<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -172,6 +186,11 @@
       本当によかったわ<three_dots><end_line>
       やっぱりアナタたちとの落とし前は<three_dots><end_line>
     </sjis>
+    <ascii>
+    That's right, I'm so glad<end_line>
+    I was able to see you again<three_dots><end_line>
+    Before I take you out<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -179,12 +198,12 @@
       本当によかったわ<three_dots><end_line>
       やっぱりアナタたちとの落とし前は<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's right, I'm so glad<end_line>
     I was able to see you again<three_dots><end_line>
     Before I take you out<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -502,6 +521,11 @@
       下らないことを話してくれたおかげで<end_line>
       落ちつくことができたぜ<three_dots><end_line>
     </sjis>
+    <ascii>
+    Thanks to your stupid speech<end_line>
+    going on so long,<end_line>
+    I was able to calm down<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -509,12 +533,12 @@
       下らないことを話してくれたおかげで<end_line>
       落ちつくことができたわ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Thanks to your stupid speech<end_line>
     going on so long,<end_line>
     I was able to calm down<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -612,17 +636,21 @@
       よっしゃあ！！！<end_line>
       いくぞ、<partner>！<end_line>
     </sjis>
+    <ascii>
+    Bring it on!!!<end_line>
+    Let's go, <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉしっ！！！<end_line>
       いくよ、<partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Bring it on!!!<end_line>
     Let's go, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Final Day/056_25630812_187185c.xml
+++ b/Translation/JE Scripts/Final Day/056_25630812_187185c.xml
@@ -89,17 +89,21 @@
       う、うごくなよ！<end_line>
       うごくと<three_dots><end_line>
     </sjis>
+    <ascii>
+    D-don't move!<end_line>
+    Or else<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       う、うごかないで！<end_line>
       うごくと<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     D-don't move!<end_line>
     Or else<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -183,17 +187,21 @@
       そんな<three_dots><end_line>
       やめろ、<partner><three_dots>！<end_line>
     </sjis>
+    <ascii>
+    No<three_dots><end_line>
+    Stop, <partner><three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そんな<three_dots><end_line>
       やめて、<partner><three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No<three_dots><end_line>
     Stop, <partner><three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="right" effect="big">
@@ -605,17 +613,21 @@
       ご、ごめん<three_dots><end_line>
       レミィも悪かったな<end_line>
     </sjis>
+    <ascii>
+    S-sorry<three_dots><end_line>
+    I even made Lemmy worry about me.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ご、ごめん<three_dots><end_line>
       レミィも心配かけちゃったね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     S-sorry<three_dots><end_line>
     I even made Lemmy worry about me.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Translation/JE Scripts/Final Day/061_25637196_187314c.xml
+++ b/Translation/JE Scripts/Final Day/061_25637196_187314c.xml
@@ -63,15 +63,18 @@
     <sjis>
       なんだよ、これ！？<end_line>
     </sjis>
+    <ascii>
+    What's going on!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、これ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's going on!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -545,15 +548,18 @@
     <sjis>
       はいっ！<end_line>
     </sjis>
+    <ascii>
+    Yes!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       はいっ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Yes!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -626,6 +632,11 @@
       いくぞ<end_line>
       <partner>！<end_line>
     </sjis>
+    <ascii>
+    Like I'd let you!<end_line>
+    Let's go,<end_line>
+    <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -633,12 +644,12 @@
       いくよ<end_line>
       <partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Like I'd let you!<end_line>
     Let's go,<end_line>
     <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Final Day/062_25641116_187409c.xml
+++ b/Translation/JE Scripts/Final Day/062_25641116_187409c.xml
@@ -7,17 +7,21 @@
       これまでだ！<end_line>
       ミューノを返せ！<end_line>
     </sjis>
+    <ascii>
+    That's it!<end_line>
+    Let Murno go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ここまでよ！<end_line>
       ミューノを返して！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's it!<end_line>
     Let Murno go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -230,17 +234,21 @@
       なんだと<three_dots><end_line>
       今なんて<three_dots><end_line>
     </sjis>
+    <ascii>
+    What<three_dots>?<end_line>
+    What was that<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによそれ<three_dots>？<end_line>
       今なんて<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What<three_dots>?<end_line>
     What was that<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="simple" effect="big">
@@ -477,6 +485,11 @@
       おい<three_dots><end_line>
       大丈夫か！？<end_line>
     </sjis>
+    <ascii>
+    <partner><three_dots>!<end_line>
+    Hey<three_dots><end_line>
+    Are you okay!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -484,12 +497,12 @@
       ねえ<three_dots><end_line>
       大丈夫！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner><three_dots>!<end_line>
     Hey<three_dots><end_line>
     Are you okay!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -599,15 +612,18 @@
     <sjis>
       あ、待て<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    Ah, wait<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、待って<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, wait<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Translation/JE Scripts/Final Day/064_25650316_187648c.xml
+++ b/Translation/JE Scripts/Final Day/064_25650316_187648c.xml
@@ -7,6 +7,11 @@
       さっきとあんまり<end_line>
       変わんないみたいだけど<three_dots><end_line>
     </sjis>
+    <ascii>
+    Is<three_dots>this it?<end_line>
+    It doesn't seem any<end_line>
+    different from before<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -14,12 +19,12 @@
       さっきとあんまり<end_line>
       変わらないみたいだけど<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Is<three_dots>this it?<end_line>
     It doesn't seem any<end_line>
     different from before<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -48,6 +53,11 @@
       幻龍鬼とかマグドラドがいた<end_line>
       ルイーズ村の迷宮に、似てるな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Actually, this place<three_dots><end_line>
+    It's quite similar to the<end_line>
+    labyrinth in Louise Village.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -55,12 +65,12 @@
       幻龍鬼とかマグドラドがいた<end_line>
       ルイーズ村の迷宮に、似てるね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Actually, this place<three_dots><end_line>
     It's quite similar to the<end_line>
     labyrinth in Louise Village.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -88,6 +98,11 @@
       とにかく前へ進むぞ！<end_line>
       ミューノを取り返すんだ！<end_line>
     </sjis>
+    <ascii>
+    I don't really get it, but anyway,<end_line>
+    let's keep moving!<end_line>
+    We're gonna get Murno back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -95,12 +110,12 @@
       とにかく前へ進もう！<end_line>
       ミューノを取り返すのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I don't really get it, but anyway,<end_line>
     let's keep moving!<end_line>
     We're gonna get Murno back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -153,6 +168,11 @@
       幻龍鬼とかマグドラドがいた<end_line>
       ルイーズ村の迷宮に、似てるな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Actually, this place<three_dots><end_line>
+    It's quite similar to the<end_line>
+    labyrinth in Louise Village.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -160,12 +180,12 @@
       幻龍鬼とかマグドラドがいた<end_line>
       ルイーズ村の迷宮に、似てるね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Actually, this place<three_dots><end_line>
     It's quite similar to the<end_line>
     labyrinth in Louise Village.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -194,6 +214,11 @@
       とにかく前へ進むぞ！<end_line>
       ミューノを取り返すんだ！<end_line>
     </sjis>
+    <ascii>
+    I don't really get it, but anyway,<end_line>
+    let's keep moving!<end_line>
+    We're gonna get Murno back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -201,12 +226,12 @@
       とにかく前へ進もう！<end_line>
       ミューノを取り返すのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I don't really get it, but anyway,<end_line>
     let's keep moving!<end_line>
     We're gonna get Murno back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -261,6 +286,11 @@
       幻龍鬼とかマグドラドがいた<end_line>
       ルイーズ村の迷宮に、似てるな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Actually, this place<three_dots><end_line>
+    It's quite similar to the<end_line>
+    labyrinth in Louise Village.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -268,12 +298,12 @@
       幻龍鬼とかマグドラドがいた<end_line>
       ルイーズ村の迷宮に、似てるね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Actually, this place<three_dots><end_line>
     It's quite similar to the<end_line>
     labyrinth in Louise Village.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -302,6 +332,11 @@
       とにかく前へ進むぞ！<end_line>
       ミューノを取り返すんだ！<end_line>
     </sjis>
+    <ascii>
+    I don't really get it, but anyway,<end_line>
+    let's keep moving!<end_line>
+    We're gonna get Murno back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -309,12 +344,12 @@
       とにかく前へ進もう！<end_line>
       ミューノを取り返すのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I don't really get it, but anyway,<end_line>
     let's keep moving!<end_line>
     We're gonna get Murno back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -369,6 +404,11 @@
       幻龍鬼とかマグドラドがいた<end_line>
       ルイーズ村の迷宮に、似てるな<three_dots><end_line>
     </sjis>
+    <ascii>
+    Actually, this place<three_dots><end_line>
+    It's quite similar to the<end_line>
+    labyrinth in Louise Village.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -376,12 +416,12 @@
       幻龍鬼とかマグドラドがいた<end_line>
       ルイーズ村の迷宮に、似てるね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Actually, this place<three_dots><end_line>
     It's quite similar to the<end_line>
     labyrinth in Louise Village.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -408,6 +448,11 @@
       とにかく前へ進むぞ！<end_line>
       ミューノを取り返すんだ！<end_line>
     </sjis>
+    <ascii>
+    I don't really get it, but anyway,<end_line>
+    let's keep moving!<end_line>
+    We're gonna get Murno back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -415,12 +460,12 @@
       とにかく前へ進もう！<end_line>
       ミューノを取り返すのよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I don't really get it, but anyway,<end_line>
     let's keep moving!<end_line>
     We're gonna get Murno back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Translation/JE Scripts/Final Day/070_25652188_1876bdc.xml
+++ b/Translation/JE Scripts/Final Day/070_25652188_1876bdc.xml
@@ -1,4 +1,3 @@
-#401
 <dialogue>
   <info box="left">
   <portrait_l entry="player" eye="decided" mouth="yell">
@@ -8,6 +7,11 @@
       待てよ！<end_line>
       ミューノを返せ！<end_line>
     </sjis>
+    <ascii>
+    Hey!<end_line>
+    Wait!<end_line>
+    Let Murno go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -15,12 +19,12 @@
       待ちなさい！<end_line>
       ミューノを返して！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hey!<end_line>
     Wait!<end_line>
     Let Murno go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -269,17 +273,21 @@
       あ！？<end_line>
       おい<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah!?<end_line>
+    Hey<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ！？<end_line>
       ちょっと<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah!?<end_line>
     Hey<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -303,17 +311,21 @@
       な<three_dots><end_line>
       ちょっと待てよ！？<end_line>
     </sjis>
+    <ascii>
+    Wha<three_dots><end_line>
+    Will you just wait a second!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な<three_dots><end_line>
       ちょっと待ってよ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wha<three_dots><end_line>
     Will you just wait a second!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -362,15 +374,18 @@
     <sjis>
       な、なんだと！<end_line>
     </sjis>
+    <ascii>
+    What was that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       な、なんですって！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What was that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -437,15 +452,18 @@
     <sjis>
       お、お前<three_dots>！？<end_line>
     </sjis>
+    <ascii>
+    A-anise<three_dots>!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、あんた<three_dots>！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     A-anise<three_dots>!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -533,6 +551,11 @@
       待て！<end_line>
       これはオレじゃない！<end_line>
     </sjis>
+    <ascii>
+    I-its mad!?<end_line>
+    Wait!<end_line>
+    I didn't do anything!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -540,12 +563,12 @@
       待って！<end_line>
       これはわたしじゃないの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I-its mad!?<end_line>
     Wait!<end_line>
     I didn't do anything!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="left" effect="big">
@@ -870,6 +893,11 @@
       あつい、ぞ<three_dots>？<end_line>
       これ<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    What<three_dots>?<end_line>
+    It's<three_dots> hot?<end_line>
+    This<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -877,12 +905,12 @@
       あつい、よ<three_dots>？<end_line>
       これ<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What<three_dots>?<end_line>
     It's<three_dots> hot?<end_line>
     This<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -908,15 +936,18 @@
     <sjis>
       次はなんだよ！？<end_line>
     </sjis>
+    <ascii>
+    What is it this time!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今度はなんなのよ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is it this time!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -957,6 +988,11 @@
       あつい、ぞ<three_dots>？<end_line>
       これ<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    What<three_dots>?<end_line>
+    It's<three_dots> hot?<end_line>
+    This<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -964,12 +1000,12 @@
       あつい、よ<three_dots>？<end_line>
       これ<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What<three_dots>?<end_line>
     It's<three_dots> hot?<end_line>
     This<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -995,15 +1031,18 @@
     <sjis>
       次はなんだよ！？<end_line>
     </sjis>
+    <ascii>
+    What is it this time!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今度はなんなのよ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is it this time!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -1042,6 +1081,11 @@
       あつい、ぞ<three_dots>？<end_line>
       これ<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    What<three_dots>?<end_line>
+    It's<three_dots> hot?<end_line>
+    This<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1049,12 +1093,12 @@
       あつい、よ<three_dots>？<end_line>
       これ<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What<three_dots>?<end_line>
     It's<three_dots> hot?<end_line>
     This<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1080,15 +1124,18 @@
     <sjis>
       次はなんだよ！？<end_line>
     </sjis>
+    <ascii>
+    What is it this time!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今度はなんなのよ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is it this time!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -1127,6 +1174,11 @@
       あつい、ぞ<three_dots>？<end_line>
       これ<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    What<three_dots>?<end_line>
+    It's<three_dots> hot?<end_line>
+    This<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1134,12 +1186,12 @@
       あつい、よ<three_dots>？<end_line>
       これ<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What<three_dots>?<end_line>
     It's<three_dots> hot?<end_line>
     This<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -1165,15 +1217,18 @@
     <sjis>
       次はなんだよ！？<end_line>
     </sjis>
+    <ascii>
+    What is it this time!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       今度はなんなのよ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is it this time!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">

--- a/Translation/JE Scripts/Final Day/071_25657932_187824c.xml
+++ b/Translation/JE Scripts/Final Day/071_25657932_187824c.xml
@@ -17,6 +17,11 @@
       マグドラド、おちついた<three_dots><end_line>
       かな<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    We did it!<end_line>
+    Magdrad calmed down<three_dots><end_line>
+    Right<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -24,12 +29,12 @@
       マグドラド、おちついた<three_dots><end_line>
       かな<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     We did it!<end_line>
     Magdrad calmed down<three_dots><end_line>
     Right<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -52,6 +57,10 @@
       大丈夫か！？<end_line>
       早くなんとかしないと<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah! Are you okay?<end_line>
+    I have to do something<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -59,11 +68,11 @@
       大丈夫！？<end_line>
       早くなんとかしないと<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah! Are you okay?<end_line>
     I have to do something<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -89,17 +98,21 @@
       でもお前<three_dots><end_line>
       そのケガで<three_dots><end_line>
     </sjis>
+    <ascii>
+    But<three_dots><end_line>
+    With your injuries<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       でもあんた<three_dots><end_line>
       そのケガで<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     But<three_dots><end_line>
     With your injuries<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -109,17 +122,21 @@
       お<three_dots>おい<three_dots><end_line>
       な、なんだよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    H<three_dots>hey<three_dots><end_line>
+    W-what is this<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え<three_dots>ちょっと<three_dots><end_line>
       な、なんなのよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     H<three_dots>hey<three_dots><end_line>
     W-what is this<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -221,6 +238,11 @@
       お前<three_dots><end_line>
       大丈夫か？<end_line>
     </sjis>
+    <ascii>
+    H-hey<three_dots>!<end_line>
+    Are<three_dots><end_line>
+    Are you okay?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -228,12 +250,12 @@
       あんた<three_dots><end_line>
       大丈夫なの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     H-hey<three_dots>!<end_line>
     Are<three_dots><end_line>
     Are you okay?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -322,15 +344,18 @@
     <sjis>
       なんだよ<three_dots><end_line>
     </sjis>
+    <ascii>
+    What's with her<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なんなのよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What's with her<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -350,17 +375,21 @@
       あ、そうだ<end_line>
       ありがとうな<end_line>
     </sjis>
+    <ascii>
+    Ah, right.<end_line>
+    Thanks.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、そうだ<end_line>
       ありがとうね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, right.<end_line>
     Thanks.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -381,6 +410,11 @@
       幻龍鬼があらわれるなんて<end_line>
       思ってもみなかったぜ<three_dots><end_line>
     </sjis>
+    <ascii>
+    I had no idea<end_line>
+    the Phantom Dragon<end_line>
+    would show up here<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -388,12 +422,12 @@
       幻龍鬼があらわれるなんて<end_line>
       思ってもみなかったよ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I had no idea<end_line>
     the Phantom Dragon<end_line>
     would show up here<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -461,6 +495,11 @@
       ま、とにかく今は<end_line>
       先に進もう！<end_line>
     </sjis>
+    <ascii>
+    Maybe<three_dots><end_line>
+    Anyway, we've<end_line>
+    got to keep moving!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -468,10 +507,10 @@
       ま、とにかく今は<end_line>
       先に進もう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Maybe<three_dots><end_line>
     Anyway, we've<end_line>
     got to keep moving!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Final Day/077_25660204_1878b2c.xml
+++ b/Translation/JE Scripts/Final Day/077_25660204_1878b2c.xml
@@ -7,6 +7,10 @@
       <partner>！<end_line>
       大丈夫か？<end_line>
     </sjis>
+    <ascii>
+    <partner>,<end_line>
+    what's wrong!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -14,11 +18,11 @@
       <partner>！<end_line>
       大丈夫？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     <partner>,<end_line>
     what's wrong!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -93,15 +97,19 @@
       お、おう<three_dots><end_line>
       わかった！<end_line>
     </sjis>
+    <ascii>
+    Y-yeah<three_dots><end_line>
+    I will!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       う、うん<three_dots><end_line>
       わかった！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Y-yeah<three_dots><end_line>
     I will!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Final Day/079_25661388_1878fcc.xml
+++ b/Translation/JE Scripts/Final Day/079_25661388_1878fcc.xml
@@ -6,17 +6,21 @@
       なんだ、あれ<three_dots><end_line>
       剣？<end_line>
     </sjis>
+    <ascii>
+    What is that<three_dots><end_line>
+    A sword?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なに、あれ<three_dots><end_line>
       剣？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is that<three_dots><end_line>
     A sword?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -104,15 +108,18 @@
     <sjis>
       こいつが、原因<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    This is it<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あいつが、原因<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This is it<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -238,15 +245,18 @@
     <sjis>
       そこをどけ！<end_line>
     </sjis>
+    <ascii>
+    Move aside!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そこをどいて！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Move aside!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -352,17 +362,21 @@
       エラそうなのはどっちだよ！<end_line>
       とにかくミューノを返せ！<end_line>
     </sjis>
+    <ascii>
+    No, that's you!<end_line>
+    Anyway, give Murno back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       エラそうなのはどっちよ！<end_line>
       とにかくミューノを返して！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No, that's you!<end_line>
     Anyway, give Murno back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Final Day/080_25665676_187a08c.xml
+++ b/Translation/JE Scripts/Final Day/080_25665676_187a08c.xml
@@ -311,6 +311,11 @@
       おい、どうしたんだ？<end_line>
       <partner>！？<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+    Hey, what's going on?<end_line>
+    <partner>!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -318,12 +323,12 @@
       ねえ、どうしたの？<end_line>
       <partner>！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
     Hey, what's going on?<end_line>
     <partner>!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -400,6 +405,11 @@
       おい、<partner>！<end_line>
       どうしたんだよ！？<end_line>
     </sjis>
+    <ascii>
+    Wha!?<end_line>
+    Hey, <partner>!<end_line>
+    What's wrong!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -407,12 +417,12 @@
       ちょっと、<partner>！<end_line>
       どうしたの！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Wha!?<end_line>
     Hey, <partner>!<end_line>
     What's wrong!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -436,17 +446,21 @@
       なんだよ<end_line>
       何が起こってるんだよ！？<end_line>
     </sjis>
+    <ascii>
+    What?<end_line>
+    What's going on!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なんなの<end_line>
       何が起こってるのよ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What?<end_line>
     What's going on!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="simple" effect="big">
@@ -647,6 +661,11 @@
       <partner>、ウソだろ<three_dots><end_line>
       お前<three_dots><end_line>
     </sjis>
+    <ascii>
+    No<three_dots><end_line>
+    <partner><three_dots><end_line>
+    Why<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -654,12 +673,12 @@
       <partner>、ウソでしょ<three_dots><end_line>
       あなた<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No<three_dots><end_line>
     <partner><three_dots><end_line>
     Why<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -703,17 +722,21 @@
       やめろ、<partner>っ！<end_line>
       目を覚ませ！<end_line>
     </sjis>
+    <ascii>
+    Stop it, <partner>!<end_line>
+    Open your eyes!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       やめて、<partner>っ！<end_line>
       目を覚まして！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Stop it, <partner>!<end_line>
     Open your eyes!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -891,17 +914,21 @@
       お前<three_dots><end_line>
       アニス<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    You're<three_dots><end_line>
+    Anise<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あんた<three_dots><end_line>
       アニス<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You're<three_dots><end_line>
     Anise<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1165,16 +1192,19 @@
       なんだと<three_dots><end_line>
       お前、それって<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Don't tell me, you<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ<three_dots><end_line>
       あんた、もしかして<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Don't tell me, you<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Translation/JE Scripts/Final Day/081_25677660_187cf5c.xml
+++ b/Translation/JE Scripts/Final Day/081_25677660_187cf5c.xml
@@ -1,4 +1,3 @@
-#final fight vee
 <bigtext>
   <info box="right" effect="big">
   <portrait_r entry="partner" eye="decided" mouth="yell">
@@ -76,6 +75,10 @@
       忘れたなんて<end_line>
       ウソだろ、<partner>！<end_line>
     </sjis>
+    <ascii>
+    No<three_dots><end_line>
+    That's a lie, right, <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -83,11 +86,11 @@
       忘れたなんて<end_line>
       ウソでしょ、<partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     No<three_dots><end_line>
     That's a lie, right, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">
@@ -227,6 +230,11 @@
       <partner>はもう<end_line>
       オレのことなんかわからないって<three_dots><end_line>
     </sjis>
+    <ascii>
+    Even if you say that,<end_line>
+    <partner> doesn't<end_line>
+    recognize me anymore<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -234,12 +242,12 @@
       <partner>はもう<end_line>
       わたしのことなんかわからないって<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Even if you say that,<end_line>
     <partner> doesn't<end_line>
     recognize me anymore<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -399,6 +407,11 @@
       お前と鍛えたこの武器で<end_line>
       今すぐ目覚めさせてやるぜ！<end_line>
     </sjis>
+    <ascii>
+    Come! <partner>!<end_line>
+    I'll bring you back right now<end_line>
+    with the weapons we forged together!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -406,10 +419,10 @@
       あなたと鍛えたこの武器で<end_line>
       今すぐ目覚めさせてあげる！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Come! <partner>!<end_line>
     I'll bring you back right now<end_line>
     with the weapons we forged together!<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Final Day/082_25687516_187f5dc.xml
+++ b/Translation/JE Scripts/Final Day/082_25687516_187f5dc.xml
@@ -24,17 +24,21 @@
       オレがわかるのか、<partner>？<end_line>
       もとにもどったのか！<end_line>
     </sjis>
+    <ascii>
+    You recognize me, <partner>?<end_line>
+    You're back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしがわかるの、<partner>？<end_line>
       もとにもどったのね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You recognize me, <partner>?<end_line>
     You're back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -74,15 +78,18 @@
     <sjis>
       あの遺跡だな！<end_line>
     </sjis>
+    <ascii>
+    The ruins, right!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あの遺跡ね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The ruins, right!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -108,17 +115,21 @@
       よっしゃ！<end_line>
       やってみるか！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    I'll give it a try!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       やってみよう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     I'll give it a try!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -146,17 +157,21 @@
       オレがわかるのか、<partner>？<end_line>
       もとにもどったのか！<end_line>
     </sjis>
+    <ascii>
+    You recognize me, <partner>?<end_line>
+    You're back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしがわかるの、<partner>？<end_line>
       もとにもどったのね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You recognize me, <partner>?<end_line>
     You're back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -195,15 +210,18 @@
     <sjis>
       あの遺跡だな！<end_line>
     </sjis>
+    <ascii>
+    The ruins, right!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あの遺跡ね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The ruins, right!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="enzi">
@@ -229,17 +247,21 @@
       よっしゃ！<end_line>
       やってみるか！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    I'll give it a try!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       やってみよう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     I'll give it a try!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -267,17 +289,21 @@
       オレがわかるのか、<partner>？<end_line>
       もとにもどったのか！<end_line>
     </sjis>
+    <ascii>
+    You recognize me, <partner>?<end_line>
+    You're back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしがわかるの、<partner>？<end_line>
       もとにもどったのね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You recognize me, <partner>?<end_line>
     You're back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -318,15 +344,18 @@
     <sjis>
       あの遺跡だな！<end_line>
     </sjis>
+    <ascii>
+    The ruins, right!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あの遺跡ね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The ruins, right!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="killfith">
@@ -352,17 +381,21 @@
       よっしゃ！<end_line>
       やってみるか！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    I'll give it a try!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       やってみよう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     I'll give it a try!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -390,17 +423,21 @@
       オレがわかるのか、<partner>？<end_line>
       もとにもどったのか！<end_line>
     </sjis>
+    <ascii>
+    You recognize me, <partner>?<end_line>
+    You're back!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしがわかるの、<partner>？<end_line>
       もとにもどったのね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You recognize me, <partner>?<end_line>
     You're back!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -439,15 +476,18 @@
     <sjis>
       あの遺跡だな！<end_line>
     </sjis>
+    <ascii>
+    The ruins, right!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あの遺跡ね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     The ruins, right!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="rufeel">
@@ -473,17 +513,21 @@
       よっしゃ！<end_line>
       やってみるか！<end_line>
     </sjis>
+    <ascii>
+    Alright!<end_line>
+    I'll give it a try!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       よぉし！<end_line>
       やってみよう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Alright!<end_line>
     I'll give it a try!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -531,6 +575,11 @@
       いいところに来た！<end_line>
       アニスをたのむ！<end_line>
     </sjis>
+    <ascii>
+    Tier!<end_line>
+    Good timing!<end_line>
+    Take care of Anise for me!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -538,12 +587,12 @@
       いいところに来てくれたね！<end_line>
       アニスをおねがい！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Tier!<end_line>
     Good timing!<end_line>
     Take care of Anise for me!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -580,17 +629,21 @@
       レミィもウェルマンさんを<end_line>
       たのむ！<end_line>
     </sjis>
+    <ascii>
+    Lemmy, you take care of Wellman,<end_line>
+    please!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       レミィもウェルマンさんを<end_line>
       おねがい！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Lemmy, you take care of Wellman,<end_line>
     please!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -682,17 +735,21 @@
       さすが親方！　カッコイイ！<end_line>
       その調子でアニスもたのむよ！<end_line>
     </sjis>
+    <ascii>
+    That's my Master! So cool!<end_line>
+    I'll leave Anise to you!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       さすが親方！　カッコイイ！<end_line>
       その調子でアニスもおねがいね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     That's my Master! So cool!<end_line>
     I'll leave Anise to you!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -718,17 +775,21 @@
       レミィもウェルマンさんを<end_line>
       たのむ！<end_line>
     </sjis>
+    <ascii>
+    Lemmy, you take care of Wellman,<end_line>
+    please!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       レミィもウェルマンさんを<end_line>
       おねがい！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Lemmy, you take care of Wellman,<end_line>
     please!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -810,6 +871,11 @@
       いいところに来てくれたよ！<end_line>
       アニスをたのむ！<end_line>
     </sjis>
+    <ascii>
+    Brother!<end_line>
+    Good timing!<end_line>
+    Take care of Anise for me!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -817,12 +883,12 @@
       いいところに来てくれたね！<end_line>
       アニスをおねがい！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Brother!<end_line>
     Good timing!<end_line>
     Take care of Anise for me!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -859,17 +925,21 @@
       レミィもウェルマンさんを<end_line>
       たのむ！<end_line>
     </sjis>
+    <ascii>
+    Lemmy, you take care of Wellman,<end_line>
+    please!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       レミィもウェルマンさんを<end_line>
       おねがい！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Lemmy, you take care of Wellman,<end_line>
     please!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -981,15 +1051,18 @@
     <sjis>
       いくぞ、<partner>！<end_line>
     </sjis>
+    <ascii>
+    Let's go, <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       いくよ、<partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Let's go, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Final Day/084_25691036_188039c.xml
+++ b/Translation/JE Scripts/Final Day/084_25691036_188039c.xml
@@ -159,6 +159,11 @@
       おそくなっちゃって<three_dots><end_line>
       本当に、ごめん<three_dots><end_line>
     </sjis>
+    <ascii>
+    I'm the one who should apologize<three_dots><end_line>
+    I was late<three_dots><end_line>
+    I'm really sorry<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -166,12 +171,12 @@
       おそくなっちゃって<three_dots><end_line>
       本当に、ごめんね<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm the one who should apologize<three_dots><end_line>
     I was late<three_dots><end_line>
     I'm really sorry<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -391,15 +396,18 @@
     <sjis>
       なにするんだ！<end_line>
     </sjis>
+    <ascii>
+    What are you doing!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なにするの！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What are you doing!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Translation/JE Scripts/Final Day/085_25901276_18b38dc.xml
+++ b/Translation/JE Scripts/Final Day/085_25901276_18b38dc.xml
@@ -15,13 +15,16 @@
     <sjis>
       こっちからは上に戻れないみたいだ<end_line>
     </sjis>
+    <ascii>
+    Can't go up this way.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       こっちからは上に戻れないみたい<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Can't go up this way.<end_line>
   </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Final Day/086_25693692_1880dfc.xml
+++ b/Translation/JE Scripts/Final Day/086_25693692_1880dfc.xml
@@ -1,4 +1,3 @@
-#More branching dialogue here
 <dialogue>
   <partner name="run-dor">
   <info box="simple">
@@ -258,17 +257,21 @@
       あ、ああ<three_dots><end_line>
       オレは<three_dots>？<end_line>
     </sjis>
+    <ascii>
+    Ah, huh<three_dots><end_line>
+    I<three_dots>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、あれ<three_dots><end_line>
       わたし<three_dots>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, huh<three_dots><end_line>
     I<three_dots>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -508,17 +511,21 @@
       あ、大丈夫だぜ～！<end_line>
       レミィ！<end_line>
     </sjis>
+    <ascii>
+    Ah, I'm fine~!<end_line>
+    Lemmy~!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あ、大丈夫だよ～！<end_line>
       レミィ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah, I'm fine~!<end_line>
     Lemmy~!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="simple">

--- a/Translation/JE Scripts/Final Day/087_25696044_188172c.xml
+++ b/Translation/JE Scripts/Final Day/087_25696044_188172c.xml
@@ -1,4 +1,3 @@
-#390
 <dialogue>
   <info box="left">
   <portrait_l entry="player" eye="surprised" mouth="talk">
@@ -266,6 +265,11 @@
       オレたちだって大丈夫だったんだ<end_line>
       だから、きっと<three_dots><end_line>
     </sjis>
+    <ascii>
+    Ah<three_dots>, um<three_dots><end_line>
+    We got out of it fine,<end_line>
+    so I'm sure<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -273,12 +277,12 @@
       わたしたちだって大丈夫だったんだよ<end_line>
       だから、きっと<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ah<three_dots>, um<three_dots><end_line>
     We got out of it fine,<end_line>
     so I'm sure<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -353,15 +357,18 @@
     <sjis>
       なんだよ、それ<three_dots><end_line>
     </sjis>
+    <ascii>
+    What the<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、それ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What the<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -1089,17 +1096,21 @@
       こ<three_dots><end_line>
       こんな、でかい<three_dots><end_line>
     </sjis>
+    <ascii>
+    It's<three_dots><end_line>
+    It's huge<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       こ<three_dots><end_line>
       こんな、おっきい<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     It's<three_dots><end_line>
     It's huge<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="right" effect="big">

--- a/Translation/JE Scripts/Final Day/088_25702060_1882eac.xml
+++ b/Translation/JE Scripts/Final Day/088_25702060_1882eac.xml
@@ -74,15 +74,18 @@
     <sjis>
       もうやめろ！<end_line>
     </sjis>
+    <ascii>
+    Enough already!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       もうやめて！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Enough already!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="right" effect="big">
@@ -101,15 +104,18 @@
     <sjis>
       なんだ！？<end_line>
     </sjis>
+    <ascii>
+    What!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、これ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -169,7 +175,7 @@
     あの人の体が<three_dots><end_line>
     取り込まれてしまいますわ<three_dots>！<end_line>
   </sjis>
-   <ascii>
+  <ascii>
     What<three_dots> this awful power<three_dots><end_line>
     His body is<three_dots><end_line>
     Being consumed<three_dots>!<end_line>
@@ -183,15 +189,18 @@
     <sjis>
       剣に<three_dots>、喰われる！？<end_line>
     </sjis>
+    <ascii>
+    Consumed<three_dots> by the sword!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       剣に<three_dots>、喰べられる！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Consumed<three_dots> by the sword!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="right" effect="big">
@@ -212,6 +221,11 @@
       吸い込まれる<three_dots>！？<end_line>
       <partner><three_dots>！<end_line>
     </sjis>
+    <ascii>
+    What is this<three_dots>!<end_line>
+    I'm getting sucked in<three_dots>!?<end_line>
+    <partner><three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -219,12 +233,12 @@
       吸い込まれる<three_dots>！？<end_line>
       <partner><three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is this<three_dots>!<end_line>
     I'm getting sucked in<three_dots>!?<end_line>
     <partner><three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Final Day/090_25704076_188368c.xml
+++ b/Translation/JE Scripts/Final Day/090_25704076_188368c.xml
@@ -6,17 +6,21 @@
       なんだよ<three_dots>？<end_line>
       ここはドコなんだよ<three_dots>！？<end_line>
     </sjis>
+    <ascii>
+    What just<three_dots>?<end_line>
+    Where are we<three_dots>!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ、これ<three_dots>？<end_line>
       ここはドコなのよ<three_dots>！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What just<three_dots>?<end_line>
     Where are we<three_dots>!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -531,15 +535,18 @@
     <sjis>
       行くぞ、<partner>！<end_line>
     </sjis>
+    <ascii>
+    Let's go, <partner>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       行くよ、<partner>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Let's go, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Final Day/091_25707212_18842cc.xml
+++ b/Translation/JE Scripts/Final Day/091_25707212_18842cc.xml
@@ -77,15 +77,18 @@
     <sjis>
       なんだよ！　あれ！？<end_line>
     </sjis>
+    <ascii>
+    What is that!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       なによ！　あれ！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     What is that!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -227,6 +230,11 @@
       どうしたんだ<three_dots>？<end_line>
       暗くなってくぞ<three_dots>！？<end_line>
     </sjis>
+    <ascii>
+    Huh<three_dots>!?<end_line>
+    What's going on<three_dots>?<end_line>
+    It's getting dark<three_dots>!?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -234,12 +242,12 @@
       どうしたの<three_dots>？<end_line>
       暗くなってく<three_dots>！？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Huh<three_dots>!?<end_line>
     What's going on<three_dots>?<end_line>
     It's getting dark<three_dots>!?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -432,17 +440,21 @@
       お前が先だ！<end_line>
       行けぇっ！<end_line>
     </sjis>
+    <ascii>
+    You first!<end_line>
+    Go!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       あなたが先よ！<end_line>
       行ってぇっ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     You first!<end_line>
     Go!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -504,17 +516,21 @@
       オレも<three_dots><end_line>
       間に合えっ<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    I can<three_dots><end_line>
+    Make it<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       わたしも<three_dots><end_line>
       間に合って<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I can<three_dots><end_line>
     Make it<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1429,15 +1445,18 @@
     <sjis>
       何だ、今<three_dots><end_line>
     </sjis>
+    <ascii>
+    Just now, that was<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       何、今<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Just now, that was<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1560,6 +1579,11 @@
       みんなの元へ！<end_line>
       だから<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    I'm going back!<end_line>
+    To where everyone is!<end_line>
+    So<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1567,12 +1591,12 @@
       みんなの元へ！<end_line>
       だから<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I'm going back!<end_line>
     To where everyone is!<end_line>
     So<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">
@@ -1805,15 +1829,18 @@
     <sjis>
       開けっ！！！<end_line>
     </sjis>
+    <ascii>
+    Open!!!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       開いてっ！！！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Open!!!<end_line>
   </ascii>
+  </female>
 </bigtext>
 <dialogue>
   <info box="left">

--- a/Translation/JE Scripts/Final Day/093_25713660_1885bfc.xml
+++ b/Translation/JE Scripts/Final Day/093_25713660_1885bfc.xml
@@ -29,6 +29,11 @@
       オレ<three_dots><end_line>
       戻ったんだ<three_dots><end_line>
     </sjis>
+    <ascii>
+    This is<three_dots><end_line>
+    I<three_dots><end_line>
+    I'm back<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -36,12 +41,12 @@
       わたし<three_dots><end_line>
       戻ったんだ<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     This is<three_dots><end_line>
     I<three_dots><end_line>
     I'm back<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -223,6 +228,11 @@
       わからないよ！<end_line>
       だから<three_dots>！<end_line>
     </sjis>
+    <ascii>
+    I won't know<end_line>
+    until I try!<end_line>
+    So<three_dots>!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -230,12 +240,12 @@
       わからないですよ！<end_line>
       だから<three_dots>！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I won't know<end_line>
     until I try!<end_line>
     So<three_dots>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <bigtext>
   <info box="left" effect="big">
@@ -509,6 +519,11 @@
       ありがとう<three_dots>！<end_line>
       オレ、絶対にあきらめないぜ！<end_line>
     </sjis>
+    <ascii>
+    Everyone<three_dots><end_line>
+    Thank you<three_dots>!<end_line>
+    I will never give up!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -516,12 +531,12 @@
       ありがとう<three_dots>！<end_line>
       わたし、絶対にあきらめないよ！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Everyone<three_dots><end_line>
     Thank you<three_dots>!<end_line>
     I will never give up!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -966,7 +981,8 @@
   <portrait_r entry="jade" eye="decided" mouth="talk">
   <sjis>
     おう<end_line>
-  </sjis><ascii>
+  </sjis>
+  <ascii>
     Yeah.<end_line>
   </ascii>
 </dialogue>

--- a/Translation/JE Scripts/Final Day/095_25946652_18bea1c.xml
+++ b/Translation/JE Scripts/Final Day/095_25946652_18bea1c.xml
@@ -151,17 +151,21 @@
       え<three_dots>？<end_line>
       なんだよ？<end_line>
     </sjis>
+    <ascii>
+    Eh<three_dots>?<end_line>
+    What's that mean?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え<three_dots>？<end_line>
       なによ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh<three_dots>?<end_line>
     What's that mean?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -743,17 +747,21 @@
       ミューノ<three_dots><end_line>
       本当にそれでいいのか？<end_line>
     </sjis>
+    <ascii>
+    Murno<three_dots><end_line>
+    Are you really okay with this?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       ミューノ<three_dots><end_line>
       本当にそれでいいの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Murno<three_dots><end_line>
     Are you really okay with this?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -780,6 +788,11 @@
       じゃ、これからもよろしくたのむぜ<end_line>
       <partner><end_line>
     </sjis>
+    <ascii>
+    I see<three_dots><end_line>
+    Let's continue to get along then,<end_line>
+    <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -787,12 +800,12 @@
       じゃあ、これからもよろしくね<end_line>
       <partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see<three_dots><end_line>
     Let's continue to get along then,<end_line>
     <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -903,17 +916,21 @@
       え、お前<end_line>
       召喚獣いるの？<end_line>
     </sjis>
+    <ascii>
+    Eh, you have<end_line>
+    a Summon Beast?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       え、あんた<end_line>
       召喚獣いるの？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Eh, you have<end_line>
     a Summon Beast?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -950,17 +967,21 @@
       へえ<three_dots><end_line>
       どうだ、<partner>？<end_line>
     </sjis>
+    <ascii>
+    Ohh<three_dots><end_line>
+    Well, <partner>?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       へえ<three_dots><end_line>
       どう、<partner>？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Ohh<three_dots><end_line>
     Well, <partner>?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -1025,17 +1046,21 @@
       そっか<end_line>
       じゃ、決まりだな<end_line>
     </sjis>
+    <ascii>
+    I see.<end_line>
+    Then it's decided.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       そっか<end_line>
       じゃ、決まりね<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I see.<end_line>
     Then it's decided.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">
@@ -1337,6 +1362,11 @@
       ミューノ<three_dots><end_line>
       必ずまた会おうぜ！<end_line>
     </sjis>
+    <ascii>
+    I will!<end_line>
+    Murno<three_dots><end_line>
+    I'm sure we'll meet again!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -1344,12 +1374,12 @@
       ミューノ<three_dots><end_line>
       必ずまた会おうね！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I will!<end_line>
     Murno<three_dots><end_line>
     I'm sure we'll meet again!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="right">

--- a/Translation/JE Scripts/Final Day/101_25959308_18c1b8c.xml
+++ b/Translation/JE Scripts/Final Day/101_25959308_18c1b8c.xml
@@ -66,6 +66,11 @@
       第一ロックって、名も無き世界の<end_line>
       音楽なんだろ？<end_line>
     </sjis>
+    <ascii>
+    I really don't get it<three_dots><end_line>
+    First of all, rock is music from<end_line>
+    the Nameless World, right?<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -73,12 +78,12 @@
       第一ロックって、名も無き世界の<end_line>
       音楽なんでしょ？<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I really don't get it<three_dots><end_line>
     First of all, rock is music from<end_line>
     the Nameless World, right?<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <info box="left">

--- a/Translation/JE Scripts/Final Day/25671964_187b91c.xml
+++ b/Translation/JE Scripts/Final Day/25671964_187b91c.xml
@@ -1,4 +1,3 @@
-#similar text to 187cf5c. maybe this depends on who you chose in day 10? shit.
 <bigtext>
 	<info box="right" effect="big">
 	<portrait_r entry="partner" eye="decided" mouth="yell">
@@ -72,23 +71,27 @@
 	<portrait_l entry="player" eye="sad" mouth="yell">
 	<portrait_r entry="anise" eye="special" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そんな<three_dots><end_line>
 			忘れたなんて<end_line>
 			ウソだろ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    No<three_dots><end_line>
+    That's a lie, right, <partner>!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そんな<three_dots><end_line>
 			忘れたなんて<end_line>
 			ウソでしょ、<partner>！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     No<three_dots><end_line>
     That's a lie, right, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
@@ -266,22 +269,27 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			こいっ！　<partner>！<end_line>
 			お前と鍛えたこの武器で<end_line>
 			今すぐ目覚めさせてやるぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			きなさい！　<partner>！<end_line>
-			あなたと鍛えたこの武器で<end_line>
-			今すぐ目覚めさせてあげる！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Come! <partner>!<end_line>
     I'll bring you back right now<end_line>
     with the weapons we forged together!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			きなさい！　<partner>！<end_line>
+			あなたと鍛えたこの武器で<end_line>
+			今すぐ目覚めさせてあげる！<end_line>
+		</sjis>
+    <ascii>
+    Come! <partner>!<end_line>
+    I'll bring you back right now<end_line>
+    with the weapons we forged together!<end_line>
+  </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Final Day/25674140_187c19c.xml
+++ b/Translation/JE Scripts/Final Day/25674140_187c19c.xml
@@ -2,24 +2,29 @@
 	<info box="left">
 	<portrait_l name="player">
 	<male>
-		<sjis>
+    <sjis>
 			うるさい！<end_line>
 			やめろ！<end_line>
 			<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うるさい！<end_line>
-			やめて！<end_line>
-			<partner>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Calm down!<end_line>
     Stop!<end_line>
     <partner>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うるさい！<end_line>
+			やめて！<end_line>
+			<partner>！<end_line>
+		</sjis>
+    <ascii>
+    Calm down!<end_line>
+    Stop!<end_line>
+    <partner>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -55,21 +60,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="talk">
 	<portrait_r entry="partner" eye="surprised" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			<partner><three_dots>！<end_line>
 			元にもどったのか！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<partner><three_dots>！<end_line>
-			元にもどったの！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <partner><three_dots>!<end_line>
     Are you okay!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<partner><three_dots>！<end_line>
+			元にもどったの！？<end_line>
+		</sjis>
+    <ascii>
+    <partner><three_dots>!<end_line>
+    Are you okay!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -109,21 +118,25 @@
 	<portrait_l entry="player" eye="sad" mouth="serious">
 	<portrait_r entry="partner" eye="surprised" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ？<end_line>
 			オレ、どうすればいいんだ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ？<end_line>
-			わたし、どうすればいいの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Wait, what?<end_line>
     So what do I do?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ？<end_line>
+			わたし、どうすればいいの？<end_line>
+		</sjis>
+    <ascii>
+    Wait, what?<end_line>
+    So what do I do?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -169,24 +182,29 @@
 	<portrait_l entry="player" eye="surprised" mouth="yell">
 	<portrait_r entry="partner" eye="surprised" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			こわせ<three_dots>って<end_line>
 			バカ！　なに言ってるんだよ！？<end_line>
 			そんなことできるかよ！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			こわして<three_dots>って<end_line>
-			バカ！　なに言ってるの！？<end_line>
-			そんなことできるわけないよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Destroy<three_dots>!?<end_line>
     Idiot! What are you saying!?<end_line>
     I can't do that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			こわして<three_dots>って<end_line>
+			バカ！　なに言ってるの！？<end_line>
+			そんなことできるわけないよ！<end_line>
+		</sjis>
+    <ascii>
+    Destroy<three_dots>!?<end_line>
+    Idiot! What are you saying!?<end_line>
+    I can't do that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -261,21 +279,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="talk">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			<partner><three_dots>！<end_line>
 			元にもどったのか！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<partner><three_dots>！<end_line>
-			元にもどったの！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <partner><three_dots>!<end_line>
     Are you okay!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<partner><three_dots>！<end_line>
+			元にもどったの！？<end_line>
+		</sjis>
+    <ascii>
+    <partner><three_dots>!<end_line>
+    Are you okay!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -315,24 +337,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="special" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			怨念<three_dots>？<end_line>
 			<partner>！<end_line>
 			しっかりしろよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			怨念<three_dots>？<end_line>
-			<partner>！<end_line>
-			しっかりして！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hatred<three_dots>?<end_line>
     <partner>!<end_line>
     Hold on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			怨念<three_dots>？<end_line>
+			<partner>！<end_line>
+			しっかりして！<end_line>
+		</sjis>
+    <ascii>
+    Hatred<three_dots>?<end_line>
+    <partner>!<end_line>
+    Hold on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -356,21 +383,25 @@
 	<portrait_l entry="player" eye="sad" mouth="serious">
 	<portrait_r entry="partner" eye="special" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ？<end_line>
 			オレ、どうすればいいんだ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なに？<end_line>
-			わたし、どうすればいいの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Huh?<end_line>
     What should I do?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なに？<end_line>
+			わたし、どうすればいいの？<end_line>
+		</sjis>
+    <ascii>
+    Huh?<end_line>
+    What should I do?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -390,24 +421,29 @@
 	<portrait_l entry="player" eye="surprised" mouth="yell">
 	<portrait_r entry="partner" eye="special" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			討て、<three_dots>って<end_line>
 			バカ！　なに言ってるんだよ！？<end_line>
 			そんなことできるかよ！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			討て、<three_dots>って<end_line>
-			バカ！　なに言ってるの！？<end_line>
-			そんなことできるわけないよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Take you down<three_dots>!?<end_line>
     Idiot! What are you saying!?<end_line>
     I can't do that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			討て、<three_dots>って<end_line>
+			バカ！　なに言ってるの！？<end_line>
+			そんなことできるわけないよ！<end_line>
+		</sjis>
+    <ascii>
+    Take you down<three_dots>!?<end_line>
+    Idiot! What are you saying!?<end_line>
+    I can't do that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -480,21 +516,25 @@
 	<portrait_l entry="player" eye="surprised" mouth="talk">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			<partner><three_dots>！<end_line>
 			元にもどったのか！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<partner><three_dots>！<end_line>
-			元にもどったの！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <partner><three_dots>!<end_line>
     Are you okay!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<partner><three_dots>！<end_line>
+			元にもどったの！？<end_line>
+		</sjis>
+    <ascii>
+    <partner><three_dots>!<end_line>
+    Are you okay!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -534,24 +574,29 @@
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			怨念<three_dots>？<end_line>
 			<partner>！<end_line>
 			しっかりしろよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			怨念<three_dots>？<end_line>
-			<partner>！<end_line>
-			しっかりして！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hatred<three_dots>?<end_line>
     <partner>!<end_line>
     Hold on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			怨念<three_dots>？<end_line>
+			<partner>！<end_line>
+			しっかりして！<end_line>
+		</sjis>
+    <ascii>
+    Hatred<three_dots>?<end_line>
+    <partner>!<end_line>
+    Hold on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -575,21 +620,25 @@
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<portrait_r entry="partner" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ？<end_line>
 			オレ、どうすればいいんだ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なに？<end_line>
-			わたし、どうすればいいの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What?<end_line>
     What should I do?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なに？<end_line>
+			わたし、どうすればいいの？<end_line>
+		</sjis>
+    <ascii>
+    What?<end_line>
+    What should I do?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -611,24 +660,29 @@
 	<portrait_l entry="player" eye="surprised" mouth="yell">
 	<portrait_r entry="partner" eye="special" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			討て<three_dots>って<end_line>
 			バカ！　なに言ってるんだよ！？<end_line>
 			そんなことできるかよ！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			討て<three_dots>って<end_line>
-			バカ！　なに言ってるの！？<end_line>
-			そんなことできるわけないよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Take you down<three_dots>!?<end_line>
     Idiot! What are you saying!?<end_line>
     I can't do that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			討て<three_dots>って<end_line>
+			バカ！　なに言ってるの！？<end_line>
+			そんなことできるわけないよ！<end_line>
+		</sjis>
+    <ascii>
+    Take you down<three_dots>!?<end_line>
+    Idiot! What are you saying!?<end_line>
+    I can't do that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -701,21 +755,25 @@
 	<portrait_l name="player">
 	<portrait_r entry="partner" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			<partner><three_dots>！<end_line>
 			元にもどったのか！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			<partner><three_dots>！<end_line>
-			元にもどったの！？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     <partner><three_dots>!<end_line>
     Are you okay!?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			<partner><three_dots>！<end_line>
+			元にもどったの！？<end_line>
+		</sjis>
+    <ascii>
+    <partner><three_dots>!<end_line>
+    Are you okay!?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -753,24 +811,29 @@
 	<portrait_l name="player">
 	<portrait_r entry="partner" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			怨念<three_dots>？<end_line>
 			<partner>！<end_line>
 			しっかりしろよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			怨念<three_dots>？<end_line>
-			<partner>！<end_line>
-			しっかりして！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hatred<three_dots>?<end_line>
     <partner>!<end_line>
     Hold on!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			怨念<three_dots>？<end_line>
+			<partner>！<end_line>
+			しっかりして！<end_line>
+		</sjis>
+    <ascii>
+    Hatred<three_dots>?<end_line>
+    <partner>!<end_line>
+    Hold on!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -793,21 +856,25 @@
 	<portrait_l name="player">
 	<portrait_r entry="partner" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ？<end_line>
 			オレ、どうすればいいんだ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なに？<end_line>
-			わたし、どうすればいいの？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What?<end_line>
     What should I do?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なに？<end_line>
+			わたし、どうすればいいの？<end_line>
+		</sjis>
+    <ascii>
+    What?<end_line>
+    What should I do?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -851,24 +918,29 @@
 	<portrait_l entry="player" eye="surprised" mouth="yell">
 	<portrait_r entry="partner" eye="sad" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			討って<three_dots>って<end_line>
 			バカ！　なに言ってるんだよ！？<end_line>
 			そんなことできるかよ！？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			討って<three_dots>って<end_line>
-			バカ！　なに言ってるの！？<end_line>
-			そんなことできるわけないよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Take you down<three_dots>!?<end_line>
     Idiot! What are you saying!?<end_line>
     I can't do that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			討って<three_dots>って<end_line>
+			バカ！　なに言ってるの！？<end_line>
+			そんなことできるわけないよ！<end_line>
+		</sjis>
+    <ascii>
+    Take you down<three_dots>!?<end_line>
+    Idiot! What are you saying!?<end_line>
+    I can't do that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -969,21 +1041,25 @@
 	<portrait_l entry="player" eye="decided" mouth="tense">
 	<portrait_r entry="anise" eye="special" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			忘れただと<three_dots><end_line>
 			くっそお<three_dots>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			忘れた、ですって<three_dots><end_line>
-			なによ、それ<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     No<three_dots><end_line>
     That's a lie, right, <partner>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			忘れた、ですって<three_dots><end_line>
+			なによ、それ<three_dots><end_line>
+		</sjis>
+    <ascii>
+    No<three_dots><end_line>
+    That's a lie, right, <partner>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<player gender="male">
@@ -1063,22 +1139,27 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			だからオレが思い出させてやる<end_line>
 			お前と鍛えた<end_line>
 			この武器で！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			だからわたしが思い出させてあげる<end_line>
-			あなたと鍛えた<end_line>
-			この武器で！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Then I'll make you remember!<end_line>
     I'll bring you back right now<end_line>
     with the weapons we forged together!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			だからわたしが思い出させてあげる<end_line>
+			あなたと鍛えた<end_line>
+			この武器で！<end_line>
+		</sjis>
+    <ascii>
+    Then I'll make you remember!<end_line>
+    I'll bring you back right now<end_line>
+    with the weapons we forged together!<end_line>
+  </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Final Day/25680300_187d9ac.xml
+++ b/Translation/JE Scripts/Final Day/25680300_187d9ac.xml
@@ -71,23 +71,27 @@
 	<portrait_l entry="player" eye="sad" mouth="yell">
 	<portrait_r entry="anise" eye="special" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そんな<three_dots><end_line>
 			忘れたなんて<end_line>
 			ウソだろ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    No<three_dots><end_line>
+    That's a lie, right, <partner>!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そんな<three_dots><end_line>
 			忘れたなんて<end_line>
 			ウソでしょ、<partner>！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     No<three_dots><end_line>
     That's a lie, right, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
@@ -103,7 +107,7 @@
 	<info box="left">
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			くっそ<three_dots><end_line>
 			オレは、どうすればいいんだ<three_dots><end_line>
 		</sjis>
@@ -111,9 +115,9 @@
       Shit<three_dots><end_line>
       What should I do<three_dots><end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			それじゃあ<three_dots><end_line>
 			わたしは、どうすればいいのよ<three_dots><end_line>
 		</sjis>
@@ -121,7 +125,7 @@
       Then<three_dots><end_line>
       What should I do<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -162,24 +166,29 @@
 	<portrait_l entry="player" eye="sad" mouth="yell">
 	<portrait_r entry="lemmy" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			でも、どうすりゃいいんだ！？<end_line>
 			もう<partner>には<end_line>
 			オレの声も届かないんだ<three_dots>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも、どうすればいいの！？<end_line>
-			もう<partner>には<end_line>
-			わたしの声も届かないよ<three_dots>！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     But what should I do!?<end_line>
     <partner> can't hear<end_line>
     my voice anymore<three_dots>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でも、どうすればいいの！？<end_line>
+			もう<partner>には<end_line>
+			わたしの声も届かないよ<three_dots>！<end_line>
+		</sjis>
+    <ascii>
+    But what should I do!?<end_line>
+    <partner> can't hear<end_line>
+    my voice anymore<three_dots>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -198,48 +207,58 @@
 	<info box="left">
 	<portrait_l entry="player" eye="surprised" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			オレは、鍛冶師<three_dots><end_line>
 			<three_dots><end_line>
 			へっ、そうか<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしは、鍛冶師<three_dots><end_line>
-			<three_dots><end_line>
-			あはっ、そっか<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What do you mean, I'm a<three_dots><end_line>
     <three_dots><end_line>
     Ah, right<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしは、鍛冶師<three_dots><end_line>
+			<three_dots><end_line>
+			あはっ、そっか<three_dots><end_line>
+		</sjis>
+    <ascii>
+    What do you mean, I'm a<three_dots><end_line>
+    <three_dots><end_line>
+    Ah, right<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="neutral">
 	<portrait_r entry="lemmy" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			わかったよ、レミィ<end_line>
 			<partner>はオレが<end_line>
 			絶対に目覚めさせてやる<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わかったよ、レミィ<end_line>
-			<partner>はわたしが<end_line>
-			絶対に目覚めさせてみせる<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Okay, Lemmy.<end_line>
     I'll definitely make<end_line>
     <partner> snap out of it.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わかったよ、レミィ<end_line>
+			<partner>はわたしが<end_line>
+			絶対に目覚めさせてみせる<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Okay, Lemmy.<end_line>
+    I'll definitely make<end_line>
+    <partner> snap out of it.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -268,22 +287,27 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			こいっ！　<partner>！<end_line>
 			お前と鍛えたこの武器で<end_line>
 			今すぐ目覚めさせてやるぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			きなさい！　<partner>！<end_line>
-			あなたと鍛えたこの武器で<end_line>
-			今すぐ目覚めさせてあげる！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Come! <partner>!<end_line>
     I'll bring you back right now<end_line>
     with the weapons we forged together!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			きなさい！　<partner>！<end_line>
+			あなたと鍛えたこの武器で<end_line>
+			今すぐ目覚めさせてあげる！<end_line>
+		</sjis>
+    <ascii>
+    Come! <partner>!<end_line>
+    I'll bring you back right now<end_line>
+    with the weapons we forged together!<end_line>
+  </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Final Day/25682460_187e21c.xml
+++ b/Translation/JE Scripts/Final Day/25682460_187e21c.xml
@@ -71,23 +71,27 @@
 	<portrait_l entry="player" eye="sad" mouth="yell">
 	<portrait_r entry="anise" eye="special" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そんな<three_dots><end_line>
 			忘れたなんて<end_line>
 			ウソだろ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    No<three_dots><end_line>
+    That's a lie, right, <partner>!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そんな<three_dots><end_line>
 			忘れたなんて<end_line>
 			ウソでしょ、<partner>！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     No<three_dots><end_line>
     That's a lie, right, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
@@ -103,7 +107,7 @@
 	<info box="left">
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			くっそ<three_dots><end_line>
 			オレは、どうすればいいんだ<three_dots><end_line>
 		</sjis>
@@ -111,9 +115,9 @@
       Shit<three_dots><end_line>
       What should I do<three_dots><end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			それじゃあ<three_dots><end_line>
 			わたしは、どうすればいいのよ<three_dots><end_line>
 		</sjis>
@@ -121,7 +125,7 @@
       Then<three_dots><end_line>
       What should I do<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
@@ -196,21 +200,25 @@
 	<portrait_l entry="player" eye="sad" mouth="serious">
 	<portrait_r entry="jade" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			もう、オレのことなんか<end_line>
 			わからなくなったって<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			もう、わたしのことなんか<end_line>
-			わからなくなったって<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     No longer<end_line>
     recognizes me<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			もう、わたしのことなんか<end_line>
+			わからなくなったって<three_dots><end_line>
+		</sjis>
+    <ascii>
+    No longer<end_line>
+    recognizes me<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -256,24 +264,29 @@
 	<portrait_l entry="player" eye="sad" mouth="yell">
 	<portrait_r entry="jade" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			でも<three_dots><end_line>
 			<partner>にはもう<end_line>
 			オレの声も届かないんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも<three_dots><end_line>
-			<partner>にはもう<end_line>
-			わたしの声も届かないんだよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     But what should I do!?<end_line>
     <partner> can't hear<end_line>
     my voice anymore<three_dots>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でも<three_dots><end_line>
+			<partner>にはもう<end_line>
+			わたしの声も届かないんだよ！<end_line>
+		</sjis>
+    <ascii>
+    But what should I do!?<end_line>
+    <partner> can't hear<end_line>
+    my voice anymore<three_dots>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -390,22 +403,27 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			こいっ！　<partner>！<end_line>
 			お前と鍛えたこの武器で<end_line>
 			今すぐ目覚めさせてやるぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			きなさい！　<partner>！<end_line>
-			あなたと鍛えたこの武器で<end_line>
-			今すぐ目覚めさせてあげる！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Come! <partner>!<end_line>
     I'll bring you back right now<end_line>
     with the weapons we forged together!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			きなさい！　<partner>！<end_line>
+			あなたと鍛えたこの武器で<end_line>
+			今すぐ目覚めさせてあげる！<end_line>
+		</sjis>
+    <ascii>
+    Come! <partner>!<end_line>
+    I'll bring you back right now<end_line>
+    with the weapons we forged together!<end_line>
+  </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Final Day/25684988_187ebfc.xml
+++ b/Translation/JE Scripts/Final Day/25684988_187ebfc.xml
@@ -71,23 +71,27 @@
 	<portrait_l entry="player" eye="sad" mouth="yell">
 	<portrait_r entry="anise" eye="special" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そんな<three_dots><end_line>
 			忘れたなんて<end_line>
 			ウソだろ、<partner>！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    No<three_dots><end_line>
+    That's a lie, right, <partner>!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そんな<three_dots><end_line>
 			忘れたなんて<end_line>
 			ウソでしょ、<partner>！<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     No<three_dots><end_line>
     That's a lie, right, <partner>!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
@@ -103,7 +107,7 @@
 	<info box="left">
 	<portrait_l entry="player" eye="sad" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			くっそ<three_dots><end_line>
 			オレは、どうすればいいんだ<three_dots><end_line>
 		</sjis>
@@ -111,9 +115,9 @@
       Shit<three_dots><end_line>
       What should I do<three_dots><end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			それじゃあ<three_dots><end_line>
 			わたしは、どうすればいいのよ<three_dots><end_line>
 		</sjis>
@@ -121,7 +125,7 @@
       Then<three_dots><end_line>
       What should I do<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="simple">
@@ -198,21 +202,25 @@
 	<portrait_l entry="player" eye="sad" mouth="serious">
 	<portrait_r entry="tier" eye="surprised" mouth="stressed">
 	<male>
-		<sjis>
+    <sjis>
 			もう、オレのことなんか<end_line>
 			わからなくなったって<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			もう、わたしのことなんか<end_line>
-			わからなくなったって<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     No longer<end_line>
     recognizes me<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			もう、わたしのことなんか<end_line>
+			わからなくなったって<three_dots><end_line>
+		</sjis>
+    <ascii>
+    No longer<end_line>
+    recognizes me<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -260,24 +268,29 @@
 	<portrait_l entry="player" eye="sad" mouth="stressed">
 	<portrait_r entry="tier" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			でも<three_dots><end_line>
 			<partner>にはもう<end_line>
 			オレの声も届かないんだ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			でも<three_dots><end_line>
-			<partner>にはもう<end_line>
-			わたしの声も届かないんだよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     But what should I do!?<end_line>
     <partner> can't hear<end_line>
     my voice anymore<three_dots>!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			でも<three_dots><end_line>
+			<partner>にはもう<end_line>
+			わたしの声も届かないんだよ！<end_line>
+		</sjis>
+    <ascii>
+    But what should I do!?<end_line>
+    <partner> can't hear<end_line>
+    my voice anymore<three_dots>!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -383,22 +396,27 @@
 	<info box="left">
 	<portrait_l entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			こいっ！　<partner>！<end_line>
 			お前と鍛えたこの武器で<end_line>
 			今すぐ目覚めさせてやるぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			きなさい！　<partner>！<end_line>
-			あなたと鍛えたこの武器で<end_line>
-			今すぐ目覚めさせてあげる！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Come! <partner>!<end_line>
     I'll bring you back right now<end_line>
     with the weapons we forged together!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			きなさい！　<partner>！<end_line>
+			あなたと鍛えたこの武器で<end_line>
+			今すぐ目覚めさせてあげる！<end_line>
+		</sjis>
+    <ascii>
+    Come! <partner>!<end_line>
+    I'll bring you back right now<end_line>
+    with the weapons we forged together!<end_line>
+  </ascii>
+  </female>
 </dialogue>

--- a/Translation/JE Scripts/Final Day/25719628_188734c.xml
+++ b/Translation/JE Scripts/Final Day/25719628_188734c.xml
@@ -49,144 +49,174 @@
 	<portrait_l entry="player" eye="neutral_blush" mouth="talk">
 	<portrait_r entry="tier" eye="surprised_blush" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			聞こえたよ<three_dots><end_line>
 			みんなの声<three_dots>、それから<three_dots><end_line>
 			君の声<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			聞こえたよ<three_dots><end_line>
-			みんなの声<three_dots>、それから<three_dots><end_line>
-			あなたの声<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I heard it<three_dots><end_line>
     Everyone's voices<three_dots> And then<three_dots><end_line>
     Yours<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			聞こえたよ<three_dots><end_line>
+			みんなの声<three_dots>、それから<three_dots><end_line>
+			あなたの声<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I heard it<three_dots><end_line>
+    Everyone's voices<three_dots> And then<three_dots><end_line>
+    Yours<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="neutral_blush" mouth="talk">
 	<portrait_r entry="tier" eye="surprised_blush" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			聞こえたよ<three_dots><end_line>
 			みんなの声<three_dots>、それから<three_dots><end_line>
 			<partner>の声<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			聞こえたよ<three_dots><end_line>
-			みんなの声<three_dots>、それから<three_dots><end_line>
-			あなたの声<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I heard it<three_dots><end_line>
     Everyone's voices<three_dots> And then<three_dots><end_line>
     Yours<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			聞こえたよ<three_dots><end_line>
+			みんなの声<three_dots>、それから<three_dots><end_line>
+			あなたの声<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I heard it<three_dots><end_line>
+    Everyone's voices<three_dots> And then<three_dots><end_line>
+    Yours<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="neutral_blush" mouth="talk">
 	<portrait_r entry="tier" eye="surprised_blush" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			聞こえたよ<three_dots><end_line>
 			みんなの声<three_dots>、それから<three_dots><end_line>
 			親方の声<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			聞こえたよ<three_dots><end_line>
-			みんなの声<three_dots>、それから<three_dots><end_line>
-			親方の声<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I heard it<three_dots><end_line>
     Everyone's voices<three_dots> And then<three_dots><end_line>
     Master's<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			聞こえたよ<three_dots><end_line>
+			みんなの声<three_dots>、それから<three_dots><end_line>
+			親方の声<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I heard it<three_dots><end_line>
+    Everyone's voices<three_dots> And then<three_dots><end_line>
+    Master's<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="neutral_blush" mouth="talk">
 	<portrait_r entry="tier" eye="surprised_blush" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			聞こえたよ<three_dots><end_line>
 			みんなの声<three_dots>、それから<three_dots><end_line>
 			お前の声<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			聞こえたよ<three_dots><end_line>
-			みんなの声<three_dots>、それから<three_dots><end_line>
-			あなたの声<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I heard it<three_dots><end_line>
     Everyone's voices<three_dots> And then<three_dots><end_line>
     Yours<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			聞こえたよ<three_dots><end_line>
+			みんなの声<three_dots>、それから<three_dots><end_line>
+			あなたの声<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I heard it<three_dots><end_line>
+    Everyone's voices<three_dots> And then<three_dots><end_line>
+    Yours<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="neutral_blush" mouth="talk">
 	<portrait_r entry="tier" eye="surprised_blush" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			聞こえたよ<three_dots><end_line>
 			みんなの声<three_dots>、それから<three_dots><end_line>
 			アニキの声<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			聞こえたよ<three_dots><end_line>
-			みんなの声<three_dots>、それから<three_dots><end_line>
-			アニキの声<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I heard it<three_dots><end_line>
     Everyone's voices<three_dots> And then<three_dots><end_line>
     Brother's<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			聞こえたよ<three_dots><end_line>
+			みんなの声<three_dots>、それから<three_dots><end_line>
+			アニキの声<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I heard it<three_dots><end_line>
+    Everyone's voices<three_dots> And then<three_dots><end_line>
+    Brother's<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
 	<portrait_l entry="player" eye="neutral_blush" mouth="talk">
 	<portrait_r entry="tier" eye="surprised_blush" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			聞こえたよ<three_dots><end_line>
 			みんなの声<three_dots>、それから<three_dots><end_line>
 			ティエの声<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			聞こえたよ<three_dots><end_line>
-			みんなの声<three_dots>、それから<three_dots><end_line>
-			ティエの声<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I heard it<three_dots><end_line>
     Everyone's voices<three_dots> And then<three_dots><end_line>
     Tier's<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			聞こえたよ<three_dots><end_line>
+			みんなの声<three_dots>、それから<three_dots><end_line>
+			ティエの声<three_dots><end_line>
+		</sjis>
+    <ascii>
+    I heard it<three_dots><end_line>
+    Everyone's voices<three_dots> And then<three_dots><end_line>
+    Tier's<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">

--- a/Translation/JE Scripts/Final Day/25953596_18c053c.xml
+++ b/Translation/JE Scripts/Final Day/25953596_18c053c.xml
@@ -18,24 +18,29 @@
 	<portrait_l entry="murno" eye="sad" mouth="talk">
 	<portrait_r entry="player" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			ホント<end_line>
 			オレたちが悪いことしたワケじゃ<end_line>
 			ないってのに<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ホント<end_line>
-			わたしたちが悪いことしたワケじゃ<end_line>
-			ないってのに<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Really.<end_line>
     It's not like it's our fault<end_line>
     any of this happened<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ホント<end_line>
+			わたしたちが悪いことしたワケじゃ<end_line>
+			ないってのに<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Really.<end_line>
+    It's not like it's our fault<end_line>
+    any of this happened<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -137,21 +142,25 @@
 	<portrait_l entry="murno" eye="sad" mouth="neutral">
 	<portrait_r entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			それにあの魔石のおかげで<end_line>
 			オレはミューノに会えたんだし<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			それにあの魔石のおかげで<end_line>
-			わたしはミューノに会えたんだし<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     And its because of the<end_line>
     Demon Stone that I met you, Murno<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			それにあの魔石のおかげで<end_line>
+			わたしはミューノに会えたんだし<three_dots><end_line>
+		</sjis>
+    <ascii>
+    And its because of the<end_line>
+    Demon Stone that I met you, Murno<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -184,24 +193,29 @@
 	<portrait_l entry="murno" eye="decided" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			うん、がんばろう<end_line>
 			オレももっともっと強くなる<end_line>
 			いっしょにがんばろう<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			うん、がんばろう<end_line>
-			わたしももっともっと強くなる<end_line>
-			いっしょにがんばろう<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Yeah, you can do it!<end_line>
     I'm still getting stronger too.<end_line>
     Let's work at it together.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			うん、がんばろう<end_line>
+			わたしももっともっと強くなる<end_line>
+			いっしょにがんばろう<end_line>
+		</sjis>
+    <ascii>
+    Yeah, you can do it!<end_line>
+    I'm still getting stronger too.<end_line>
+    Let's work at it together.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -223,24 +237,29 @@
 	<portrait_l entry="murno" eye="decided" mouth="talk">
 	<portrait_r entry="player" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			じゃあオレだって<end_line>
 			毎日ミューノを思いだして<end_line>
 			それ以上がんばる！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			じゃあわたしだって<end_line>
-			毎日ミューノを思いだして<end_line>
-			それ以上がんばる！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Me too, I'll think about<end_line>
     you every day Murno,<end_line>
     and try even harder than that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			じゃあわたしだって<end_line>
+			毎日ミューノを思いだして<end_line>
+			それ以上がんばる！<end_line>
+		</sjis>
+    <ascii>
+    Me too, I'll think about<end_line>
+    you every day Murno,<end_line>
+    and try even harder than that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -260,21 +279,25 @@
 	<portrait_l entry="murno" eye="happy" mouth="neutral">
 	<portrait_r entry="player" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ<end_line>
 			ミューノだって<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ<end_line>
-			ミューノだって<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey,<end_line>
     aren't you the same?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ<end_line>
+			ミューノだって<end_line>
+		</sjis>
+    <ascii>
+    Hey,<end_line>
+    aren't you the same?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">

--- a/Translation/JE Scripts/Final Day/25955020_18c0acc.xml
+++ b/Translation/JE Scripts/Final Day/25955020_18c0acc.xml
@@ -4,24 +4,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノと出会って<end_line>
 			<partner>の召喚石を拾って<end_line>
 			ホントに色んなコトがあったな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノと出会って<end_line>
-			あなたの召喚石を拾って<end_line>
-			ホントに色んなコトがあったね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     A lot's happened since I<end_line>
     met Murno and picked<end_line>
     up your Summonstone.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノと出会って<end_line>
+			あなたの召喚石を拾って<end_line>
+			ホントに色んなコトがあったね<end_line>
+		</sjis>
+    <ascii>
+    A lot's happened since I<end_line>
+    met Murno and picked<end_line>
+    up your Summonstone.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -45,24 +50,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、そんなこと<three_dots><end_line>
 			<three_dots><end_line>
 			あるかな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、そんなこと<three_dots><end_line>
-			<three_dots><end_line>
-			あるかな<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey, that<three_dots><end_line>
     <three_dots><end_line>
     Is true.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、そんなこと<three_dots><end_line>
+			<three_dots><end_line>
+			あるかな<end_line>
+		</sjis>
+    <ascii>
+    Hey, that<three_dots><end_line>
+    <three_dots><end_line>
+    Is true.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -118,24 +128,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			あはは<three_dots>、ズバリ言うなぁ<end_line>
 			でも、そうだな！<end_line>
 			これからもよろしくたのむぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あはは<three_dots>、ズバリ言うねぇ<end_line>
-			でも、そうだね！<end_line>
-			これからもよろしくたのむよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ahaha<three_dots> How blunt.<end_line>
     But you're right!<end_line>
     Let's continue to work hard!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あはは<three_dots>、ズバリ言うねぇ<end_line>
+			でも、そうだね！<end_line>
+			これからもよろしくたのむよ！<end_line>
+		</sjis>
+    <ascii>
+    Ahaha<three_dots> How blunt.<end_line>
+    But you're right!<end_line>
+    Let's continue to work hard!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -187,24 +202,29 @@
 	<portrait_l entry="partner" eye="surprised" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そ、そうか、気合いだな<three_dots><end_line>
 			わかったぜ！<end_line>
 			そういうときはアレだな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そ、そうか、気合いだね<three_dots><end_line>
-			わかった！<end_line>
-			そういうときはアレだね！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     R-right<three_dots> It's all about spirit<three_dots><end_line>
     Okay!<end_line>
     This is the perfect time for that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そ、そうか、気合いだね<three_dots><end_line>
+			わかった！<end_line>
+			そういうときはアレだね！<end_line>
+		</sjis>
+    <ascii>
+    R-right<three_dots> It's all about spirit<three_dots><end_line>
+    Okay!<end_line>
+    This is the perfect time for that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -274,24 +294,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ありがとう、<partner><end_line>
 			いっしょに叫んでくれるなんて<end_line>
 			すっごくうれしいぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ありがとう、<partner><end_line>
-			いっしょに叫んでくれるなんて<end_line>
-			すっごいうれしいよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Thanks, <partner>!<end_line>
     I'm so happy you<end_line>
     joined me this time!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ありがとう、<partner><end_line>
+			いっしょに叫んでくれるなんて<end_line>
+			すっごいうれしいよ！<end_line>
+		</sjis>
+    <ascii>
+    Thanks, <partner>!<end_line>
+    I'm so happy you<end_line>
+    joined me this time!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -311,24 +336,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			もちろん！<end_line>
 			燃えてきたぜ！<end_line>
 			よっしゃ、がんばるぞ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			もちろん！<end_line>
-			燃えてくるわ！<end_line>
-			よぉし、がんばるぞ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Of course!<end_line>
     I'm all fired up!<end_line>
     Alright, let's work hard!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			もちろん！<end_line>
+			燃えてくるわ！<end_line>
+			よぉし、がんばるぞ！<end_line>
+		</sjis>
+    <ascii>
+    Of course!<end_line>
+    I'm all fired up!<end_line>
+    Alright, let's work hard!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="run-dor">
@@ -348,24 +378,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノと出会って<end_line>
 			<partner>の召喚石を拾って<end_line>
 			ホントに色んなコトがあったな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノと出会って<end_line>
-			あなたの召喚石を拾って<end_line>
-			ホントに色んなコトがあったね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     A lot's happened since I<end_line>
     met Murno and picked<end_line>
     up your Summonstone.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノと出会って<end_line>
+			あなたの召喚石を拾って<end_line>
+			ホントに色んなコトがあったね<end_line>
+		</sjis>
+    <ascii>
+    A lot's happened since I<end_line>
+    met Murno and picked<end_line>
+    up your Summonstone.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -431,24 +466,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なに言ってるんだよ、<partner><end_line>
 			ホントはオレがいなくたって<end_line>
 			自分が助けたとか思ってるだろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なに言ってるのよ、<partner><end_line>
-			ホントはわたしがいなくたって<end_line>
-			自分が助けたとか思ってるでしょ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     What's that?<end_line>
     You're thinking could've done<end_line>
     it without me too, right?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なに言ってるのよ、<partner><end_line>
+			ホントはわたしがいなくたって<end_line>
+			自分が助けたとか思ってるでしょ？<end_line>
+		</sjis>
+    <ascii>
+    What's that?<end_line>
+    You're thinking could've done<end_line>
+    it without me too, right?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -572,24 +612,29 @@
 	<portrait_l entry="partner" eye="decided" mouth="yell">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そ、そうか、気合いだな<three_dots><end_line>
 			わかったぜ！<end_line>
 			そういうときはアレだな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そ、そうか、気合いだね<three_dots><end_line>
-			わかった！<end_line>
-			そういうときはアレだね！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     R-right<three_dots> It's all about spirit<three_dots><end_line>
     Okay!<end_line>
     This is the perfect time for that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そ、そうか、気合いだね<three_dots><end_line>
+			わかった！<end_line>
+			そういうときはアレだね！<end_line>
+		</sjis>
+    <ascii>
+    R-right<three_dots> It's all about spirit<three_dots><end_line>
+    Okay!<end_line>
+    This is the perfect time for that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -659,24 +704,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="happy" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			ありがとう、<partner><end_line>
 			いっしょに叫んでくれるなんて<end_line>
 			すっごくうれしいぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ありがとう、<partner><end_line>
-			いっしょに叫んでくれるなんて<end_line>
-			すっごいうれしいよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Thanks, <partner>!<end_line>
     I'm so happy you<end_line>
     joined me this time!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ありがとう、<partner><end_line>
+			いっしょに叫んでくれるなんて<end_line>
+			すっごいうれしいよ！<end_line>
+		</sjis>
+    <ascii>
+    Thanks, <partner>!<end_line>
+    I'm so happy you<end_line>
+    joined me this time!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="enzi">
@@ -700,24 +750,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノと出会って<end_line>
 			<partner>の召喚石を拾って<end_line>
 			ホントに色んなコトがあったな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノと出会って<end_line>
-			あなたの召喚石を拾って<end_line>
-			ホントに色んなコトがあったね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     A lot's happened since I<end_line>
     met Murno and picked<end_line>
     up your Summonstone.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノと出会って<end_line>
+			あなたの召喚石を拾って<end_line>
+			ホントに色んなコトがあったね<end_line>
+		</sjis>
+    <ascii>
+    A lot's happened since I<end_line>
+    met Murno and picked<end_line>
+    up your Summonstone.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -741,24 +796,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="talk">
 	<portrait_r entry="player" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、そんなこと<three_dots><end_line>
 			<three_dots><end_line>
 			あるかな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、そんなこと<three_dots><end_line>
-			<three_dots><end_line>
-			あるかな<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey, that<three_dots><end_line>
     <three_dots><end_line>
     Is true.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、そんなこと<three_dots><end_line>
+			<three_dots><end_line>
+			あるかな<end_line>
+		</sjis>
+    <ascii>
+    Hey, that<three_dots><end_line>
+    <three_dots><end_line>
+    Is true.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -794,24 +854,29 @@
 	<portrait_l entry="partner" eye="sad" mouth="tense">
 	<portrait_r entry="player" eye="decided" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、それ<end_line>
 			少しぐらい良いことだって<end_line>
 			あっただろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ<end_line>
-			少しぐらい良いことだって<end_line>
-			あったでしょ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Come on,<end_line>
     there has to be something good<end_line>
     worth mentioning, right?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ<end_line>
+			少しぐらい良いことだって<end_line>
+			あったでしょ？<end_line>
+		</sjis>
+    <ascii>
+    Come on,<end_line>
+    there has to be something good<end_line>
+    worth mentioning, right?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -833,24 +898,29 @@
 	<portrait_l entry="partner" eye="decided" mouth="serious">
 	<portrait_r entry="player" eye="decided" mouth="yell">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ！　オレはあるぞ！<end_line>
 			<partner>がいてくれたおかげで<end_line>
 			スゴイ武器だってつくれたし<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ！　わたしはあるよ！<end_line>
-			<partner>がいてくれたおかげで<end_line>
-			スゴイ武器だってつくれたし<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, I have one!<end_line>
     Thanks to you, I was able to make<end_line>
     some really amazing weapons!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ！　わたしはあるよ！<end_line>
+			<partner>がいてくれたおかげで<end_line>
+			スゴイ武器だってつくれたし<end_line>
+		</sjis>
+    <ascii>
+    Well, I have one!<end_line>
+    Thanks to you, I was able to make<end_line>
+    some really amazing weapons!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -900,24 +970,29 @@
 	<portrait_l entry="partner" eye="surprised_blush" mouth="stressed">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			どうだ、<partner>！<end_line>
 			お前もいっこくらい良いこと<end_line>
 			思いつくだろ？　言えよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			どう、<partner>！<end_line>
-			あなたもいっこくらい良いこと<end_line>
-			思いつくでしょ？　言って！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     How's that, <partner>!<end_line>
     You must have one good<end_line>
     thing to say! Speak up!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			どう、<partner>！<end_line>
+			あなたもいっこくらい良いこと<end_line>
+			思いつくでしょ？　言って！<end_line>
+		</sjis>
+    <ascii>
+    How's that, <partner>!<end_line>
+    You must have one good<end_line>
+    thing to say! Speak up!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -939,18 +1014,21 @@
 	<portrait_l entry="partner" eye="decided_blush" mouth="serious">
 	<portrait_r entry="player" eye="decided" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			言えよ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			言って！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Say it!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			言って！<end_line>
+		</sjis>
+    <ascii>
+    Say it!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -990,21 +1068,25 @@
 	<portrait_l entry="partner" eye="decided_blush" mouth="tense">
 	<portrait_r entry="player" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			また、なに言ってんだよ<end_line>
 			ホントは自分で守りたかったくせに<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			また、なに言ってんのよ<end_line>
-			ホントは自分で守りたかったくせに<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Oh, come on. You really wanted<end_line>
     to do that yourself, right?.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			また、なに言ってんのよ<end_line>
+			ホントは自分で守りたかったくせに<end_line>
+		</sjis>
+    <ascii>
+    Oh, come on. You really wanted<end_line>
+    to do that yourself, right?.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1028,24 +1110,29 @@
 	<portrait_l entry="partner" eye="surprised_blush" mouth="yell">
 	<portrait_r entry="player" eye="happy" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			あはは<three_dots><end_line>
 			ごめんごめん<end_line>
 			そんなに怒るなよ～<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			あはは<three_dots><end_line>
-			ごめんごめん<end_line>
-			そんなに怒らないでよ～<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ahaha<three_dots><end_line>
     Sorry, sorry.<end_line>
     Don't be so angry~<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			あはは<three_dots><end_line>
+			ごめんごめん<end_line>
+			そんなに怒らないでよ～<end_line>
+		</sjis>
+    <ascii>
+    Ahaha<three_dots><end_line>
+    Sorry, sorry.<end_line>
+    Don't be so angry~<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1069,21 +1156,25 @@
 	<portrait_l entry="partner" eye="decided" mouth="serious">
 	<portrait_r entry="player" eye="sad" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			１００万バームって言ってもな～<end_line>
 			やっぱムリだろ？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			１００万バームって言ってもね～<end_line>
-			やっぱムリでしょ？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     About that~<end_line>
     Isn't that impossible?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			１００万バームって言ってもね～<end_line>
+			やっぱムリでしょ？<end_line>
+		</sjis>
+    <ascii>
+    About that~<end_line>
+    Isn't that impossible?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1107,24 +1198,29 @@
 	<portrait_l entry="partner" eye="special" mouth="yell">
 	<portrait_r entry="player" eye="surprised" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			そ、そうか<three_dots><end_line>
 			とりあえずは気合い、かな<three_dots><end_line>
 			そういうときはアレだな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そ、そうね<three_dots><end_line>
-			とりあえずは気合い、かな<three_dots><end_line>
-			そういうときはアレだね！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     R-right<three_dots><end_line>
     We'll start with motivation<three_dots><end_line>
     This is the perfect time for that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そ、そうね<three_dots><end_line>
+			とりあえずは気合い、かな<three_dots><end_line>
+			そういうときはアレだね！<end_line>
+		</sjis>
+    <ascii>
+    R-right<three_dots><end_line>
+    We'll start with motivation<three_dots><end_line>
+    This is the perfect time for that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1194,24 +1290,29 @@
 	<portrait_l entry="partner" eye="neutral_blush" mouth="neutral">
 	<portrait_r entry="player" eye="happy" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			まさか<partner>がいっしょに<end_line>
 			叫んでくれるなんて、ユメみたいだ！<end_line>
 			すっごくうれしいぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			まさか<partner>がいっしょに<end_line>
-			叫んでくれるなんて、ユメみたい！<end_line>
-			すっごいうれしいよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     I never thought you'd<end_line>
     join me, <partner>!<end_line>
     This is awesome!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			まさか<partner>がいっしょに<end_line>
+			叫んでくれるなんて、ユメみたい！<end_line>
+			すっごいうれしいよ！<end_line>
+		</sjis>
+    <ascii>
+    I never thought you'd<end_line>
+    join me, <partner>!<end_line>
+    This is awesome!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="killfith">
@@ -1260,24 +1361,29 @@
 	<info box="right">
 	<portrait_r name="player">
 	<male>
-		<sjis>
+    <sjis>
 			ミューノと出会って<end_line>
 			<partner>の召喚石を拾って<end_line>
 			ホントに色んなコトがあったな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ミューノと出会って<end_line>
-			あなたの召喚石を拾って<end_line>
-			ホントに色んなコトがあったね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     A lot's happened since I<end_line>
     met Murno and picked<end_line>
     up your Summonstone.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ミューノと出会って<end_line>
+			あなたの召喚石を拾って<end_line>
+			ホントに色んなコトがあったね<end_line>
+		</sjis>
+    <ascii>
+    A lot's happened since I<end_line>
+    met Murno and picked<end_line>
+    up your Summonstone.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1299,24 +1405,29 @@
 	<info box="right">
 	<portrait_r name="player">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ、そんなこと<three_dots><end_line>
 			<three_dots><end_line>
 			あるかな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、そんなこと<three_dots><end_line>
-			<three_dots><end_line>
-			あるかな<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Hey, that<three_dots><end_line>
     <three_dots><end_line>
     Is true.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、そんなこと<three_dots><end_line>
+			<three_dots><end_line>
+			あるかな<end_line>
+		</sjis>
+    <ascii>
+    Hey, that<three_dots><end_line>
+    <three_dots><end_line>
+    Is true.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1442,24 +1553,29 @@
 	<info box="right">
 	<portrait_r name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そうだね<three_dots><end_line>
 			１００万バームをかせがないと<end_line>
 			ならないしな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<three_dots><end_line>
-			１００万バームをかせがないと<end_line>
-			ならないし<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right<three_dots><end_line>
     We still have to earn<end_line>
     one million boam<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<three_dots><end_line>
+			１００万バームをかせがないと<end_line>
+			ならないし<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Right<three_dots><end_line>
+    We still have to earn<end_line>
+    one million boam<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1481,24 +1597,29 @@
 	<info box="right">
 	<portrait_r name="player">
 	<male>
-		<sjis>
+    <sjis>
 			そ、そうか、気合いだな<three_dots><end_line>
 			わかったぜ！<end_line>
 			そういうときはアレだな！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そ、そうか、気合いだね<three_dots><end_line>
-			わかった！<end_line>
-			そういうときはアレだね！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     R-right, it's all about spirit<three_dots><end_line>
     Okay!<end_line>
     This is the perfect time for that!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そ、そうか、気合いだね<three_dots><end_line>
+			わかった！<end_line>
+			そういうときはアレだね！<end_line>
+		</sjis>
+    <ascii>
+    R-right, it's all about spirit<three_dots><end_line>
+    Okay!<end_line>
+    This is the perfect time for that!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1564,24 +1685,29 @@
 	<portrait_l entry="partner" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="happy" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			ありがとう、<partner><end_line>
 			いっしょに叫んでくれるなんて<end_line>
 			すっごくうれしいぜ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			ありがとう、<partner><end_line>
-			いっしょに叫んでくれるなんて<end_line>
-			すっごいうれしいよ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Thanks, <partner>!<end_line>
     I'm so happy you<end_line>
     joined me this time!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			ありがとう、<partner><end_line>
+			いっしょに叫んでくれるなんて<end_line>
+			すっごいうれしいよ！<end_line>
+		</sjis>
+    <ascii>
+    Thanks, <partner>!<end_line>
+    I'm so happy you<end_line>
+    joined me this time!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">
@@ -1605,23 +1731,27 @@
 	<portrait_l entry="partner" eye="happy" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			これからもふたりで<end_line>
 			がんばろうぜ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
+    <ascii>
+    Right.<end_line>
+    Let's do our best!<end_line>
+  </ascii>
+  </male>
+  <female>
+    <sjis>
 			そうだね<end_line>
 			これからもふたりで<end_line>
 			がんばろう<end_line>
 		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Right.<end_line>
     Let's do our best!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<partner name="rufeel">

--- a/Translation/JE Scripts/Final Day/25960652_18c20cc.xml
+++ b/Translation/JE Scripts/Final Day/25960652_18c20cc.xml
@@ -3,21 +3,25 @@
 	<portrait_l entry="lemmy" eye="serious" mouth="talk">
 	<portrait_r entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			へぇ<three_dots><end_line>
 			こんなとこ、あがれるんだな<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			へぇ<three_dots><end_line>
-			こんなとこ、あがれるんだね<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Huh<three_dots><end_line>
     I didn't know you could get up here.<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			へぇ<three_dots><end_line>
+			こんなとこ、あがれるんだね<end_line>
+		</sjis>
+    <ascii>
+    Huh<three_dots><end_line>
+    I didn't know you could get up here.<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -35,18 +39,21 @@
 	<portrait_l entry="lemmy" eye="serious" mouth="talk">
 	<portrait_r entry="player" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			で、話ってなんだよ<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			で、話ってなによ<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So what did you want to talk about?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			で、話ってなによ<end_line>
+		</sjis>
+    <ascii>
+    So what did you want to talk about?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -96,21 +103,25 @@
 	<portrait_l entry="lemmy" eye="decided_blush" mouth="tense">
 	<portrait_r entry="player" eye="happy" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			オレにお礼を言うのは<end_line>
 			そんなに恥ずかしいことなのか<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			わたしにお礼を言うのは<end_line>
-			そんなに恥ずかしいことなのね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Is it really<end_line>
     that embarrassing<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			わたしにお礼を言うのは<end_line>
+			そんなに恥ずかしいことなのね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Is it really<end_line>
+    that embarrassing<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -130,24 +141,29 @@
 	<portrait_l entry="lemmy" eye="surprised" mouth="stressed">
 	<portrait_r entry="player" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			もういいよ<three_dots><end_line>
 			けど、なんだよ<end_line>
 			お礼って？<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			もういいよ<three_dots><end_line>
-			けど、なによ<end_line>
-			お礼って？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright I guess<three_dots><end_line>
     But thanks for<end_line>
     what, exactly?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			もういいよ<three_dots><end_line>
+			けど、なによ<end_line>
+			お礼って？<end_line>
+		</sjis>
+    <ascii>
+    Alright I guess<three_dots><end_line>
+    But thanks for<end_line>
+    what, exactly?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -184,24 +200,29 @@
 	<portrait_l entry="lemmy" eye="serious" mouth="tense">
 	<portrait_r entry="player" eye="serious" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			そっか！　よかったな！<end_line>
 			これで悩みもなくなったから<end_line>
 			オレと勝負を<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そっか！　よかったね！<end_line>
-			これで悩みもなくなったから<end_line>
-			わたしと勝負を<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Oh, right! That's great!<end_line>
     So no more worries then?<end_line>
     About our match<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そっか！　よかったね！<end_line>
+			これで悩みもなくなったから<end_line>
+			わたしと勝負を<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Oh, right! That's great!<end_line>
+    So no more worries then?<end_line>
+    About our match<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <bigtext>
 	<info box="left" effect="big">
@@ -219,21 +240,25 @@
 	<portrait_l entry="lemmy" eye="decided" mouth="yell">
 	<portrait_r entry="player" eye="sad" mouth="stressed">
 	<male>
-		<sjis>
+    <sjis>
 			え～！？<end_line>
 			まだなんか残ってるのかよ～<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			え～！？<end_line>
-			まだなんか残ってるの～？<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Ehh!?<end_line>
     What else could there be?<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			え～！？<end_line>
+			まだなんか残ってるの～？<end_line>
+		</sjis>
+    <ascii>
+    Ehh!?<end_line>
+    What else could there be?<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -255,21 +280,25 @@
 	<portrait_l entry="lemmy" eye="neutral_blush" mouth="neutral">
 	<portrait_r entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだよ<end_line>
 			そんなこと<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ<end_line>
-			そんなこと<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Huh,<end_line>
     you don't need to<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ<end_line>
+			そんなこと<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Huh,<end_line>
+    you don't need to<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <bigtext>
 	<info box="left" effect="big">
@@ -320,15 +349,15 @@
 	<portrait_l entry="lemmy" eye="decided" mouth="tense">
 	<portrait_r entry="player" eye="happy" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			よかったな、レミィ<end_line>
 		</sjis>
     <ascii>
       And it's settled.<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			どういたしまして<end_line>
 			よかったね、レミィ<end_line>
 		</sjis>
@@ -336,7 +365,7 @@
       You're welcome.<end_line>
       And it's settled.<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -358,21 +387,25 @@
 	<portrait_l entry="lemmy" eye="decided" mouth="talk">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			なんだと<end_line>
 			オレだって<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			なによ、それ！<end_line>
-			わたしだって負けないから！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Heh!<end_line>
     Neither will I!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			なによ、それ！<end_line>
+			わたしだって負けないから！<end_line>
+		</sjis>
+    <ascii>
+    Heh!<end_line>
+    Neither will I!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">

--- a/Translation/JE Scripts/Final Day/25962140_18c269c.xml
+++ b/Translation/JE Scripts/Final Day/25962140_18c269c.xml
@@ -87,21 +87,21 @@
 	<portrait_l entry="jade" eye="decided" mouth="neutral">
 	<portrait_r entry="player" eye="surprised" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			この世界を救った男と言っても<end_line>
 		</sjis>
     <ascii>
       The man who saved Lindbaum,<end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			この世界を救った女と言っても<end_line>
 		</sjis>
     <ascii>
       The woman who saved Lindbaum,<end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -134,21 +134,25 @@
 	<portrait_l entry="jade" eye="decided" mouth="serious">
 	<portrait_r entry="player" eye="happy_blush" mouth="stressed">
 	<male>
-		<sjis>
+    <sjis>
 			そんな、アニキ、大げさな<three_dots><end_line>
 			オレが世界を救っただなんて<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そんな、アニキ、大げさな<three_dots><end_line>
-			わたしが世界を救っただなんて<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Brother, you're exaggerating<three_dots><end_line>
     Me saving the world<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そんな、アニキ、大げさな<three_dots><end_line>
+			わたしが世界を救っただなんて<end_line>
+		</sjis>
+    <ascii>
+    Brother, you're exaggerating<three_dots><end_line>
+    Me saving the world<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -183,7 +187,7 @@
 	<portrait_l entry="jade" eye="serious" mouth="neutral">
 	<portrait_r entry="player" eye="neutral_blush" mouth="talk">
 	<male>
-		<sjis>
+    <sjis>
 			ああ、お前はたいした男だぜ<end_line>
 			今まではロブの弟子<end_line>
 			かわいい弟分とか思っていたが<three_dots><end_line>
@@ -193,9 +197,9 @@
       As Rob's apprentice, you were like<end_line>
       a little brother, but now<three_dots><end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			ああ、お前はたいした女だぜ<end_line>
 			今まではロブの弟子<end_line>
 			かわいい妹分とか思っていたが<three_dots><end_line>
@@ -205,7 +209,7 @@
       As Rob's apprentice, you were like<end_line>
       a little sister, but now<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -236,7 +240,7 @@
 	<portrait_l entry="jade" eye="decided" mouth="neutral">
 	<portrait_r entry="player" eye="serious" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			言っただろ？<end_line>
 			お前はもう弟分じゃないってな<end_line>
 			お前はもう立派な鍛冶師だ<three_dots><end_line>
@@ -246,9 +250,9 @@
       little brother anymore.<end_line>
       You're a Craftknight<three_dots><end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			言っただろ？<end_line>
 			お前はもう妹分じゃないってな<end_line>
 			お前はもう立派な鍛冶師だ<three_dots><end_line>
@@ -258,7 +262,7 @@
       little sister anymore.<end_line>
       You're a Craftknight<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -280,24 +284,29 @@
 	<portrait_l entry="jade" eye="decided" mouth="talk">
 	<portrait_r entry="player" eye="surprised_blush" mouth="serious">
 	<male>
-		<sjis>
+    <sjis>
 			え<three_dots>、でも、そんな<three_dots><end_line>
 			アニキがアニキじゃなくなるなんて<three_dots><end_line>
 			オレ<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			え<three_dots>、でも、そんな<three_dots><end_line>
-			アニキがアニキじゃなくなるなんて<three_dots><end_line>
-			わたし<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Eh<three_dots> But<three_dots><end_line>
     If Brother isn't Brother, then<three_dots><end_line>
     What do I<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			え<three_dots>、でも、そんな<three_dots><end_line>
+			アニキがアニキじゃなくなるなんて<three_dots><end_line>
+			わたし<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Eh<three_dots> But<three_dots><end_line>
+    If Brother isn't Brother, then<three_dots><end_line>
+    What do I<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -365,18 +374,21 @@
 	<portrait_l entry="jade" eye="decided" mouth="yell">
 	<portrait_r entry="player" eye="surprised" mouth="stressed">
 	<male>
-		<sjis>
+    <sjis>
 			世界を救った男？　上等だ！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			世界を救った女？　上等だ！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     So you saved the world. Perfect!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			世界を救った女？　上等だ！<end_line>
+		</sjis>
+    <ascii>
+    So you saved the world. Perfect!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">

--- a/Translation/JE Scripts/Final Day/25963900_18c2d7c.xml
+++ b/Translation/JE Scripts/Final Day/25963900_18c2d7c.xml
@@ -31,24 +31,29 @@
 	<portrait_l entry="tier" eye="serious" mouth="tense">
 	<portrait_r entry="player" eye="serious" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			たしかに大変な目にはあったけど<end_line>
 			悪いことばっかじゃないぜ<end_line>
 			ほら<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			たしかに大変な目にはあったけど<end_line>
-			悪いことばっかじゃないよ<end_line>
-			ほら<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Well, it's not like<end_line>
     everything was that bad.<end_line>
     You know<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			たしかに大変な目にはあったけど<end_line>
+			悪いことばっかじゃないよ<end_line>
+			ほら<three_dots><end_line>
+		</sjis>
+    <ascii>
+    Well, it's not like<end_line>
+    everything was that bad.<end_line>
+    You know<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
@@ -111,7 +116,7 @@
 	<portrait_l entry="tier" eye="special_blush" mouth="neutral">
 	<portrait_r entry="player" eye="happy" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			魔石の件も片付いたことだし<end_line>
 			これでほほえみ亭専属の<end_line>
 			鍛冶師としてしっかりと<three_dots><end_line>
@@ -121,9 +126,9 @@
       I'll have you continue on<end_line>
       as my exclusive Craftknight<three_dots><end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			魔石の件も片付いたことだし<end_line>
 			これでほほえみ亭専属の鍛冶師兼<end_line>
 			カンバン娘としてしっかりと<three_dots><end_line>
@@ -133,14 +138,14 @@
       I'll have you continue on <end_line>
       as my exclusive poster girl<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="right">
 	<portrait_l entry="tier" eye="special_blush" mouth="neutral">
 	<portrait_r entry="player" eye="sad" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			でも、ほら、その前に<end_line>
 			親方との約束の１００万バームを<end_line>
 			なんとかしなきゃな<three_dots><end_line>
@@ -150,9 +155,9 @@
       about that 1 million boam<end_line>
       I promised Master<three_dots><end_line>
     </ascii>
-	</male>
-	<female>
-		<sjis>
+  </male>
+  <female>
+    <sjis>
 			でも、ほら、その前に<end_line>
 			親方との約束の１００万バームを<end_line>
 			なんとかしなきゃ<three_dots><end_line>
@@ -162,7 +167,7 @@
       about that 1 million boam<end_line>
       I promised Master<three_dots><end_line>
     </ascii>
-	</female>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -208,18 +213,21 @@
 	<portrait_l entry="tier" eye="sad" mouth="stressed">
 	<portrait_r entry="player" eye="decided" mouth="tense">
 	<male>
-		<sjis>
+    <sjis>
 			スゴイことになってるんだな<three_dots><end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			スゴイことになってるのね<three_dots><end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     You're exaggerating<three_dots><end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			スゴイことになってるのね<three_dots><end_line>
+		</sjis>
+    <ascii>
+    You're exaggerating<three_dots><end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">
@@ -271,21 +279,25 @@
 	<portrait_l entry="tier" eye="decided" mouth="neutral">
 	<portrait_r entry="player" eye="decided" mouth="neutral">
 	<male>
-		<sjis>
+    <sjis>
 			そうだな<end_line>
 			とにかくふたりでがんばろう！<end_line>
 		</sjis>
-	</male>
-	<female>
-		<sjis>
-			そうだね<end_line>
-			とにかくふたりでがんばろう！<end_line>
-		</sjis>
-	</female>
-  <ascii>
+    <ascii>
     Alright then.<end_line>
     We'll do it together!<end_line>
   </ascii>
+  </male>
+  <female>
+    <sjis>
+			そうだね<end_line>
+			とにかくふたりでがんばろう！<end_line>
+		</sjis>
+    <ascii>
+    Alright then.<end_line>
+    We'll do it together!<end_line>
+  </ascii>
+  </female>
 </dialogue>
 <dialogue>
 	<info box="left">

--- a/Translation/JE Scripts/Post Game/001_25723004_188807c.xml
+++ b/Translation/JE Scripts/Post Game/001_25723004_188807c.xml
@@ -7,17 +7,21 @@
       さてと<end_line>
       今日も修行をはじめるか！<end_line>
     </sjis>
+    <ascii>
+    Well then,<end_line>
+    time for training!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       さてと<end_line>
       今日も修行をはじめよっか！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well then,<end_line>
     time for training!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -103,6 +107,11 @@
       召喚獣といっしょのレミィとも<end_line>
       勝負したいし、う～ん<three_dots><end_line>
     </sjis>
+    <ascii>
+    Hmm, I wanted to make a new weapon,<end_line>
+    and also have a match with Lemmy<end_line>
+    and his Summon Beast<three_dots><end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -110,12 +119,12 @@
       召喚獣といっしょのレミィとも<end_line>
       勝負したいし、う～ん<three_dots><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Hmm, I wanted to make a new weapon,<end_line>
     and also have a match with Lemmy<end_line>
     and his Summon Beast<three_dots><end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">
@@ -190,17 +199,21 @@
       まあ、そうだな<end_line>
       いつも通り、楽しくいこうぜ！<end_line>
     </sjis>
+    <ascii>
+    I guess so.<end_line>
+    Well, let's have fun with it!<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
       まあ、そうだね<end_line>
       いつも通り、楽しくいこう！<end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     I guess so.<end_line>
     Well, let's have fun with it!<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">

--- a/Translation/JE Scripts/Post Game/042_25725676_1888aec.xml
+++ b/Translation/JE Scripts/Post Game/042_25725676_1888aec.xml
@@ -595,6 +595,11 @@
       これからもよろしくな<end_line>
       <partner><end_line>
     </sjis>
+    <ascii>
+    Well<three_dots> I suppose<end_line>
+    I'll be continuing to rely on you,<end_line>
+    <partner>.<end_line>
+  </ascii>
   </male>
   <female>
     <sjis>
@@ -602,12 +607,12 @@
       これからもよろしくね<end_line>
       <partner><end_line>
     </sjis>
-  </female>
-  <ascii>
+    <ascii>
     Well<three_dots> I suppose<end_line>
     I'll be continuing to rely on you,<end_line>
     <partner>.<end_line>
   </ascii>
+  </female>
 </dialogue>
 <dialogue>
   <partner name="run-dor">


### PR DESCRIPTION
This is a pull request with autofixed **<ascii>** tags inside **<male><female>** gendered texts. I tried to keep formatting changes to minimum, but there may be some that needs proof reading. Also it has been done only for the **JE scripts** in the: `SNSC3-Translation\Translation\JE Scripts\` directory. If you want me to parse other sets of JE scripts, then reject this Pull request and contanct me with your requirements.